### PR TITLE
feat: always rebuild local source 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,9 @@ DEPS:=filecoin.h filecoin.pc libfilecoin.a
 all: $(DEPS)
 .PHONY: all
 
-
-$(DEPS): .install-filecoin  ;
-
-.install-filecoin: rust
+$(DEPS):
 	./install-filecoin
-	@touch $@
-
 
 clean:
-	rm -rf $(DEPS) .install-filecoin
+	rm -rf $(DEPS)
 .PHONY: clean

--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ build tooling will attempt to compile a static library from local Rust sources.
 To opt out of downloading precompiled assets, set `FFI_BUILD_FROM_SOURCE=1`:
 
 ```shell
-rm .install-filecoin \
-    ; make clean \
-    ; FFI_BUILD_FROM_SOURCE=1 make
+FFI_BUILD_FROM_SOURCE=1 make clean all
 ```
 
 ## License

--- a/install-filecoin
+++ b/install-filecoin
@@ -7,27 +7,7 @@ source "install-shared.bash"
 
 rust_sources_dir="rust"
 
-if [ "${FFI_BUILD_FROM_SOURCE}" != "1" ] && download_release_tarball tarball_path "${rust_sources_dir}" "filecoin-ffi"; then
-    tmp_dir=$(mktemp -d)
-    tar -C "$tmp_dir" -xzf "$tarball_path"
-
-    find -L "${tmp_dir}" -type f -name filecoin.h -exec cp -- "{}" . \;
-    find -L "${tmp_dir}" -type f -name libfilecoin.a -exec cp -- "{}" . \;
-    find -L "${tmp_dir}" -type f -name filecoin.pc -exec cp -- "{}" . \;
-
-    (>&2 echo "successfully installed prebuilt libfilecoin")
-else
-    (>&2 echo "building libfilecoin from local sources (dir = ${rust_sources_dir})")
-
-    build_from_source "filecoin" "${rust_sources_dir}"
-
-    mkdir -p include
-    mkdir -p lib/pkgconfig
-
-    find -L "${rust_sources_dir}/target/release" -type f -name filecoin.h -exec cp -- "{}" . \;
-    find -L "${rust_sources_dir}/target/release" -type f -name libfilecoin.a -exec cp -- "{}" . \;
-    find -L "${rust_sources_dir}" -type f -name filecoin.pc -exec cp -- "{}" . \;
-
+check_installed_files() {
     if [[ ! -f "./filecoin.h" ]]; then
         (>&2 echo "failed to install filecoin.h")
         exit 1
@@ -42,6 +22,32 @@ else
         (>&2 echo "failed to install filecoin.pc")
         exit 1
     fi
+}
+
+if [ "${FFI_BUILD_FROM_SOURCE}" != "1" ] && download_release_tarball tarball_path "${rust_sources_dir}" "filecoin-ffi"; then
+    tmp_dir=$(mktemp -d)
+    tar -C "$tmp_dir" -xzf "$tarball_path"
+
+    find -L "${tmp_dir}" -type f -name filecoin.h -exec cp -- "{}" . \;
+    find -L "${tmp_dir}" -type f -name libfilecoin.a -exec cp -- "{}" . \;
+    find -L "${tmp_dir}" -type f -name filecoin.pc -exec cp -- "{}" . \;
+
+    check_installed_files
+
+    (>&2 echo "successfully installed prebuilt libfilecoin")
+else
+    (>&2 echo "building libfilecoin from local sources (dir = ${rust_sources_dir})")
+
+    build_from_source "filecoin" "${rust_sources_dir}"
+
+    mkdir -p include
+    mkdir -p lib/pkgconfig
+
+    find -L "${rust_sources_dir}/target/release" -type f -name filecoin.h -exec cp -- "{}" . \;
+    find -L "${rust_sources_dir}/target/release" -type f -name libfilecoin.a -exec cp -- "{}" . \;
+    find -L "${rust_sources_dir}" -type f -name filecoin.pc -exec cp -- "{}" . \;
+
+    check_installed_files
 
     (>&2 echo "successfully built and installed libfilecoin from source")
 fi

--- a/install-filecoin
+++ b/install-filecoin
@@ -38,7 +38,7 @@ if [ "${FFI_BUILD_FROM_SOURCE}" != "1" ] && download_release_tarball tarball_pat
 else
     (>&2 echo "building libfilecoin from local sources (dir = ${rust_sources_dir})")
 
-    build_from_source "filecoin" "${rust_sources_dir}"
+    build_from_source "${rust_sources_dir}"
 
     mkdir -p include
     mkdir -p lib/pkgconfig

--- a/install-shared.bash
+++ b/install-shared.bash
@@ -30,11 +30,10 @@ download_release_tarball() {
         --header "Accept:application/octet-stream" \
         --location \
         --output /dev/null \
-        -w %{url_effective} \
+        -w '%{url_effective}' \
         "{$__release_url}")
 
-    curl --retry 3 --output "${__tar_path}" "${__asset_url}"
-    if [[ $? -ne "0" ]]; then
+    if ! curl --retry 3 --output "${__tar_path}" "${__asset_url}"; then
         (>&2 echo "failed to download release asset (tag URL: ${__release_tag_url}, asset URL: ${__asset_url})")
         return 1
     fi
@@ -62,7 +61,7 @@ build_from_source() {
         exit 1
     fi
 
-    pushd "${__rust_sources_path}"
+    pushd "${__rust_sources_path}" || exit
 
     cargo --version
 
@@ -72,5 +71,5 @@ build_from_source() {
         cargo build --release --all
     fi
 
-    popd
+    popd || exit
 }

--- a/install-shared.bash
+++ b/install-shared.bash
@@ -13,16 +13,16 @@ download_release_tarball() {
 
     __release_response=$(curl \
         --retry 3 \
-        --location $__release_tag_url)
+        --location "${__release_tag_url}")
 
-    __release_url=$(echo $__release_response | jq -r ".assets[] | select(.name | contains(\"${__release_name}\")) | .url")
+    __release_url=$(echo "${__release_response}" | jq -r ".assets[] | select(.name | contains(\"${__release_name}\")) | .url")
 
-    if [[ -z "$__release_url" ]]; then
+    if [[ -z "${__release_url}" ]]; then
         (>&2 echo "failed to download release (tag URL: ${__release_tag_url}, response: ${__release_response})")
         return 1
     fi
 
-    __tar_path="/tmp/${__release_name}_$(basename ${__release_url}).tar.gz"
+    __tar_path="/tmp/${__release_name}_$(basename "${__release_url}").tar.gz"
 
     __asset_url=$(curl \
         --head \
@@ -31,15 +31,15 @@ download_release_tarball() {
         --location \
         --output /dev/null \
         -w %{url_effective} \
-        "$__release_url")
+        "{$__release_url}")
 
-    curl --retry 3 --output "${__tar_path}" "$__asset_url"
+    curl --retry 3 --output "${__tar_path}" "${__asset_url}"
     if [[ $? -ne "0" ]]; then
         (>&2 echo "failed to download release asset (tag URL: ${__release_tag_url}, asset URL: ${__asset_url})")
         return 1
     fi
 
-    eval $__resultvar="'$__tar_path'"
+    eval $__resultvar="'${__tar_path}'"
 }
 
 build_from_source() {
@@ -62,12 +62,12 @@ build_from_source() {
         exit 1
     fi
 
-    pushd $__rust_sources_path
+    pushd "${__rust_sources_path}"
 
     cargo --version
 
     if [[ -f "./scripts/build-release.sh" ]]; then
-        ./scripts/build-release.sh $__library_name $(cat rust-toolchain)
+        ./scripts/build-release.sh "${__library_name}" "$(cat rust-toolchain)"
     else
         cargo build --release --all
     fi

--- a/install-shared.bash
+++ b/install-shared.bash
@@ -42,8 +42,7 @@ download_release_tarball() {
 }
 
 build_from_source() {
-    __library_name=$1
-    __rust_sources_path=$2
+    __rust_sources_path=$1
     __repo_sha1=$(git rev-parse HEAD)
     __repo_sha1_truncated="${__repo_sha1:0:16}"
 
@@ -62,14 +61,7 @@ build_from_source() {
     fi
 
     pushd "${__rust_sources_path}" || exit
-
     cargo --version
-
-    if [[ -f "./scripts/build-release.sh" ]]; then
-        ./scripts/build-release.sh "${__library_name}" "$(cat rust-toolchain)"
-    else
-        cargo build --release --all
-    fi
-
+    cargo build --release --all
     popd || exit
 }


### PR DESCRIPTION
If `FFI_BUILD_FROM_SOURCE=1` is set, always rebuild from local source.

Change the scripts so that it is built within the `rust` directory
and not on a temporary directory that is different on every rebuild.
This way you get incremental builds if you make changes to the local
source (which is probably your intention if you build from source).

This PR also contains general improvements to the source (based on `shellcheck`
output).