### PR TITLE
fix: rebuild filecoin.h on code changes

### DIFF
--- a/rust/build.rs
+++ b/rust/build.rs
@@ -2,8 +2,6 @@ use std::env;
 use std::path::Path;
 
 fn main() {
-    println!("cargo:rerun-if-changed=src/");
-
     let out_dir = env::var("OUT_DIR").unwrap();
     let hdr_out = Path::new(&out_dir).join("include/filcrypto.h");
 


### PR DESCRIPTION
`cargo:rerun-if-changed` calls do not recursively check files in directories. Hence
`cargo:rerun-if-changed=src/` would only rebuilds if the directory itself changes,
but won't if the contents changes.

Luckily the `build.rs` is run if any Rust source file changes, hence we don't need
that instruction.

Fixes #28.