### PR TITLE
feat: make logging to file possible

### DIFF
--- a/generated/cgo_helpers.go
+++ b/generated/cgo_helpers.go
@@ -1429,6 +1429,92 @@ func (x *FilHashResponse) Deref() {
 	x.Digest = *NewFilBLSDigestRef(unsafe.Pointer(&x.refc52a22ef.digest))
 }
 
+// allocFilInitLogFdResponseMemory allocates memory for type C.fil_InitLogFdResponse in C.
+// The caller is responsible for freeing the this memory via C.free.
+func allocFilInitLogFdResponseMemory(n int) unsafe.Pointer {
+	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfFilInitLogFdResponseValue))
+	if err != nil {
+		panic("memory alloc error: " + err.Error())
+	}
+	return mem
+}
+
+const sizeOfFilInitLogFdResponseValue = unsafe.Sizeof([1]C.fil_InitLogFdResponse{})
+
+// Ref returns the underlying reference to C object or nil if struct is nil.
+func (x *FilInitLogFdResponse) Ref() *C.fil_InitLogFdResponse {
+	if x == nil {
+		return nil
+	}
+	return x.ref3c1a0a08
+}
+
+// Free invokes alloc map's free mechanism that cleanups any allocated memory using C free.
+// Does nothing if struct is nil or has no allocation map.
+func (x *FilInitLogFdResponse) Free() {
+	if x != nil && x.allocs3c1a0a08 != nil {
+		x.allocs3c1a0a08.(*cgoAllocMap).Free()
+		x.ref3c1a0a08 = nil
+	}
+}
+
+// NewFilInitLogFdResponseRef creates a new wrapper struct with underlying reference set to the original C object.
+// Returns nil if the provided pointer to C object is nil too.
+func NewFilInitLogFdResponseRef(ref unsafe.Pointer) *FilInitLogFdResponse {
+	if ref == nil {
+		return nil
+	}
+	obj := new(FilInitLogFdResponse)
+	obj.ref3c1a0a08 = (*C.fil_InitLogFdResponse)(unsafe.Pointer(ref))
+	return obj
+}
+
+// PassRef returns the underlying C object, otherwise it will allocate one and set its values
+// from this wrapping struct, counting allocations into an allocation map.
+func (x *FilInitLogFdResponse) PassRef() (*C.fil_InitLogFdResponse, *cgoAllocMap) {
+	if x == nil {
+		return nil, nil
+	} else if x.ref3c1a0a08 != nil {
+		return x.ref3c1a0a08, nil
+	}
+	mem3c1a0a08 := allocFilInitLogFdResponseMemory(1)
+	ref3c1a0a08 := (*C.fil_InitLogFdResponse)(mem3c1a0a08)
+	allocs3c1a0a08 := new(cgoAllocMap)
+	allocs3c1a0a08.Add(mem3c1a0a08)
+
+	var cstatus_code_allocs *cgoAllocMap
+	ref3c1a0a08.status_code, cstatus_code_allocs = (C.FCPResponseStatus)(x.StatusCode), cgoAllocsUnknown
+	allocs3c1a0a08.Borrow(cstatus_code_allocs)
+
+	var cerror_msg_allocs *cgoAllocMap
+	ref3c1a0a08.error_msg, cerror_msg_allocs = unpackPCharString(x.ErrorMsg)
+	allocs3c1a0a08.Borrow(cerror_msg_allocs)
+
+	x.ref3c1a0a08 = ref3c1a0a08
+	x.allocs3c1a0a08 = allocs3c1a0a08
+	return ref3c1a0a08, allocs3c1a0a08
+
+}
+
+// PassValue does the same as PassRef except that it will try to dereference the returned pointer.
+func (x FilInitLogFdResponse) PassValue() (C.fil_InitLogFdResponse, *cgoAllocMap) {
+	if x.ref3c1a0a08 != nil {
+		return *x.ref3c1a0a08, nil
+	}
+	ref, allocs := x.PassRef()
+	return *ref, allocs
+}
+
+// Deref uses the underlying reference to C object and fills the wrapping struct with values.
+// Do not forget to call this method whether you get a struct for C object and want to read its values.
+func (x *FilInitLogFdResponse) Deref() {
+	if x.ref3c1a0a08 == nil {
+		return
+	}
+	x.StatusCode = (FCPResponseStatus)(x.ref3c1a0a08.status_code)
+	x.ErrorMsg = packPCharString(x.ref3c1a0a08.error_msg)
+}
+
 // allocFilBLSPrivateKeyMemory allocates memory for type C.fil_BLSPrivateKey in C.
 // The caller is responsible for freeing the this memory via C.free.
 func allocFilBLSPrivateKeyMemory(n int) unsafe.Pointer {

--- a/generated/generated.go
+++ b/generated/generated.go
@@ -16,7 +16,7 @@ import (
 	"unsafe"
 )
 
-// FilAggregate function as declared in filecoin-ffi/filecoin.h:268
+// FilAggregate function as declared in filecoin-ffi/filecoin.h:273
 func FilAggregate(flattenedSignaturesPtr string, flattenedSignaturesLen uint) *FilAggregateResponse {
 	flattenedSignaturesPtr = safeString(flattenedSignaturesPtr)
 	cflattenedSignaturesPtr, _ := unpackPUint8TString(flattenedSignaturesPtr)
@@ -27,7 +27,7 @@ func FilAggregate(flattenedSignaturesPtr string, flattenedSignaturesLen uint) *F
 	return __v
 }
 
-// FilClearCache function as declared in filecoin-ffi/filecoin.h:271
+// FilClearCache function as declared in filecoin-ffi/filecoin.h:276
 func FilClearCache(cacheDirPath string) *FilClearCacheResponse {
 	cacheDirPath = safeString(cacheDirPath)
 	ccacheDirPath, _ := unpackPCharString(cacheDirPath)
@@ -37,145 +37,151 @@ func FilClearCache(cacheDirPath string) *FilClearCacheResponse {
 	return __v
 }
 
-// FilDestroyAggregateResponse function as declared in filecoin-ffi/filecoin.h:273
+// FilDestroyAggregateResponse function as declared in filecoin-ffi/filecoin.h:278
 func FilDestroyAggregateResponse(ptr *FilAggregateResponse) {
 	cptr, _ := ptr.PassRef()
 	C.fil_destroy_aggregate_response(cptr)
 }
 
-// FilDestroyClearCacheResponse function as declared in filecoin-ffi/filecoin.h:275
+// FilDestroyClearCacheResponse function as declared in filecoin-ffi/filecoin.h:280
 func FilDestroyClearCacheResponse(ptr *FilClearCacheResponse) {
 	cptr, _ := ptr.PassRef()
 	C.fil_destroy_clear_cache_response(cptr)
 }
 
-// FilDestroyFinalizeTicketResponse function as declared in filecoin-ffi/filecoin.h:277
+// FilDestroyFinalizeTicketResponse function as declared in filecoin-ffi/filecoin.h:282
 func FilDestroyFinalizeTicketResponse(ptr *FilFinalizeTicketResponse) {
 	cptr, _ := ptr.PassRef()
 	C.fil_destroy_finalize_ticket_response(cptr)
 }
 
-// FilDestroyGenerateCandidatesResponse function as declared in filecoin-ffi/filecoin.h:279
+// FilDestroyGenerateCandidatesResponse function as declared in filecoin-ffi/filecoin.h:284
 func FilDestroyGenerateCandidatesResponse(ptr *FilGenerateCandidatesResponse) {
 	cptr, _ := ptr.PassRef()
 	C.fil_destroy_generate_candidates_response(cptr)
 }
 
-// FilDestroyGenerateDataCommitmentResponse function as declared in filecoin-ffi/filecoin.h:281
+// FilDestroyGenerateDataCommitmentResponse function as declared in filecoin-ffi/filecoin.h:286
 func FilDestroyGenerateDataCommitmentResponse(ptr *FilGenerateDataCommitmentResponse) {
 	cptr, _ := ptr.PassRef()
 	C.fil_destroy_generate_data_commitment_response(cptr)
 }
 
-// FilDestroyGeneratePieceCommitmentResponse function as declared in filecoin-ffi/filecoin.h:283
+// FilDestroyGeneratePieceCommitmentResponse function as declared in filecoin-ffi/filecoin.h:288
 func FilDestroyGeneratePieceCommitmentResponse(ptr *FilGeneratePieceCommitmentResponse) {
 	cptr, _ := ptr.PassRef()
 	C.fil_destroy_generate_piece_commitment_response(cptr)
 }
 
-// FilDestroyGeneratePostResponse function as declared in filecoin-ffi/filecoin.h:285
+// FilDestroyGeneratePostResponse function as declared in filecoin-ffi/filecoin.h:290
 func FilDestroyGeneratePostResponse(ptr *FilGeneratePoStResponse) {
 	cptr, _ := ptr.PassRef()
 	C.fil_destroy_generate_post_response(cptr)
 }
 
-// FilDestroyGpuDeviceResponse function as declared in filecoin-ffi/filecoin.h:287
+// FilDestroyGpuDeviceResponse function as declared in filecoin-ffi/filecoin.h:292
 func FilDestroyGpuDeviceResponse(ptr *FilGpuDeviceResponse) {
 	cptr, _ := ptr.PassRef()
 	C.fil_destroy_gpu_device_response(cptr)
 }
 
-// FilDestroyHashResponse function as declared in filecoin-ffi/filecoin.h:289
+// FilDestroyHashResponse function as declared in filecoin-ffi/filecoin.h:294
 func FilDestroyHashResponse(ptr *FilHashResponse) {
 	cptr, _ := ptr.PassRef()
 	C.fil_destroy_hash_response(cptr)
 }
 
-// FilDestroyPrivateKeyGenerateResponse function as declared in filecoin-ffi/filecoin.h:291
+// FilDestroyInitLogFdResponse function as declared in filecoin-ffi/filecoin.h:296
+func FilDestroyInitLogFdResponse(ptr *FilInitLogFdResponse) {
+	cptr, _ := ptr.PassRef()
+	C.fil_destroy_init_log_fd_response(cptr)
+}
+
+// FilDestroyPrivateKeyGenerateResponse function as declared in filecoin-ffi/filecoin.h:298
 func FilDestroyPrivateKeyGenerateResponse(ptr *FilPrivateKeyGenerateResponse) {
 	cptr, _ := ptr.PassRef()
 	C.fil_destroy_private_key_generate_response(cptr)
 }
 
-// FilDestroyPrivateKeyPublicKeyResponse function as declared in filecoin-ffi/filecoin.h:293
+// FilDestroyPrivateKeyPublicKeyResponse function as declared in filecoin-ffi/filecoin.h:300
 func FilDestroyPrivateKeyPublicKeyResponse(ptr *FilPrivateKeyPublicKeyResponse) {
 	cptr, _ := ptr.PassRef()
 	C.fil_destroy_private_key_public_key_response(cptr)
 }
 
-// FilDestroyPrivateKeySignResponse function as declared in filecoin-ffi/filecoin.h:295
+// FilDestroyPrivateKeySignResponse function as declared in filecoin-ffi/filecoin.h:302
 func FilDestroyPrivateKeySignResponse(ptr *FilPrivateKeySignResponse) {
 	cptr, _ := ptr.PassRef()
 	C.fil_destroy_private_key_sign_response(cptr)
 }
 
-// FilDestroySealCommitPhase1Response function as declared in filecoin-ffi/filecoin.h:297
+// FilDestroySealCommitPhase1Response function as declared in filecoin-ffi/filecoin.h:304
 func FilDestroySealCommitPhase1Response(ptr *FilSealCommitPhase1Response) {
 	cptr, _ := ptr.PassRef()
 	C.fil_destroy_seal_commit_phase1_response(cptr)
 }
 
-// FilDestroySealCommitPhase2Response function as declared in filecoin-ffi/filecoin.h:299
+// FilDestroySealCommitPhase2Response function as declared in filecoin-ffi/filecoin.h:306
 func FilDestroySealCommitPhase2Response(ptr *FilSealCommitPhase2Response) {
 	cptr, _ := ptr.PassRef()
 	C.fil_destroy_seal_commit_phase2_response(cptr)
 }
 
-// FilDestroySealPreCommitPhase1Response function as declared in filecoin-ffi/filecoin.h:301
+// FilDestroySealPreCommitPhase1Response function as declared in filecoin-ffi/filecoin.h:308
 func FilDestroySealPreCommitPhase1Response(ptr *FilSealPreCommitPhase1Response) {
 	cptr, _ := ptr.PassRef()
 	C.fil_destroy_seal_pre_commit_phase1_response(cptr)
 }
 
-// FilDestroySealPreCommitPhase2Response function as declared in filecoin-ffi/filecoin.h:303
+// FilDestroySealPreCommitPhase2Response function as declared in filecoin-ffi/filecoin.h:310
 func FilDestroySealPreCommitPhase2Response(ptr *FilSealPreCommitPhase2Response) {
 	cptr, _ := ptr.PassRef()
 	C.fil_destroy_seal_pre_commit_phase2_response(cptr)
 }
 
-// FilDestroyStringResponse function as declared in filecoin-ffi/filecoin.h:305
+// FilDestroyStringResponse function as declared in filecoin-ffi/filecoin.h:312
 func FilDestroyStringResponse(ptr *FilStringResponse) {
 	cptr, _ := ptr.PassRef()
 	C.fil_destroy_string_response(cptr)
 }
 
-// FilDestroyUnsealRangeResponse function as declared in filecoin-ffi/filecoin.h:307
+// FilDestroyUnsealRangeResponse function as declared in filecoin-ffi/filecoin.h:314
 func FilDestroyUnsealRangeResponse(ptr *FilUnsealRangeResponse) {
 	cptr, _ := ptr.PassRef()
 	C.fil_destroy_unseal_range_response(cptr)
 }
 
-// FilDestroyUnsealResponse function as declared in filecoin-ffi/filecoin.h:309
+// FilDestroyUnsealResponse function as declared in filecoin-ffi/filecoin.h:316
 func FilDestroyUnsealResponse(ptr *FilUnsealResponse) {
 	cptr, _ := ptr.PassRef()
 	C.fil_destroy_unseal_response(cptr)
 }
 
-// FilDestroyVerifyPostResponse function as declared in filecoin-ffi/filecoin.h:315
+// FilDestroyVerifyPostResponse function as declared in filecoin-ffi/filecoin.h:322
 func FilDestroyVerifyPostResponse(ptr *FilVerifyPoStResponse) {
 	cptr, _ := ptr.PassRef()
 	C.fil_destroy_verify_post_response(cptr)
 }
 
-// FilDestroyVerifySealResponse function as declared in filecoin-ffi/filecoin.h:321
+// FilDestroyVerifySealResponse function as declared in filecoin-ffi/filecoin.h:328
 func FilDestroyVerifySealResponse(ptr *FilVerifySealResponse) {
 	cptr, _ := ptr.PassRef()
 	C.fil_destroy_verify_seal_response(cptr)
 }
 
-// FilDestroyWriteWithAlignmentResponse function as declared in filecoin-ffi/filecoin.h:323
+// FilDestroyWriteWithAlignmentResponse function as declared in filecoin-ffi/filecoin.h:330
 func FilDestroyWriteWithAlignmentResponse(ptr *FilWriteWithAlignmentResponse) {
 	cptr, _ := ptr.PassRef()
 	C.fil_destroy_write_with_alignment_response(cptr)
 }
 
-// FilDestroyWriteWithoutAlignmentResponse function as declared in filecoin-ffi/filecoin.h:325
+// FilDestroyWriteWithoutAlignmentResponse function as declared in filecoin-ffi/filecoin.h:332
 func FilDestroyWriteWithoutAlignmentResponse(ptr *FilWriteWithoutAlignmentResponse) {
 	cptr, _ := ptr.PassRef()
 	C.fil_destroy_write_without_alignment_response(cptr)
 }
 
-// FilFinalizeTicket function as declared in filecoin-ffi/filecoin.h:330
+// FilFinalizeTicket function as declared in filecoin-ffi/filecoin.h:337
 func FilFinalizeTicket(partialTicket Fil32ByteArray) *FilFinalizeTicketResponse {
 	cpartialTicket, _ := partialTicket.PassValue()
 	__ret := C.fil_finalize_ticket(cpartialTicket)
@@ -183,7 +189,7 @@ func FilFinalizeTicket(partialTicket Fil32ByteArray) *FilFinalizeTicketResponse 
 	return __v
 }
 
-// FilGenerateCandidates function as declared in filecoin-ffi/filecoin.h:336
+// FilGenerateCandidates function as declared in filecoin-ffi/filecoin.h:343
 func FilGenerateCandidates(randomness Fil32ByteArray, challengeCount uint64, replicasPtr []FilPrivateReplicaInfo, replicasLen uint, proverId Fil32ByteArray) *FilGenerateCandidatesResponse {
 	crandomness, _ := randomness.PassValue()
 	cchallengeCount, _ := (C.uint64_t)(challengeCount), cgoAllocsUnknown
@@ -196,7 +202,7 @@ func FilGenerateCandidates(randomness Fil32ByteArray, challengeCount uint64, rep
 	return __v
 }
 
-// FilGenerateDataCommitment function as declared in filecoin-ffi/filecoin.h:345
+// FilGenerateDataCommitment function as declared in filecoin-ffi/filecoin.h:352
 func FilGenerateDataCommitment(registeredProof FilRegisteredSealProof, piecesPtr []FilPublicPieceInfo, piecesLen uint) *FilGenerateDataCommitmentResponse {
 	cregisteredProof, _ := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	cpiecesPtr, _ := unpackArgSFilPublicPieceInfo(piecesPtr)
@@ -207,7 +213,7 @@ func FilGenerateDataCommitment(registeredProof FilRegisteredSealProof, piecesPtr
 	return __v
 }
 
-// FilGeneratePieceCommitment function as declared in filecoin-ffi/filecoin.h:353
+// FilGeneratePieceCommitment function as declared in filecoin-ffi/filecoin.h:360
 func FilGeneratePieceCommitment(registeredProof FilRegisteredSealProof, pieceFdRaw int32, unpaddedPieceSize uint64) *FilGeneratePieceCommitmentResponse {
 	cregisteredProof, _ := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	cpieceFdRaw, _ := (C.int)(pieceFdRaw), cgoAllocsUnknown
@@ -217,7 +223,7 @@ func FilGeneratePieceCommitment(registeredProof FilRegisteredSealProof, pieceFdR
 	return __v
 }
 
-// FilGeneratePost function as declared in filecoin-ffi/filecoin.h:361
+// FilGeneratePost function as declared in filecoin-ffi/filecoin.h:368
 func FilGeneratePost(randomness Fil32ByteArray, replicasPtr []FilPrivateReplicaInfo, replicasLen uint, winnersPtr []FilCandidate, winnersLen uint, proverId Fil32ByteArray) *FilGeneratePoStResponse {
 	crandomness, _ := randomness.PassValue()
 	creplicasPtr, _ := unpackArgSFilPrivateReplicaInfo(replicasPtr)
@@ -232,14 +238,14 @@ func FilGeneratePost(randomness Fil32ByteArray, replicasPtr []FilPrivateReplicaI
 	return __v
 }
 
-// FilGetGpuDevices function as declared in filecoin-ffi/filecoin.h:371
+// FilGetGpuDevices function as declared in filecoin-ffi/filecoin.h:378
 func FilGetGpuDevices() *FilGpuDeviceResponse {
 	__ret := C.fil_get_gpu_devices()
 	__v := NewFilGpuDeviceResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
 
-// FilGetMaxUserBytesPerStagedSector function as declared in filecoin-ffi/filecoin.h:377
+// FilGetMaxUserBytesPerStagedSector function as declared in filecoin-ffi/filecoin.h:384
 func FilGetMaxUserBytesPerStagedSector(registeredProof FilRegisteredSealProof) uint64 {
 	cregisteredProof, _ := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_max_user_bytes_per_staged_sector(cregisteredProof)
@@ -247,7 +253,7 @@ func FilGetMaxUserBytesPerStagedSector(registeredProof FilRegisteredSealProof) u
 	return __v
 }
 
-// FilGetPostCircuitIdentifier function as declared in filecoin-ffi/filecoin.h:383
+// FilGetPostCircuitIdentifier function as declared in filecoin-ffi/filecoin.h:390
 func FilGetPostCircuitIdentifier(registeredProof FilRegisteredPoStProof) *FilStringResponse {
 	cregisteredProof, _ := (C.fil_RegisteredPoStProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_post_circuit_identifier(cregisteredProof)
@@ -255,7 +261,7 @@ func FilGetPostCircuitIdentifier(registeredProof FilRegisteredPoStProof) *FilStr
 	return __v
 }
 
-// FilGetPostParamsCid function as declared in filecoin-ffi/filecoin.h:389
+// FilGetPostParamsCid function as declared in filecoin-ffi/filecoin.h:396
 func FilGetPostParamsCid(registeredProof FilRegisteredPoStProof) *FilStringResponse {
 	cregisteredProof, _ := (C.fil_RegisteredPoStProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_post_params_cid(cregisteredProof)
@@ -263,7 +269,7 @@ func FilGetPostParamsCid(registeredProof FilRegisteredPoStProof) *FilStringRespo
 	return __v
 }
 
-// FilGetPostParamsPath function as declared in filecoin-ffi/filecoin.h:396
+// FilGetPostParamsPath function as declared in filecoin-ffi/filecoin.h:403
 func FilGetPostParamsPath(registeredProof FilRegisteredPoStProof) *FilStringResponse {
 	cregisteredProof, _ := (C.fil_RegisteredPoStProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_post_params_path(cregisteredProof)
@@ -271,7 +277,7 @@ func FilGetPostParamsPath(registeredProof FilRegisteredPoStProof) *FilStringResp
 	return __v
 }
 
-// FilGetPostVerifyingKeyCid function as declared in filecoin-ffi/filecoin.h:402
+// FilGetPostVerifyingKeyCid function as declared in filecoin-ffi/filecoin.h:409
 func FilGetPostVerifyingKeyCid(registeredProof FilRegisteredPoStProof) *FilStringResponse {
 	cregisteredProof, _ := (C.fil_RegisteredPoStProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_post_verifying_key_cid(cregisteredProof)
@@ -279,7 +285,7 @@ func FilGetPostVerifyingKeyCid(registeredProof FilRegisteredPoStProof) *FilStrin
 	return __v
 }
 
-// FilGetPostVerifyingKeyPath function as declared in filecoin-ffi/filecoin.h:409
+// FilGetPostVerifyingKeyPath function as declared in filecoin-ffi/filecoin.h:416
 func FilGetPostVerifyingKeyPath(registeredProof FilRegisteredPoStProof) *FilStringResponse {
 	cregisteredProof, _ := (C.fil_RegisteredPoStProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_post_verifying_key_path(cregisteredProof)
@@ -287,7 +293,7 @@ func FilGetPostVerifyingKeyPath(registeredProof FilRegisteredPoStProof) *FilStri
 	return __v
 }
 
-// FilGetPostVersion function as declared in filecoin-ffi/filecoin.h:415
+// FilGetPostVersion function as declared in filecoin-ffi/filecoin.h:422
 func FilGetPostVersion(registeredProof FilRegisteredPoStProof) *FilStringResponse {
 	cregisteredProof, _ := (C.fil_RegisteredPoStProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_post_version(cregisteredProof)
@@ -295,7 +301,7 @@ func FilGetPostVersion(registeredProof FilRegisteredPoStProof) *FilStringRespons
 	return __v
 }
 
-// FilGetSealCircuitIdentifier function as declared in filecoin-ffi/filecoin.h:421
+// FilGetSealCircuitIdentifier function as declared in filecoin-ffi/filecoin.h:428
 func FilGetSealCircuitIdentifier(registeredProof FilRegisteredSealProof) *FilStringResponse {
 	cregisteredProof, _ := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_seal_circuit_identifier(cregisteredProof)
@@ -303,7 +309,7 @@ func FilGetSealCircuitIdentifier(registeredProof FilRegisteredSealProof) *FilStr
 	return __v
 }
 
-// FilGetSealParamsCid function as declared in filecoin-ffi/filecoin.h:427
+// FilGetSealParamsCid function as declared in filecoin-ffi/filecoin.h:434
 func FilGetSealParamsCid(registeredProof FilRegisteredSealProof) *FilStringResponse {
 	cregisteredProof, _ := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_seal_params_cid(cregisteredProof)
@@ -311,7 +317,7 @@ func FilGetSealParamsCid(registeredProof FilRegisteredSealProof) *FilStringRespo
 	return __v
 }
 
-// FilGetSealParamsPath function as declared in filecoin-ffi/filecoin.h:434
+// FilGetSealParamsPath function as declared in filecoin-ffi/filecoin.h:441
 func FilGetSealParamsPath(registeredProof FilRegisteredSealProof) *FilStringResponse {
 	cregisteredProof, _ := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_seal_params_path(cregisteredProof)
@@ -319,7 +325,7 @@ func FilGetSealParamsPath(registeredProof FilRegisteredSealProof) *FilStringResp
 	return __v
 }
 
-// FilGetSealVerifyingKeyCid function as declared in filecoin-ffi/filecoin.h:440
+// FilGetSealVerifyingKeyCid function as declared in filecoin-ffi/filecoin.h:447
 func FilGetSealVerifyingKeyCid(registeredProof FilRegisteredSealProof) *FilStringResponse {
 	cregisteredProof, _ := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_seal_verifying_key_cid(cregisteredProof)
@@ -327,7 +333,7 @@ func FilGetSealVerifyingKeyCid(registeredProof FilRegisteredSealProof) *FilStrin
 	return __v
 }
 
-// FilGetSealVerifyingKeyPath function as declared in filecoin-ffi/filecoin.h:447
+// FilGetSealVerifyingKeyPath function as declared in filecoin-ffi/filecoin.h:454
 func FilGetSealVerifyingKeyPath(registeredProof FilRegisteredSealProof) *FilStringResponse {
 	cregisteredProof, _ := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_seal_verifying_key_path(cregisteredProof)
@@ -335,7 +341,7 @@ func FilGetSealVerifyingKeyPath(registeredProof FilRegisteredSealProof) *FilStri
 	return __v
 }
 
-// FilGetSealVersion function as declared in filecoin-ffi/filecoin.h:453
+// FilGetSealVersion function as declared in filecoin-ffi/filecoin.h:460
 func FilGetSealVersion(registeredProof FilRegisteredSealProof) *FilStringResponse {
 	cregisteredProof, _ := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_seal_version(cregisteredProof)
@@ -343,7 +349,7 @@ func FilGetSealVersion(registeredProof FilRegisteredSealProof) *FilStringRespons
 	return __v
 }
 
-// FilHash function as declared in filecoin-ffi/filecoin.h:463
+// FilHash function as declared in filecoin-ffi/filecoin.h:470
 func FilHash(messagePtr string, messageLen uint) *FilHashResponse {
 	messagePtr = safeString(messagePtr)
 	cmessagePtr, _ := unpackPUint8TString(messagePtr)
@@ -354,14 +360,22 @@ func FilHash(messagePtr string, messageLen uint) *FilHashResponse {
 	return __v
 }
 
-// FilPrivateKeyGenerate function as declared in filecoin-ffi/filecoin.h:468
+// FilInitLogFd function as declared in filecoin-ffi/filecoin.h:481
+func FilInitLogFd(logFd int32) *FilInitLogFdResponse {
+	clogFd, _ := (C.int)(logFd), cgoAllocsUnknown
+	__ret := C.fil_init_log_fd(clogFd)
+	__v := NewFilInitLogFdResponseRef(unsafe.Pointer(__ret))
+	return __v
+}
+
+// FilPrivateKeyGenerate function as declared in filecoin-ffi/filecoin.h:486
 func FilPrivateKeyGenerate() *FilPrivateKeyGenerateResponse {
 	__ret := C.fil_private_key_generate()
 	__v := NewFilPrivateKeyGenerateResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
 
-// FilPrivateKeyGenerateWithSeed function as declared in filecoin-ffi/filecoin.h:481
+// FilPrivateKeyGenerateWithSeed function as declared in filecoin-ffi/filecoin.h:499
 func FilPrivateKeyGenerateWithSeed(rawSeed Fil32ByteArray) *FilPrivateKeyGenerateResponse {
 	crawSeed, _ := rawSeed.PassValue()
 	__ret := C.fil_private_key_generate_with_seed(crawSeed)
@@ -369,7 +383,7 @@ func FilPrivateKeyGenerateWithSeed(rawSeed Fil32ByteArray) *FilPrivateKeyGenerat
 	return __v
 }
 
-// FilPrivateKeyPublicKey function as declared in filecoin-ffi/filecoin.h:492
+// FilPrivateKeyPublicKey function as declared in filecoin-ffi/filecoin.h:510
 func FilPrivateKeyPublicKey(rawPrivateKeyPtr string) *FilPrivateKeyPublicKeyResponse {
 	rawPrivateKeyPtr = safeString(rawPrivateKeyPtr)
 	crawPrivateKeyPtr, _ := unpackPUint8TString(rawPrivateKeyPtr)
@@ -379,7 +393,7 @@ func FilPrivateKeyPublicKey(rawPrivateKeyPtr string) *FilPrivateKeyPublicKeyResp
 	return __v
 }
 
-// FilPrivateKeySign function as declared in filecoin-ffi/filecoin.h:505
+// FilPrivateKeySign function as declared in filecoin-ffi/filecoin.h:523
 func FilPrivateKeySign(rawPrivateKeyPtr string, messagePtr string, messageLen uint) *FilPrivateKeySignResponse {
 	rawPrivateKeyPtr = safeString(rawPrivateKeyPtr)
 	crawPrivateKeyPtr, _ := unpackPUint8TString(rawPrivateKeyPtr)
@@ -393,7 +407,7 @@ func FilPrivateKeySign(rawPrivateKeyPtr string, messagePtr string, messageLen ui
 	return __v
 }
 
-// FilSealCommitPhase1 function as declared in filecoin-ffi/filecoin.h:513
+// FilSealCommitPhase1 function as declared in filecoin-ffi/filecoin.h:531
 func FilSealCommitPhase1(registeredProof FilRegisteredSealProof, commR Fil32ByteArray, commD Fil32ByteArray, cacheDirPath string, replicaPath string, sectorId uint64, proverId Fil32ByteArray, ticket Fil32ByteArray, seed Fil32ByteArray, piecesPtr []FilPublicPieceInfo, piecesLen uint) *FilSealCommitPhase1Response {
 	cregisteredProof, _ := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	ccommR, _ := commR.PassValue()
@@ -416,7 +430,7 @@ func FilSealCommitPhase1(registeredProof FilRegisteredSealProof, commR Fil32Byte
 	return __v
 }
 
-// FilSealCommitPhase2 function as declared in filecoin-ffi/filecoin.h:525
+// FilSealCommitPhase2 function as declared in filecoin-ffi/filecoin.h:543
 func FilSealCommitPhase2(sealCommitPhase1OutputPtr string, sealCommitPhase1OutputLen uint, sectorId uint64, proverId Fil32ByteArray) *FilSealCommitPhase2Response {
 	sealCommitPhase1OutputPtr = safeString(sealCommitPhase1OutputPtr)
 	csealCommitPhase1OutputPtr, _ := unpackPUint8TString(sealCommitPhase1OutputPtr)
@@ -429,7 +443,7 @@ func FilSealCommitPhase2(sealCommitPhase1OutputPtr string, sealCommitPhase1Outpu
 	return __v
 }
 
-// FilSealPreCommitPhase1 function as declared in filecoin-ffi/filecoin.h:534
+// FilSealPreCommitPhase1 function as declared in filecoin-ffi/filecoin.h:552
 func FilSealPreCommitPhase1(registeredProof FilRegisteredSealProof, cacheDirPath string, stagedSectorPath string, sealedSectorPath string, sectorId uint64, proverId Fil32ByteArray, ticket Fil32ByteArray, piecesPtr []FilPublicPieceInfo, piecesLen uint) *FilSealPreCommitPhase1Response {
 	cregisteredProof, _ := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	cacheDirPath = safeString(cacheDirPath)
@@ -452,7 +466,7 @@ func FilSealPreCommitPhase1(registeredProof FilRegisteredSealProof, cacheDirPath
 	return __v
 }
 
-// FilSealPreCommitPhase2 function as declared in filecoin-ffi/filecoin.h:548
+// FilSealPreCommitPhase2 function as declared in filecoin-ffi/filecoin.h:566
 func FilSealPreCommitPhase2(sealPreCommitPhase1OutputPtr string, sealPreCommitPhase1OutputLen uint, cacheDirPath string, sealedSectorPath string) *FilSealPreCommitPhase2Response {
 	sealPreCommitPhase1OutputPtr = safeString(sealPreCommitPhase1OutputPtr)
 	csealPreCommitPhase1OutputPtr, _ := unpackPUint8TString(sealPreCommitPhase1OutputPtr)
@@ -469,7 +483,7 @@ func FilSealPreCommitPhase2(sealPreCommitPhase1OutputPtr string, sealPreCommitPh
 	return __v
 }
 
-// FilUnseal function as declared in filecoin-ffi/filecoin.h:556
+// FilUnseal function as declared in filecoin-ffi/filecoin.h:574
 func FilUnseal(registeredProof FilRegisteredSealProof, cacheDirPath string, sealedSectorPath string, unsealOutputPath string, sectorId uint64, proverId Fil32ByteArray, ticket Fil32ByteArray, commD Fil32ByteArray) *FilUnsealResponse {
 	cregisteredProof, _ := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	cacheDirPath = safeString(cacheDirPath)
@@ -490,7 +504,7 @@ func FilUnseal(registeredProof FilRegisteredSealProof, cacheDirPath string, seal
 	return __v
 }
 
-// FilUnsealRange function as declared in filecoin-ffi/filecoin.h:568
+// FilUnsealRange function as declared in filecoin-ffi/filecoin.h:586
 func FilUnsealRange(registeredProof FilRegisteredSealProof, cacheDirPath string, sealedSectorPath string, unsealOutputPath string, sectorId uint64, proverId Fil32ByteArray, ticket Fil32ByteArray, commD Fil32ByteArray, offset uint64, length uint64) *FilUnsealRangeResponse {
 	cregisteredProof, _ := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	cacheDirPath = safeString(cacheDirPath)
@@ -513,7 +527,7 @@ func FilUnsealRange(registeredProof FilRegisteredSealProof, cacheDirPath string,
 	return __v
 }
 
-// FilVerify function as declared in filecoin-ffi/filecoin.h:589
+// FilVerify function as declared in filecoin-ffi/filecoin.h:607
 func FilVerify(signaturePtr string, flattenedDigestsPtr string, flattenedDigestsLen uint, flattenedPublicKeysPtr string, flattenedPublicKeysLen uint) int32 {
 	signaturePtr = safeString(signaturePtr)
 	csignaturePtr, _ := unpackPUint8TString(signaturePtr)
@@ -531,7 +545,7 @@ func FilVerify(signaturePtr string, flattenedDigestsPtr string, flattenedDigests
 	return __v
 }
 
-// FilVerifyPost function as declared in filecoin-ffi/filecoin.h:598
+// FilVerifyPost function as declared in filecoin-ffi/filecoin.h:616
 func FilVerifyPost(randomness Fil32ByteArray, challengeCount uint64, replicasPtr []FilPublicReplicaInfo, replicasLen uint, proofsPtr []FilPoStProof, proofsLen uint, winnersPtr []FilCandidate, winnersLen uint, proverId Fil32ByteArray) *FilVerifyPoStResponse {
 	crandomness, _ := randomness.PassValue()
 	cchallengeCount, _ := (C.uint64_t)(challengeCount), cgoAllocsUnknown
@@ -550,7 +564,7 @@ func FilVerifyPost(randomness Fil32ByteArray, challengeCount uint64, replicasPtr
 	return __v
 }
 
-// FilVerifySeal function as declared in filecoin-ffi/filecoin.h:612
+// FilVerifySeal function as declared in filecoin-ffi/filecoin.h:630
 func FilVerifySeal(registeredProof FilRegisteredSealProof, commR Fil32ByteArray, commD Fil32ByteArray, proverId Fil32ByteArray, ticket Fil32ByteArray, seed Fil32ByteArray, sectorId uint64, proofPtr string, proofLen uint) *FilVerifySealResponse {
 	cregisteredProof, _ := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	ccommR, _ := commR.PassValue()
@@ -568,7 +582,7 @@ func FilVerifySeal(registeredProof FilRegisteredSealProof, commR Fil32ByteArray,
 	return __v
 }
 
-// FilWriteWithAlignment function as declared in filecoin-ffi/filecoin.h:626
+// FilWriteWithAlignment function as declared in filecoin-ffi/filecoin.h:644
 func FilWriteWithAlignment(registeredProof FilRegisteredSealProof, srcFd int32, srcSize uint64, dstFd int32, existingPieceSizesPtr []uint64, existingPieceSizesLen uint) *FilWriteWithAlignmentResponse {
 	cregisteredProof, _ := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	csrcFd, _ := (C.int)(srcFd), cgoAllocsUnknown
@@ -581,7 +595,7 @@ func FilWriteWithAlignment(registeredProof FilRegisteredSealProof, srcFd int32, 
 	return __v
 }
 
-// FilWriteWithoutAlignment function as declared in filecoin-ffi/filecoin.h:637
+// FilWriteWithoutAlignment function as declared in filecoin-ffi/filecoin.h:655
 func FilWriteWithoutAlignment(registeredProof FilRegisteredSealProof, srcFd int32, srcSize uint64, dstFd int32) *FilWriteWithoutAlignmentResponse {
 	cregisteredProof, _ := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	csrcFd, _ := (C.int)(srcFd), cgoAllocsUnknown

--- a/generated/types.go
+++ b/generated/types.go
@@ -125,42 +125,50 @@ type FilHashResponse struct {
 	allocsc52a22ef interface{}
 }
 
-// FilBLSPrivateKey as declared in filecoin-ffi/filecoin.h:133
+// FilInitLogFdResponse as declared in filecoin-ffi/filecoin.h:134
+type FilInitLogFdResponse struct {
+	StatusCode     FCPResponseStatus
+	ErrorMsg       string
+	ref3c1a0a08    *C.fil_InitLogFdResponse
+	allocs3c1a0a08 interface{}
+}
+
+// FilBLSPrivateKey as declared in filecoin-ffi/filecoin.h:138
 type FilBLSPrivateKey struct {
 	Inner          [32]byte
 	ref2f77fe3a    *C.fil_BLSPrivateKey
 	allocs2f77fe3a interface{}
 }
 
-// FilPrivateKeyGenerateResponse as declared in filecoin-ffi/filecoin.h:140
+// FilPrivateKeyGenerateResponse as declared in filecoin-ffi/filecoin.h:145
 type FilPrivateKeyGenerateResponse struct {
 	PrivateKey    FilBLSPrivateKey
 	ref2dba09f    *C.fil_PrivateKeyGenerateResponse
 	allocs2dba09f interface{}
 }
 
-// FilBLSPublicKey as declared in filecoin-ffi/filecoin.h:144
+// FilBLSPublicKey as declared in filecoin-ffi/filecoin.h:149
 type FilBLSPublicKey struct {
 	Inner          [48]byte
 	ref6d0cab13    *C.fil_BLSPublicKey
 	allocs6d0cab13 interface{}
 }
 
-// FilPrivateKeyPublicKeyResponse as declared in filecoin-ffi/filecoin.h:151
+// FilPrivateKeyPublicKeyResponse as declared in filecoin-ffi/filecoin.h:156
 type FilPrivateKeyPublicKeyResponse struct {
 	PublicKey      FilBLSPublicKey
 	refee14e59d    *C.fil_PrivateKeyPublicKeyResponse
 	allocsee14e59d interface{}
 }
 
-// FilPrivateKeySignResponse as declared in filecoin-ffi/filecoin.h:158
+// FilPrivateKeySignResponse as declared in filecoin-ffi/filecoin.h:163
 type FilPrivateKeySignResponse struct {
 	Signature      FilBLSSignature
 	refcdf97b28    *C.fil_PrivateKeySignResponse
 	allocscdf97b28 interface{}
 }
 
-// FilSealCommitPhase1Response as declared in filecoin-ffi/filecoin.h:165
+// FilSealCommitPhase1Response as declared in filecoin-ffi/filecoin.h:170
 type FilSealCommitPhase1Response struct {
 	StatusCode                FCPResponseStatus
 	ErrorMsg                  string
@@ -170,7 +178,7 @@ type FilSealCommitPhase1Response struct {
 	allocs61ed8561            interface{}
 }
 
-// FilSealCommitPhase2Response as declared in filecoin-ffi/filecoin.h:172
+// FilSealCommitPhase2Response as declared in filecoin-ffi/filecoin.h:177
 type FilSealCommitPhase2Response struct {
 	StatusCode     FCPResponseStatus
 	ErrorMsg       string
@@ -180,7 +188,7 @@ type FilSealCommitPhase2Response struct {
 	allocs5860b9a4 interface{}
 }
 
-// FilSealPreCommitPhase1Response as declared in filecoin-ffi/filecoin.h:179
+// FilSealPreCommitPhase1Response as declared in filecoin-ffi/filecoin.h:184
 type FilSealPreCommitPhase1Response struct {
 	ErrorMsg                     string
 	StatusCode                   FCPResponseStatus
@@ -190,7 +198,7 @@ type FilSealPreCommitPhase1Response struct {
 	allocs132bbfd8               interface{}
 }
 
-// FilSealPreCommitPhase2Response as declared in filecoin-ffi/filecoin.h:187
+// FilSealPreCommitPhase2Response as declared in filecoin-ffi/filecoin.h:192
 type FilSealPreCommitPhase2Response struct {
 	ErrorMsg        string
 	StatusCode      FCPResponseStatus
@@ -201,7 +209,7 @@ type FilSealPreCommitPhase2Response struct {
 	allocs2aa6831d  interface{}
 }
 
-// FilStringResponse as declared in filecoin-ffi/filecoin.h:196
+// FilStringResponse as declared in filecoin-ffi/filecoin.h:201
 type FilStringResponse struct {
 	StatusCode     FCPResponseStatus
 	ErrorMsg       string
@@ -210,7 +218,7 @@ type FilStringResponse struct {
 	allocs4f413043 interface{}
 }
 
-// FilUnsealRangeResponse as declared in filecoin-ffi/filecoin.h:201
+// FilUnsealRangeResponse as declared in filecoin-ffi/filecoin.h:206
 type FilUnsealRangeResponse struct {
 	StatusCode     FCPResponseStatus
 	ErrorMsg       string
@@ -218,7 +226,7 @@ type FilUnsealRangeResponse struct {
 	allocs61e219c9 interface{}
 }
 
-// FilUnsealResponse as declared in filecoin-ffi/filecoin.h:206
+// FilUnsealResponse as declared in filecoin-ffi/filecoin.h:211
 type FilUnsealResponse struct {
 	StatusCode     FCPResponseStatus
 	ErrorMsg       string
@@ -226,7 +234,7 @@ type FilUnsealResponse struct {
 	allocsdb3aa0f1 interface{}
 }
 
-// FilVerifyPoStResponse as declared in filecoin-ffi/filecoin.h:212
+// FilVerifyPoStResponse as declared in filecoin-ffi/filecoin.h:217
 type FilVerifyPoStResponse struct {
 	StatusCode     FCPResponseStatus
 	ErrorMsg       string
@@ -235,7 +243,7 @@ type FilVerifyPoStResponse struct {
 	allocs3a164861 interface{}
 }
 
-// FilVerifySealResponse as declared in filecoin-ffi/filecoin.h:218
+// FilVerifySealResponse as declared in filecoin-ffi/filecoin.h:223
 type FilVerifySealResponse struct {
 	StatusCode     FCPResponseStatus
 	ErrorMsg       string
@@ -244,7 +252,7 @@ type FilVerifySealResponse struct {
 	allocsd4397079 interface{}
 }
 
-// FilWriteWithAlignmentResponse as declared in filecoin-ffi/filecoin.h:226
+// FilWriteWithAlignmentResponse as declared in filecoin-ffi/filecoin.h:231
 type FilWriteWithAlignmentResponse struct {
 	CommP                 [32]byte
 	ErrorMsg              string
@@ -255,7 +263,7 @@ type FilWriteWithAlignmentResponse struct {
 	allocsa330e79         interface{}
 }
 
-// FilWriteWithoutAlignmentResponse as declared in filecoin-ffi/filecoin.h:233
+// FilWriteWithoutAlignmentResponse as declared in filecoin-ffi/filecoin.h:238
 type FilWriteWithoutAlignmentResponse struct {
 	CommP              [32]byte
 	ErrorMsg           string
@@ -265,14 +273,14 @@ type FilWriteWithoutAlignmentResponse struct {
 	allocsc8e1ed8      interface{}
 }
 
-// Fil32ByteArray as declared in filecoin-ffi/filecoin.h:237
+// Fil32ByteArray as declared in filecoin-ffi/filecoin.h:242
 type Fil32ByteArray struct {
 	Inner          [32]byte
 	ref373ec61a    *C.fil_32ByteArray
 	allocs373ec61a interface{}
 }
 
-// FilPrivateReplicaInfo as declared in filecoin-ffi/filecoin.h:245
+// FilPrivateReplicaInfo as declared in filecoin-ffi/filecoin.h:250
 type FilPrivateReplicaInfo struct {
 	RegisteredProof FilRegisteredPoStProof
 	CacheDirPath    string
@@ -283,7 +291,7 @@ type FilPrivateReplicaInfo struct {
 	allocs81a31e9b  interface{}
 }
 
-// FilPublicPieceInfo as declared in filecoin-ffi/filecoin.h:250
+// FilPublicPieceInfo as declared in filecoin-ffi/filecoin.h:255
 type FilPublicPieceInfo struct {
 	NumBytes       uint64
 	CommP          [32]byte
@@ -291,7 +299,7 @@ type FilPublicPieceInfo struct {
 	allocsd00025ac interface{}
 }
 
-// FilPublicReplicaInfo as declared in filecoin-ffi/filecoin.h:256
+// FilPublicReplicaInfo as declared in filecoin-ffi/filecoin.h:261
 type FilPublicReplicaInfo struct {
 	RegisteredProof FilRegisteredPoStProof
 	CommR           [32]byte

--- a/rust/src/proofs/api.rs
+++ b/rust/src/proofs/api.rs
@@ -1,6 +1,5 @@
 use std::mem;
 use std::slice::from_raw_parts;
-use std::sync::Once;
 
 use ffi_toolkit::{
     c_str_to_pbuf, catch_panic_response, raw_ptr, rust_str_to_c_str, FCPResponseStatus,
@@ -14,6 +13,7 @@ use libc;
 use super::helpers::{bls_12_fr_into_bytes, c_to_rust_candidates, to_private_replica_info_map};
 use super::types::*;
 use crate::proofs::helpers::c_to_rust_post_proofs;
+use crate::util::api::init_log;
 use filecoin_proofs_api::seal::SealPreCommitPhase2Output;
 use std::path::PathBuf;
 
@@ -1079,16 +1079,6 @@ pub unsafe extern "C" fn fil_destroy_generate_candidates_response(
 #[no_mangle]
 pub unsafe extern "C" fn fil_destroy_clear_cache_response(ptr: *mut fil_ClearCacheResponse) {
     let _ = Box::from_raw(ptr);
-}
-
-/// Protects the init off the logger.
-static LOG_INIT: Once = Once::new();
-
-/// Ensures the logger is initialized.
-fn init_log() {
-    LOG_INIT.call_once(|| {
-        fil_logger::init();
-    });
 }
 
 #[cfg(test)]

--- a/rust/src/util/api.rs
+++ b/rust/src/util/api.rs
@@ -1,8 +1,20 @@
+use std::sync::Once;
+
 use bellperson::GPU_NVIDIA_DEVICES;
 use ffi_toolkit::{catch_panic_response, raw_ptr};
 
 use super::types::fil_GpuDeviceResponse;
 use std::ffi::CString;
+
+/// Protects the init off the logger.
+static LOG_INIT: Once = Once::new();
+
+/// Ensures the logger is initialized.
+pub fn init_log() {
+    LOG_INIT.call_once(|| {
+        fil_logger::init();
+    });
+}
 
 /// Returns an array of strings containing the device names that can be used.
 #[no_mangle]

--- a/rust/src/util/types.rs
+++ b/rust/src/util/types.rs
@@ -30,3 +30,26 @@ code_and_message_impl!(fil_GpuDeviceResponse);
 pub unsafe extern "C" fn fil_destroy_gpu_device_response(ptr: *mut fil_GpuDeviceResponse) {
     let _ = Box::from_raw(ptr);
 }
+
+#[repr(C)]
+#[derive(DropStructMacro)]
+pub struct fil_InitLogFdResponse {
+    pub status_code: FCPResponseStatus,
+    pub error_msg: *const libc::c_char,
+}
+
+impl Default for fil_InitLogFdResponse {
+    fn default() -> Self {
+        Self {
+            error_msg: ptr::null(),
+            status_code: FCPResponseStatus::FCPNoError,
+        }
+    }
+}
+
+code_and_message_impl!(fil_InitLogFdResponse);
+
+#[no_mangle]
+pub unsafe extern "C" fn fil_destroy_init_log_fd_response(ptr: *mut fil_InitLogFdResponse) {
+    let _ = Box::from_raw(ptr);
+}


### PR DESCRIPTION
The file is usually a pipe that was opened by the caller.

This feature was requested by @lanzafame (and earlier explored together with @Kubuxu iirc).

There are no Go binding yet, which I guess can be generated.