### PR TITLE
feat: get GPU devices via FFI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,7 +185,7 @@ commands:
           name: Ensure paramcache is installed to project root
           command: |
             test -f ./paramcache \
-              || (rustup run --install nightly cargo install filecoin-proofs --force --git=https://github.com/filecoin-project/rust-fil-proofs.git --branch=master --bin=paramcache --root=./ \
+              || (rustup run --install nightly cargo install filecoin-proofs --force --git=https://github.com/filecoin-project/rust-fil-proofs.git --branch=temp/v20-params --bin=paramcache --root=./ \
                 && mv ./bin/paramcache ./paramcache)
           no_output_timeout: 60m
   build_and_run_tests:
@@ -203,10 +203,10 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - v20b-proof-params-{{ arch }}
+            - v20c-proof-params-{{ arch }}
   save_parameter_cache:
     steps:
       - save_cache:
-          key: v20b-proof-params-{{ arch }}
+          key: v20c-proof-params-{{ arch }}
           paths:
             - "~/filecoin-proof-parameters/"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,10 +203,10 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - v20-proof-params-{{ arch }}
+            - v20b-proof-params-{{ arch }}
   save_parameter_cache:
     steps:
       - save_cache:
-          key: v20-proof-params-{{ arch }}
+          key: v20b-proof-params-{{ arch }}
           paths:
             - "~/filecoin-proof-parameters/"

--- a/proofs.go
+++ b/proofs.go
@@ -532,6 +532,8 @@ func GeneratePoSt(
 	return goBytes(resPtr.flattened_proofs_ptr, resPtr.flattened_proofs_len), nil
 }
 
+// GetGPUDevices produces a slice of strings, each representing the name of a
+// detected GPU device.
 func GetGPUDevices() ([]string, error) {
 	resPtr := C.get_gpu_devices()
 	defer C.destroy_gpu_device_response(resPtr)

--- a/proofs.go
+++ b/proofs.go
@@ -532,6 +532,27 @@ func GeneratePoSt(
 	return goBytes(resPtr.flattened_proofs_ptr, resPtr.flattened_proofs_len), nil
 }
 
+func GetGPUDevices() ([]string, error) {
+	resPtr := C.get_gpu_devices()
+	defer C.destroy_gpu_device_response(resPtr)
+
+	if resPtr.status_code != 0 {
+		return nil, errors.New(C.GoString(resPtr.error_msg))
+	}
+
+	devices := make([]string, resPtr.devices_len)
+	if resPtr.devices_ptr == nil || resPtr.devices_len == 0 {
+		return devices, nil
+	}
+
+	ptrs := (*[1 << 30]*C.char)(unsafe.Pointer(resPtr.devices_ptr))[:resPtr.devices_len:resPtr.devices_len]
+	for i := 0; i < int(resPtr.devices_len); i++ {
+		devices[i] = C.GoString(ptrs[i])
+	}
+
+	return devices, nil
+}
+
 // SingleProofPartitionProofLen denotes the number of bytes in a proof generated
 // with a single partition. The number of bytes in a proof increases linearly
 // with the number of partitions used when creating that proof.

--- a/proofs_test.go
+++ b/proofs_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"math/big"
@@ -235,6 +236,12 @@ func TestJsonMarshalSymmetry(t *testing.T) {
 
 		require.Equal(t, toSerialize, fromSerialized)
 	}
+}
+
+func TestGetGPUDevicesDoesNotProduceAnError(t *testing.T) {
+	devices, err := GetGPUDevices()
+	require.NoError(t, err)
+	fmt.Printf("devices: %+v\n", devices) // clutters up test output, but useful
 }
 
 func requireTempFile(t *testing.T, fileContentsReader io.Reader, size uint64) *os.File {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -137,6 +137,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "bellperson"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bit-vec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blake2s_simd 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ff 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fil-ocl 0.19.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "groupy 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "paired 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bincode"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,7 +701,7 @@ name = "filecoin"
 version = "0.7.3"
 dependencies = [
  "anyhow 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "bellperson 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bellperson 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bls-signatures 0.3.0 (git+https://github.com/filecoin-project/bls-signatures.git)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cbindgen 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2505,6 +2529,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 "checksum bellperson 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "74a9962e2e0afac5ed008b61c1c87fe352d29717288087254c3b618bf92ec71d"
+"checksum bellperson 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "27db3027f939172145c34023bc4821a51df784268cc71bcb9894d9b5741cb423"
 "checksum bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5753e2a71534719bf3f4e57006c3a4f0d2c672a4b676eec84161f763eca87dbf"
 "checksum bit-vec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a4523a10839ffae575fb08aa3423026c8cb4687eef43952afb956229d4f246f7"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -677,6 +677,7 @@ name = "filecoin"
 version = "0.7.3"
 dependencies = [
  "anyhow 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bellperson 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "bls-signatures 0.3.0 (git+https://github.com/filecoin-project/bls-signatures.git)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cbindgen 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -27,14 +27,10 @@ fil_logger = "0.1.0"
 rand = "0.7"
 rayon = "1.2.1"
 anyhow = "1.0.23"
-bellperson = "0.4.4"
+bellperson = { version = "0.5", features = ["gpu"] }
 
 [build-dependencies]
 cbindgen = "= 0.10.0"
 
 [dev-dependencies]
 tempfile = "3.0.8"
-
-[features]
-default = ["gpu"]
-gpu = ["bellperson/gpu"]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -27,9 +27,14 @@ fil_logger = "0.1.0"
 rand = "0.7"
 rayon = "1.2.1"
 anyhow = "1.0.23"
+bellperson = "0.4.4"
 
 [build-dependencies]
 cbindgen = "= 0.10.0"
 
 [dev-dependencies]
 tempfile = "3.0.8"
+
+[features]
+default = ["gpu"]
+gpu = ["bellperson/gpu"]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -8,3 +8,4 @@ extern crate log;
 
 pub mod bls;
 pub mod proofs;
+pub mod util;

--- a/rust/src/util/api.rs
+++ b/rust/src/util/api.rs
@@ -1,0 +1,47 @@
+use std::ffi::CString;
+
+use bellperson::GPU_NVIDIA_DEVICES;
+use ffi_toolkit::{catch_panic_response, raw_ptr};
+
+use super::types::GpuDeviceResponse;
+
+/// Returns an array of strings containing the device names that can be used.
+#[no_mangle]
+pub unsafe extern "C" fn get_gpu_devices() -> *mut GpuDeviceResponse {
+    catch_panic_response(|| {
+        let devices: Vec<*const libc::c_char> = GPU_NVIDIA_DEVICES
+            .iter()
+            .map(|device| {
+                let name = device.name().unwrap_or("Unknown".to_string());
+                CString::new(&name[..]).unwrap().as_ptr()
+            })
+            .collect();
+        let mut response = GpuDeviceResponse::default();
+        response.devices_len = devices.len();
+        response.devices_ptr = devices.as_ptr();
+
+        raw_ptr(response)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::CStr;
+    use std::slice::from_raw_parts;
+
+    use crate::util::api::get_gpu_devices;
+    use crate::util::types::destroy_gpu_device_response;
+
+    #[test]
+    fn test_get_gpu_devices() {
+        unsafe {
+            let resp = get_gpu_devices();
+            let devices: Vec<&str> = from_raw_parts((*resp).devices_ptr, (*resp).devices_len)
+                .iter()
+                .map(|name_ptr| CStr::from_ptr(*name_ptr).to_str().unwrap())
+                .collect();
+            assert_eq!(devices.len(), (*resp).devices_len);
+            destroy_gpu_device_response(resp);
+        }
+    }
+}

--- a/rust/src/util/api.rs
+++ b/rust/src/util/api.rs
@@ -1,24 +1,30 @@
-use std::ffi::CString;
-
 use bellperson::GPU_NVIDIA_DEVICES;
 use ffi_toolkit::{catch_panic_response, raw_ptr};
 
 use super::types::GpuDeviceResponse;
+use std::ffi::CString;
 
 /// Returns an array of strings containing the device names that can be used.
 #[no_mangle]
 pub unsafe extern "C" fn get_gpu_devices() -> *mut GpuDeviceResponse {
     catch_panic_response(|| {
+        let n = GPU_NVIDIA_DEVICES.len();
+
         let devices: Vec<*const libc::c_char> = GPU_NVIDIA_DEVICES
             .iter()
-            .map(|device| {
-                let name = device.name().unwrap_or("Unknown".to_string());
-                CString::new(&name[..]).unwrap().as_ptr()
+            .map(|d| d.name().unwrap_or_else(|_| "Unknown".to_string()))
+            .map(|d| {
+                CString::new(d)
+                    .unwrap_or_else(|_| CString::new("Unknown").unwrap())
+                    .into_raw() as *const libc::c_char
             })
             .collect();
+
+        let dyn_array = Box::into_raw(devices.into_boxed_slice());
+
         let mut response = GpuDeviceResponse::default();
-        response.devices_len = devices.len();
-        response.devices_ptr = devices.as_ptr();
+        response.devices_len = n;
+        response.devices_ptr = dyn_array as *const *const libc::c_char;
 
         raw_ptr(response)
     })
@@ -26,9 +32,6 @@ pub unsafe extern "C" fn get_gpu_devices() -> *mut GpuDeviceResponse {
 
 #[cfg(test)]
 mod tests {
-    use std::ffi::CStr;
-    use std::slice::from_raw_parts;
-
     use crate::util::api::get_gpu_devices;
     use crate::util::types::destroy_gpu_device_response;
 
@@ -36,10 +39,22 @@ mod tests {
     fn test_get_gpu_devices() {
         unsafe {
             let resp = get_gpu_devices();
-            let devices: Vec<&str> = from_raw_parts((*resp).devices_ptr, (*resp).devices_len)
-                .iter()
-                .map(|name_ptr| CStr::from_ptr(*name_ptr).to_str().unwrap())
+
+            let strings = std::slice::from_raw_parts_mut(
+                (*resp).devices_ptr as *mut *mut libc::c_char,
+                (*resp).devices_len as usize,
+            );
+
+            let devices: Vec<String> = strings
+                .into_iter()
+                .map(|s| {
+                    std::ffi::CStr::from_ptr(*s)
+                        .to_str()
+                        .unwrap_or("Unknown")
+                        .to_owned()
+                })
                 .collect();
+
             assert_eq!(devices.len(), (*resp).devices_len);
             destroy_gpu_device_response(resp);
         }

--- a/rust/src/util/mod.rs
+++ b/rust/src/util/mod.rs
@@ -1,0 +1,2 @@
+pub mod api;
+pub mod types;

--- a/rust/src/util/types.rs
+++ b/rust/src/util/types.rs
@@ -1,0 +1,32 @@
+use std::ptr;
+
+use drop_struct_macro_derive::DropStructMacro;
+// `CodeAndMessage` is the trait implemented by `code_and_message_impl
+use ffi_toolkit::{code_and_message_impl, free_c_str, CodeAndMessage, FCPResponseStatus};
+
+#[repr(C)]
+#[derive(DropStructMacro)]
+pub struct GpuDeviceResponse {
+    pub status_code: FCPResponseStatus,
+    pub error_msg: *const libc::c_char,
+    pub devices_len: libc::size_t,
+    pub devices_ptr: *const *const libc::c_char,
+}
+
+impl Default for GpuDeviceResponse {
+    fn default() -> Self {
+        Self {
+            error_msg: ptr::null(),
+            status_code: FCPResponseStatus::FCPNoError,
+            devices_len: 0,
+            devices_ptr: ptr::null(),
+        }
+    }
+}
+
+code_and_message_impl!(GpuDeviceResponse);
+
+#[no_mangle]
+pub unsafe extern "C" fn destroy_gpu_device_response(ptr: *mut GpuDeviceResponse) {
+    let _ = Box::from_raw(ptr);
+}


### PR DESCRIPTION
A new FFI call (`util::get_gpu_devices()`) is introduced. It returns
the available GPUs as an array of strings.

I consider it ready for review. The tests will pass once https://github.com/filecoin-project/bellman/pull/31 is merged and released.