### PR TITLE
perf(proofs): parallelize replicas conversion in generate_candida…

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -697,7 +697,7 @@ dependencies = [
 [[package]]
 name = "filecoin-proofs"
 version = "0.6.4"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs.git#d815366e1adee1ea3b32fa2416f09eccf2d096b6"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs.git#42a0020214edd89ee5f866a7304f50852819c1ca"
 dependencies = [
  "anyhow 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "bellperson 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -728,7 +728,7 @@ dependencies = [
  "rand_xorshift 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_cbor 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.9.22"
+version = "0.9.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1979,7 +1979,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "storage-proofs"
 version = "0.6.2"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs.git#d815366e1adee1ea3b32fa2416f09eccf2d096b6"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs.git#42a0020214edd89ee5f866a7304f50852819c1ca"
 dependencies = [
  "aes 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "anyhow 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2678,7 +2678,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
-"checksum reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)" = "2c2064233e442ce85c77231ebd67d9eca395207dec2127fe0bbedde4bd29a650"
+"checksum reqwest 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)" = "f88643aea3c1343c804950d7bf983bd2067f5ab59db6d613a08e05572f2714ab"
 "checksum rust-ini 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -25,7 +25,7 @@ log = "0.4.7"
 paired = "0.16.0"
 fil_logger = "0.1.0"
 rand = "0.7"
-rayon = "1"
+rayon = "1.2.1"
 anyhow = "1.0.23"
 
 [build-dependencies]

--- a/rust/src/proofs/helpers.rs
+++ b/rust/src/proofs/helpers.rs
@@ -1,7 +1,7 @@
 use std::collections::btree_map::BTreeMap;
 use std::slice::from_raw_parts;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use ffi_toolkit::{c_str_to_pbuf, c_str_to_rust_str};
 use filecoin_proofs::{constants as api_constants, Commitment, PublicReplicaInfo};
 use filecoin_proofs::{types as api_types, PrivateReplicaInfo};
@@ -177,11 +177,10 @@ pub unsafe fn to_private_replica_info_map(
             } = info;
 
             filecoin_proofs::PrivateReplicaInfo::new(replica_path, comm_r, cache_dir_path)
-                .map_err(|err| {
-                    format_err!(
-                        "could not load private replica (id = {}) from cache: {}",
-                        sector_id,
-                        err
+                .with_context(|err| {
+                    format!(
+                        "could not load private replica (id = {}) from cache",
+                        sector_id
                     )
                 })
                 .map(|p| (SectorId::from(sector_id), p))

--- a/rust/src/proofs/helpers.rs
+++ b/rust/src/proofs/helpers.rs
@@ -177,7 +177,7 @@ pub unsafe fn to_private_replica_info_map(
             } = info;
 
             filecoin_proofs::PrivateReplicaInfo::new(replica_path, comm_r, cache_dir_path)
-                .with_context(|err| {
+                .with_context(|| {
                     format!(
                         "could not load private replica (id = {}) from cache",
                         sector_id

--- a/rust/src/proofs/helpers.rs
+++ b/rust/src/proofs/helpers.rs
@@ -135,33 +135,56 @@ pub fn bls_12_fr_into_bytes(fr: Fr) -> [u8; 32] {
     commitment
 }
 
+#[derive(Debug, Clone)]
+struct PrivateReplicaInfoTmp {
+    pub cache_dir_path: std::path::PathBuf,
+    pub comm_r: [u8; 32],
+    pub replica_path: String,
+    pub sector_id: u64,
+}
+
 pub unsafe fn to_private_replica_info_map(
     replicas_ptr: *const FFIPrivateReplicaInfo,
     replicas_len: libc::size_t,
 ) -> Result<BTreeMap<SectorId, PrivateReplicaInfo>> {
+    use rayon::prelude::*;
+
     ensure!(!replicas_ptr.is_null(), "replicas_ptr must not be null");
 
-    from_raw_parts(replicas_ptr, replicas_len)
+    let replicas: Vec<_> = from_raw_parts(replicas_ptr, replicas_len)
         .iter()
-        .cloned()
-        .map(|ffi_r| {
-            let cache_dir_path = c_str_to_pbuf(ffi_r.cache_dir_path);
-            let cloned = cache_dir_path.clone();
+        .map(|ffi_info| {
+            let cache_dir_path = c_str_to_pbuf(ffi_info.cache_dir_path);
+            let replica_path = c_str_to_rust_str(ffi_info.replica_path).to_string();
 
-            filecoin_proofs::PrivateReplicaInfo::new(
-                c_str_to_rust_str(ffi_r.replica_path).to_string(),
-                ffi_r.comm_r,
+            PrivateReplicaInfoTmp {
                 cache_dir_path,
-            )
-            .map_err(|err| {
-                format_err!(
-                    "could not load private replica (id = {}) from cache (path = {:?}): {}",
-                    ffi_r.sector_id,
-                    cloned,
-                    err
-                )
-            })
-            .map(|p| (SectorId::from(ffi_r.sector_id), p))
+                comm_r: ffi_info.comm_r,
+                replica_path,
+                sector_id: ffi_info.sector_id,
+            }
+        })
+        .collect();
+
+    replicas
+        .into_par_iter()
+        .map(|info| {
+            let PrivateReplicaInfoTmp {
+                cache_dir_path,
+                comm_r,
+                replica_path,
+                sector_id,
+            } = info;
+
+            filecoin_proofs::PrivateReplicaInfo::new(replica_path, comm_r, cache_dir_path)
+                .map_err(|err| {
+                    format_err!(
+                        "could not load private replica (id = {}) from cache: {}",
+                        sector_id,
+                        err
+                    )
+                })
+                .map(|p| (SectorId::from(sector_id), p))
         })
         .collect()
 }


### PR DESCRIPTION
This helps quite considerably when passing large amounts of sectors `PrivateReplicaInfo::new()` does a disk read