### PR TITLE
add PrivateKeyGenerateWithSeed

### DIFF
--- a/bls.go
+++ b/bls.go
@@ -73,6 +73,21 @@ func PrivateKeyGenerate() PrivateKey {
 	return out
 }
 
+// PrivateKeyGenerate generates a private key in a predictable manner
+func PrivateKeyGenerateWithSeed(seed PrivateKeyGenSeed) PrivateKey {
+	var ary generated.Fil32ByteArray
+	copy(ary.Inner[:], seed[:])
+
+	resp := generated.FilPrivateKeyGenerateWithSeed(ary)
+	resp.Deref()
+	resp.PrivateKey.Deref()
+	defer generated.FilDestroyPrivateKeyGenerateResponse(resp)
+
+	var out PrivateKey
+	copy(out[:], resp.PrivateKey.Inner[:])
+	return out
+}
+
 // PrivateKeySign signs a message
 func PrivateKeySign(privateKey PrivateKey, message Message) *Signature {
 	resp := generated.FilPrivateKeySign(string(privateKey[:]), string(message), uint(len(message)))

--- a/bls_test.go
+++ b/bls_test.go
@@ -2,11 +2,29 @@ package ffi
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestDeterministicPrivateKeyGeneration(t *testing.T) {
+	rand.Seed(time.Now().UnixNano())
+
+	for i := 0; i < 10000; i++ {
+		var xs [32]byte
+		n, err := rand.Read(xs[:])
+		require.NoError(t, err)
+		require.Equal(t, len(xs), n)
+
+		first := PrivateKeyGenerateWithSeed(xs)
+		secnd := PrivateKeyGenerateWithSeed(xs)
+
+		assert.Equal(t, first, secnd)
+	}
+}
 
 func TestBLSSigningAndVerification(t *testing.T) {
 	// generate private keys

--- a/types.go
+++ b/types.go
@@ -38,6 +38,9 @@ type Message []byte
 // Digest is a compressed affine
 type Digest [DigestBytes]byte
 
+// Used when generating a private key deterministically
+type PrivateKeyGenSeed [32]byte
+
 // Proofs
 
 // SortedPublicSectorInfo is a slice of publicSectorInfo sorted


### PR DESCRIPTION
## Why does this PR exist?

See [this thread](https://github.com/filecoin-project/filecoin-ffi/issues/38).

From @frrst:

> Nondeterministic key generation makes testing hard and I am having to hack around it.