### PR TITLE
Add cargo config

### DIFF
--- a/rust/.cargo/config
+++ b/rust/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target-dir = "./target"


### PR DESCRIPTION
This can override the developer's global default configuration (`~/.cargo/config`).
