### PR TITLE
fix: proper extern C block

### DIFF
--- a/rust/cbindgen.toml
+++ b/rust/cbindgen.toml
@@ -2,7 +2,7 @@ header = """
 /* filecoin Header */
 
 #ifdef __cplusplus
-extern "C" {{
+extern "C" {
 #endif
 """
 trailer = """


### PR DESCRIPTION
The `extern "C"` had one curly bracket too much.

Fixes #22.