### PR TITLE
chore: move nightly build to the bottom

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,17 +181,17 @@ jobs:
 
 workflows:
   version: 2
-  nightly_leak_detection:
-    triggers:
-      - schedule:
-          cron: "0 1 * * *"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - build_and_test_linux_cgo_bindings:
-          run_leak_detector: true
+  #nightly_leak_detection:
+  #  triggers:
+  #    - schedule:
+  #        cron: "0 1 * * *"
+  #        filters:
+  #          branches:
+  #            only:
+  #              - master
+  #  jobs:
+  #    - build_and_test_linux_cgo_bindings:
+  #        run_leak_detector: true
   test_all:
     jobs:
       - cargo_fetch


### PR DESCRIPTION
This way the automatic job naming doesn't interfere with GitHub settings
and PRs are not waiting for a status of the nightly job.