### PR TITLE
test: run logging with pipe test on Linux only

### DIFF
--- a/rust/src/util/api.rs
+++ b/rust/src/util/api.rs
@@ -105,7 +105,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(target_os = "linux")]
     fn test_init_log_fd() {
         let mut fds: [libc::c_int; 2] = [0; 2];
         let res = unsafe { libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC) };


### PR DESCRIPTION
OSX also doesn't support `libc::pipe2`, hence run the test on Linux only.