### PR TITLE
Revert "fix: remove reference to .install-filecoin file (#20)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,18 @@ DEPS:=filecoin.h filecoin.pc libfilecoin.a
 all: $(DEPS)
 .PHONY: all
 
-$(DEPS):
+
+# Create a file so that parallel make doesn't call `./install-filecoin` for
+# each of the deps
+$(DEPS): .install-filecoin  ;
+
+.install-filecoin: rust
 	./install-filecoin
+	@touch $@
+
 
 clean:
-	rm -rf $(DEPS)
+	rm -rf $(DEPS) .install-filecoin
 	rm -f ./runner
 .PHONY: clean
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ build tooling will attempt to compile a static library from local Rust sources.
 To opt out of downloading precompiled assets, set `FFI_BUILD_FROM_SOURCE=1`:
 
 ```shell
-FFI_BUILD_FROM_SOURCE=1 make clean all
+rm .install-filecoin \
+    ; make clean \
+    ; FFI_BUILD_FROM_SOURCE=1 make
 ```
 
 ## Updating CGO Bindings


### PR DESCRIPTION
This reverts commit bbff56c621856352ac9d05540a32c5c48a2861fb.

This is a partial revert. It keeps the simplified instruction in the
README, but still does the Makefile tricks so that it works well with
parallel make. It also adds a comment about it, so that it doesn't
get removed again in the future.