### PR TITLE
use dtynn's forked c-for-go to regenerate CGO bindings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,9 +294,16 @@ commands:
   ensure_generated_cgo_up_to_date:
     steps:
       - run:
-          name: Generate CGO bindings and compare with what's tracked by Git
+          name: Generate CGO bindings (using forked c-for-go) and compare with what's tracked by Git
           command: |
-            go run github.com/xlab/c-for-go --ccincl --ccdefs --nostamp filcrypto.yml
+            DIR=$(pwd)
+            git clone git@github.com:dtynn/c-for-go.git $GOPATH/src/github.com/xlab/c-for-go
+            cd $GOPATH/src/github.com/xlab/c-for-go
+            git checkout fix/2-mem-issues
+            GO111MODULE=off go get
+            GO111MODULE=off go build -o /tmp/c-for-go-forked main.go process.go
+            cd $DIR
+            /tmp/c-for-go-forked --ccincl --ccdefs --nostamp filcrypto.yml
             git diff --exit-code ./generated/
   run_tests:
     parameters:

--- a/generated/cgo_helpers.go
+++ b/generated/cgo_helpers.go
@@ -12,6 +12,7 @@ package generated
 */
 import "C"
 import (
+	"fmt"
 	"runtime"
 	"sync"
 	"unsafe"
@@ -71,8 +72,8 @@ func (a *cgoAllocMap) Free() {
 // The caller is responsible for freeing the this memory via C.free.
 func allocFilBLSSignatureMemory(n int) unsafe.Pointer {
 	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfFilBLSSignatureValue))
-	if err != nil {
-		panic("memory alloc error: " + err.Error())
+	if mem == nil {
+		panic(fmt.Sprintln("memory alloc error: ", err))
 	}
 	return mem
 }
@@ -152,8 +153,8 @@ func (x *FilBLSSignature) Deref() {
 // The caller is responsible for freeing the this memory via C.free.
 func allocFilAggregateResponseMemory(n int) unsafe.Pointer {
 	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfFilAggregateResponseValue))
-	if err != nil {
-		panic("memory alloc error: " + err.Error())
+	if mem == nil {
+		panic(fmt.Sprintln("memory alloc error: ", err))
 	}
 	return mem
 }
@@ -233,8 +234,8 @@ func (x *FilAggregateResponse) Deref() {
 // The caller is responsible for freeing the this memory via C.free.
 func allocFilClearCacheResponseMemory(n int) unsafe.Pointer {
 	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfFilClearCacheResponseValue))
-	if err != nil {
-		panic("memory alloc error: " + err.Error())
+	if mem == nil {
+		panic(fmt.Sprintln("memory alloc error: ", err))
 	}
 	return mem
 }
@@ -366,8 +367,8 @@ func (x *FilClearCacheResponse) Deref() {
 // The caller is responsible for freeing the this memory via C.free.
 func allocFilFinalizeTicketResponseMemory(n int) unsafe.Pointer {
 	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfFilFinalizeTicketResponseValue))
-	if err != nil {
-		panic("memory alloc error: " + err.Error())
+	if mem == nil {
+		panic(fmt.Sprintln("memory alloc error: ", err))
 	}
 	return mem
 }
@@ -457,8 +458,8 @@ func (x *FilFinalizeTicketResponse) Deref() {
 // The caller is responsible for freeing the this memory via C.free.
 func allocFilGenerateDataCommitmentResponseMemory(n int) unsafe.Pointer {
 	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfFilGenerateDataCommitmentResponseValue))
-	if err != nil {
-		panic("memory alloc error: " + err.Error())
+	if mem == nil {
+		panic(fmt.Sprintln("memory alloc error: ", err))
 	}
 	return mem
 }
@@ -548,8 +549,8 @@ func (x *FilGenerateDataCommitmentResponse) Deref() {
 // The caller is responsible for freeing the this memory via C.free.
 func allocFilGeneratePieceCommitmentResponseMemory(n int) unsafe.Pointer {
 	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfFilGeneratePieceCommitmentResponseValue))
-	if err != nil {
-		panic("memory alloc error: " + err.Error())
+	if mem == nil {
+		panic(fmt.Sprintln("memory alloc error: ", err))
 	}
 	return mem
 }
@@ -644,8 +645,8 @@ func (x *FilGeneratePieceCommitmentResponse) Deref() {
 // The caller is responsible for freeing the this memory via C.free.
 func allocFilPoStProofMemory(n int) unsafe.Pointer {
 	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfFilPoStProofValue))
-	if err != nil {
-		panic("memory alloc error: " + err.Error())
+	if mem == nil {
+		panic(fmt.Sprintln("memory alloc error: ", err))
 	}
 	return mem
 }
@@ -755,8 +756,8 @@ func (x *FilPoStProof) Deref() {
 // The caller is responsible for freeing the this memory via C.free.
 func allocFilGenerateWindowPoStResponseMemory(n int) unsafe.Pointer {
 	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfFilGenerateWindowPoStResponseValue))
-	if err != nil {
-		panic("memory alloc error: " + err.Error())
+	if mem == nil {
+		panic(fmt.Sprintln("memory alloc error: ", err))
 	}
 	return mem
 }
@@ -777,8 +778,8 @@ func unpackSFilPoStProof(x []FilPoStProof) (unpacked *C.fil_PoStProof, allocs *c
 		return nil, nil
 	}
 	allocs = new(cgoAllocMap)
-	defer runtime.SetFinalizer(&unpacked, func(**C.fil_PoStProof) {
-		go allocs.Free()
+	defer runtime.SetFinalizer(allocs, func(a *cgoAllocMap) {
+		go a.Free()
 	})
 
 	len0 := len(x)
@@ -897,8 +898,8 @@ func (x *FilGenerateWindowPoStResponse) Deref() {
 // The caller is responsible for freeing the this memory via C.free.
 func allocFilGenerateWinningPoStResponseMemory(n int) unsafe.Pointer {
 	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfFilGenerateWinningPoStResponseValue))
-	if err != nil {
-		panic("memory alloc error: " + err.Error())
+	if mem == nil {
+		panic(fmt.Sprintln("memory alloc error: ", err))
 	}
 	return mem
 }
@@ -993,8 +994,8 @@ func (x *FilGenerateWinningPoStResponse) Deref() {
 // The caller is responsible for freeing the this memory via C.free.
 func allocFilGenerateWinningPoStSectorChallengeMemory(n int) unsafe.Pointer {
 	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfFilGenerateWinningPoStSectorChallengeValue))
-	if err != nil {
-		panic("memory alloc error: " + err.Error())
+	if mem == nil {
+		panic(fmt.Sprintln("memory alloc error: ", err))
 	}
 	return mem
 }
@@ -1093,8 +1094,8 @@ func (x *FilGenerateWinningPoStSectorChallenge) Deref() {
 // The caller is responsible for freeing the this memory via C.free.
 func allocFilGpuDeviceResponseMemory(n int) unsafe.Pointer {
 	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfFilGpuDeviceResponseValue))
-	if err != nil {
-		panic("memory alloc error: " + err.Error())
+	if mem == nil {
+		panic(fmt.Sprintln("memory alloc error: ", err))
 	}
 	return mem
 }
@@ -1105,8 +1106,8 @@ const sizeOfFilGpuDeviceResponseValue = unsafe.Sizeof([1]C.fil_GpuDeviceResponse
 // The caller is responsible for freeing the this memory via C.free.
 func allocPCharMemory(n int) unsafe.Pointer {
 	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfPCharValue))
-	if err != nil {
-		panic("memory alloc error: " + err.Error())
+	if mem == nil {
+		panic(fmt.Sprintln("memory alloc error: ", err))
 	}
 	return mem
 }
@@ -1119,8 +1120,8 @@ func unpackSString(x []string) (unpacked **C.char, allocs *cgoAllocMap) {
 		return nil, nil
 	}
 	allocs = new(cgoAllocMap)
-	defer runtime.SetFinalizer(&unpacked, func(***C.char) {
-		go allocs.Free()
+	defer runtime.SetFinalizer(allocs, func(a *cgoAllocMap) {
+		go a.Free()
 	})
 
 	len0 := len(x)
@@ -1237,8 +1238,8 @@ func (x *FilGpuDeviceResponse) Deref() {
 // The caller is responsible for freeing the this memory via C.free.
 func allocFilBLSDigestMemory(n int) unsafe.Pointer {
 	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfFilBLSDigestValue))
-	if err != nil {
-		panic("memory alloc error: " + err.Error())
+	if mem == nil {
+		panic(fmt.Sprintln("memory alloc error: ", err))
 	}
 	return mem
 }
@@ -1318,8 +1319,8 @@ func (x *FilBLSDigest) Deref() {
 // The caller is responsible for freeing the this memory via C.free.
 func allocFilHashResponseMemory(n int) unsafe.Pointer {
 	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfFilHashResponseValue))
-	if err != nil {
-		panic("memory alloc error: " + err.Error())
+	if mem == nil {
+		panic(fmt.Sprintln("memory alloc error: ", err))
 	}
 	return mem
 }
@@ -1399,8 +1400,8 @@ func (x *FilHashResponse) Deref() {
 // The caller is responsible for freeing the this memory via C.free.
 func allocFilInitLogFdResponseMemory(n int) unsafe.Pointer {
 	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfFilInitLogFdResponseValue))
-	if err != nil {
-		panic("memory alloc error: " + err.Error())
+	if mem == nil {
+		panic(fmt.Sprintln("memory alloc error: ", err))
 	}
 	return mem
 }
@@ -1485,8 +1486,8 @@ func (x *FilInitLogFdResponse) Deref() {
 // The caller is responsible for freeing the this memory via C.free.
 func allocFilBLSPrivateKeyMemory(n int) unsafe.Pointer {
 	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfFilBLSPrivateKeyValue))
-	if err != nil {
-		panic("memory alloc error: " + err.Error())
+	if mem == nil {
+		panic(fmt.Sprintln("memory alloc error: ", err))
 	}
 	return mem
 }
@@ -1566,8 +1567,8 @@ func (x *FilBLSPrivateKey) Deref() {
 // The caller is responsible for freeing the this memory via C.free.
 func allocFilPrivateKeyGenerateResponseMemory(n int) unsafe.Pointer {
 	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfFilPrivateKeyGenerateResponseValue))
-	if err != nil {
-		panic("memory alloc error: " + err.Error())
+	if mem == nil {
+		panic(fmt.Sprintln("memory alloc error: ", err))
 	}
 	return mem
 }
@@ -1647,8 +1648,8 @@ func (x *FilPrivateKeyGenerateResponse) Deref() {
 // The caller is responsible for freeing the this memory via C.free.
 func allocFilBLSPublicKeyMemory(n int) unsafe.Pointer {
 	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfFilBLSPublicKeyValue))
-	if err != nil {
-		panic("memory alloc error: " + err.Error())
+	if mem == nil {
+		panic(fmt.Sprintln("memory alloc error: ", err))
 	}
 	return mem
 }
@@ -1728,8 +1729,8 @@ func (x *FilBLSPublicKey) Deref() {
 // The caller is responsible for freeing the this memory via C.free.
 func allocFilPrivateKeyPublicKeyResponseMemory(n int) unsafe.Pointer {
 	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfFilPrivateKeyPublicKeyResponseValue))
-	if err != nil {
-		panic("memory alloc error: " + err.Error())
+	if mem == nil {
+		panic(fmt.Sprintln("memory alloc error: ", err))
 	}
 	return mem
 }
@@ -1809,8 +1810,8 @@ func (x *FilPrivateKeyPublicKeyResponse) Deref() {
 // The caller is responsible for freeing the this memory via C.free.
 func allocFilPrivateKeySignResponseMemory(n int) unsafe.Pointer {
 	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfFilPrivateKeySignResponseValue))
-	if err != nil {
-		panic("memory alloc error: " + err.Error())
+	if mem == nil {
+		panic(fmt.Sprintln("memory alloc error: ", err))
 	}
 	return mem
 }
@@ -1890,8 +1891,8 @@ func (x *FilPrivateKeySignResponse) Deref() {
 // The caller is responsible for freeing the this memory via C.free.
 func allocFilSealCommitPhase1ResponseMemory(n int) unsafe.Pointer {
 	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfFilSealCommitPhase1ResponseValue))
-	if err != nil {
-		panic("memory alloc error: " + err.Error())
+	if mem == nil {
+		panic(fmt.Sprintln("memory alloc error: ", err))
 	}
 	return mem
 }
@@ -1986,8 +1987,8 @@ func (x *FilSealCommitPhase1Response) Deref() {
 // The caller is responsible for freeing the this memory via C.free.
 func allocFilSealCommitPhase2ResponseMemory(n int) unsafe.Pointer {
 	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfFilSealCommitPhase2ResponseValue))
-	if err != nil {
-		panic("memory alloc error: " + err.Error())
+	if mem == nil {
+		panic(fmt.Sprintln("memory alloc error: ", err))
 	}
 	return mem
 }
@@ -2082,8 +2083,8 @@ func (x *FilSealCommitPhase2Response) Deref() {
 // The caller is responsible for freeing the this memory via C.free.
 func allocFilSealPreCommitPhase1ResponseMemory(n int) unsafe.Pointer {
 	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfFilSealPreCommitPhase1ResponseValue))
-	if err != nil {
-		panic("memory alloc error: " + err.Error())
+	if mem == nil {
+		panic(fmt.Sprintln("memory alloc error: ", err))
 	}
 	return mem
 }
@@ -2178,8 +2179,8 @@ func (x *FilSealPreCommitPhase1Response) Deref() {
 // The caller is responsible for freeing the this memory via C.free.
 func allocFilSealPreCommitPhase2ResponseMemory(n int) unsafe.Pointer {
 	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfFilSealPreCommitPhase2ResponseValue))
-	if err != nil {
-		panic("memory alloc error: " + err.Error())
+	if mem == nil {
+		panic(fmt.Sprintln("memory alloc error: ", err))
 	}
 	return mem
 }
@@ -2279,8 +2280,8 @@ func (x *FilSealPreCommitPhase2Response) Deref() {
 // The caller is responsible for freeing the this memory via C.free.
 func allocFilStringResponseMemory(n int) unsafe.Pointer {
 	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfFilStringResponseValue))
-	if err != nil {
-		panic("memory alloc error: " + err.Error())
+	if mem == nil {
+		panic(fmt.Sprintln("memory alloc error: ", err))
 	}
 	return mem
 }
@@ -2370,8 +2371,8 @@ func (x *FilStringResponse) Deref() {
 // The caller is responsible for freeing the this memory via C.free.
 func allocFilUnsealRangeResponseMemory(n int) unsafe.Pointer {
 	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfFilUnsealRangeResponseValue))
-	if err != nil {
-		panic("memory alloc error: " + err.Error())
+	if mem == nil {
+		panic(fmt.Sprintln("memory alloc error: ", err))
 	}
 	return mem
 }
@@ -2456,8 +2457,8 @@ func (x *FilUnsealRangeResponse) Deref() {
 // The caller is responsible for freeing the this memory via C.free.
 func allocFilUnsealResponseMemory(n int) unsafe.Pointer {
 	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfFilUnsealResponseValue))
-	if err != nil {
-		panic("memory alloc error: " + err.Error())
+	if mem == nil {
+		panic(fmt.Sprintln("memory alloc error: ", err))
 	}
 	return mem
 }
@@ -2542,8 +2543,8 @@ func (x *FilUnsealResponse) Deref() {
 // The caller is responsible for freeing the this memory via C.free.
 func allocFilVerifySealResponseMemory(n int) unsafe.Pointer {
 	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfFilVerifySealResponseValue))
-	if err != nil {
-		panic("memory alloc error: " + err.Error())
+	if mem == nil {
+		panic(fmt.Sprintln("memory alloc error: ", err))
 	}
 	return mem
 }
@@ -2633,8 +2634,8 @@ func (x *FilVerifySealResponse) Deref() {
 // The caller is responsible for freeing the this memory via C.free.
 func allocFilVerifyWindowPoStResponseMemory(n int) unsafe.Pointer {
 	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfFilVerifyWindowPoStResponseValue))
-	if err != nil {
-		panic("memory alloc error: " + err.Error())
+	if mem == nil {
+		panic(fmt.Sprintln("memory alloc error: ", err))
 	}
 	return mem
 }
@@ -2724,8 +2725,8 @@ func (x *FilVerifyWindowPoStResponse) Deref() {
 // The caller is responsible for freeing the this memory via C.free.
 func allocFilVerifyWinningPoStResponseMemory(n int) unsafe.Pointer {
 	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfFilVerifyWinningPoStResponseValue))
-	if err != nil {
-		panic("memory alloc error: " + err.Error())
+	if mem == nil {
+		panic(fmt.Sprintln("memory alloc error: ", err))
 	}
 	return mem
 }
@@ -2815,8 +2816,8 @@ func (x *FilVerifyWinningPoStResponse) Deref() {
 // The caller is responsible for freeing the this memory via C.free.
 func allocFilWriteWithAlignmentResponseMemory(n int) unsafe.Pointer {
 	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfFilWriteWithAlignmentResponseValue))
-	if err != nil {
-		panic("memory alloc error: " + err.Error())
+	if mem == nil {
+		panic(fmt.Sprintln("memory alloc error: ", err))
 	}
 	return mem
 }
@@ -2916,8 +2917,8 @@ func (x *FilWriteWithAlignmentResponse) Deref() {
 // The caller is responsible for freeing the this memory via C.free.
 func allocFilWriteWithoutAlignmentResponseMemory(n int) unsafe.Pointer {
 	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfFilWriteWithoutAlignmentResponseValue))
-	if err != nil {
-		panic("memory alloc error: " + err.Error())
+	if mem == nil {
+		panic(fmt.Sprintln("memory alloc error: ", err))
 	}
 	return mem
 }
@@ -3012,8 +3013,8 @@ func (x *FilWriteWithoutAlignmentResponse) Deref() {
 // The caller is responsible for freeing the this memory via C.free.
 func allocFilPublicPieceInfoMemory(n int) unsafe.Pointer {
 	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfFilPublicPieceInfoValue))
-	if err != nil {
-		panic("memory alloc error: " + err.Error())
+	if mem == nil {
+		panic(fmt.Sprintln("memory alloc error: ", err))
 	}
 	return mem
 }
@@ -3098,8 +3099,8 @@ func (x *FilPublicPieceInfo) Deref() {
 // The caller is responsible for freeing the this memory via C.free.
 func allocFil32ByteArrayMemory(n int) unsafe.Pointer {
 	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfFil32ByteArrayValue))
-	if err != nil {
-		panic("memory alloc error: " + err.Error())
+	if mem == nil {
+		panic(fmt.Sprintln("memory alloc error: ", err))
 	}
 	return mem
 }
@@ -3179,8 +3180,8 @@ func (x *Fil32ByteArray) Deref() {
 // The caller is responsible for freeing the this memory via C.free.
 func allocFilPrivateReplicaInfoMemory(n int) unsafe.Pointer {
 	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfFilPrivateReplicaInfoValue))
-	if err != nil {
-		panic("memory alloc error: " + err.Error())
+	if mem == nil {
+		panic(fmt.Sprintln("memory alloc error: ", err))
 	}
 	return mem
 }
@@ -3280,8 +3281,8 @@ func (x *FilPrivateReplicaInfo) Deref() {
 // The caller is responsible for freeing the this memory via C.free.
 func allocFilPublicReplicaInfoMemory(n int) unsafe.Pointer {
 	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfFilPublicReplicaInfoValue))
-	if err != nil {
-		panic("memory alloc error: " + err.Error())
+	if mem == nil {
+		panic(fmt.Sprintln("memory alloc error: ", err))
 	}
 	return mem
 }
@@ -3373,8 +3374,8 @@ func unpackArgSFilPublicPieceInfo(x []FilPublicPieceInfo) (unpacked *C.fil_Publi
 		return nil, nil
 	}
 	allocs = new(cgoAllocMap)
-	defer runtime.SetFinalizer(&unpacked, func(**C.fil_PublicPieceInfo) {
-		go allocs.Free()
+	defer runtime.SetFinalizer(allocs, func(a *cgoAllocMap) {
+		go a.Free()
 	})
 
 	len0 := len(x)
@@ -3411,8 +3412,8 @@ func unpackArgSFilPrivateReplicaInfo(x []FilPrivateReplicaInfo) (unpacked *C.fil
 		return nil, nil
 	}
 	allocs = new(cgoAllocMap)
-	defer runtime.SetFinalizer(&unpacked, func(**C.fil_PrivateReplicaInfo) {
-		go allocs.Free()
+	defer runtime.SetFinalizer(allocs, func(a *cgoAllocMap) {
+		go a.Free()
 	})
 
 	len0 := len(x)
@@ -3447,8 +3448,8 @@ func packSFilPrivateReplicaInfo(v []FilPrivateReplicaInfo, ptr0 *C.fil_PrivateRe
 // The caller is responsible for freeing the this memory via C.free.
 func allocPUint8TMemory(n int) unsafe.Pointer {
 	mem, err := C.calloc(C.size_t(n), (C.size_t)(sizeOfPUint8TValue))
-	if err != nil {
-		panic("memory alloc error: " + err.Error())
+	if mem == nil {
+		panic(fmt.Sprintln("memory alloc error: ", err))
 	}
 	return mem
 }
@@ -3461,8 +3462,8 @@ func unpackArgSUString(x []string) (unpacked **C.uint8_t, allocs *cgoAllocMap) {
 		return nil, nil
 	}
 	allocs = new(cgoAllocMap)
-	defer runtime.SetFinalizer(&unpacked, func(***C.uint8_t) {
-		go allocs.Free()
+	defer runtime.SetFinalizer(allocs, func(a *cgoAllocMap) {
+		go a.Free()
 	})
 
 	len0 := len(x)
@@ -3497,8 +3498,8 @@ func unpackArgSFilPublicReplicaInfo(x []FilPublicReplicaInfo) (unpacked *C.fil_P
 		return nil, nil
 	}
 	allocs = new(cgoAllocMap)
-	defer runtime.SetFinalizer(&unpacked, func(**C.fil_PublicReplicaInfo) {
-		go allocs.Free()
+	defer runtime.SetFinalizer(allocs, func(a *cgoAllocMap) {
+		go a.Free()
 	})
 
 	len0 := len(x)
@@ -3535,8 +3536,8 @@ func unpackArgSFilPoStProof(x []FilPoStProof) (unpacked *C.fil_PoStProof, allocs
 		return nil, nil
 	}
 	allocs = new(cgoAllocMap)
-	defer runtime.SetFinalizer(&unpacked, func(**C.fil_PoStProof) {
-		go allocs.Free()
+	defer runtime.SetFinalizer(allocs, func(a *cgoAllocMap) {
+		go a.Free()
 	})
 
 	len0 := len(x)

--- a/generated/generated.go
+++ b/generated/generated.go
@@ -19,233 +19,281 @@ import (
 // FilAggregate function as declared in filecoin-ffi/filcrypto.h:283
 func FilAggregate(flattenedSignaturesPtr string, flattenedSignaturesLen uint) *FilAggregateResponse {
 	flattenedSignaturesPtr = safeString(flattenedSignaturesPtr)
-	cflattenedSignaturesPtr, _ := unpackPUint8TString(flattenedSignaturesPtr)
-	cflattenedSignaturesLen, _ := (C.size_t)(flattenedSignaturesLen), cgoAllocsUnknown
+	cflattenedSignaturesPtr, cflattenedSignaturesPtrAllocMap := unpackPUint8TString(flattenedSignaturesPtr)
+	cflattenedSignaturesLen, cflattenedSignaturesLenAllocMap := (C.size_t)(flattenedSignaturesLen), cgoAllocsUnknown
 	__ret := C.fil_aggregate(cflattenedSignaturesPtr, cflattenedSignaturesLen)
+	runtime.KeepAlive(cflattenedSignaturesLenAllocMap)
 	runtime.KeepAlive(flattenedSignaturesPtr)
+	runtime.KeepAlive(cflattenedSignaturesPtrAllocMap)
 	__v := NewFilAggregateResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
 
 // FilClearCache function as declared in filecoin-ffi/filcrypto.h:286
 func FilClearCache(sectorSize uint64, cacheDirPath string) *FilClearCacheResponse {
-	csectorSize, _ := (C.uint64_t)(sectorSize), cgoAllocsUnknown
+	csectorSize, csectorSizeAllocMap := (C.uint64_t)(sectorSize), cgoAllocsUnknown
 	cacheDirPath = safeString(cacheDirPath)
-	ccacheDirPath, _ := unpackPCharString(cacheDirPath)
+	ccacheDirPath, ccacheDirPathAllocMap := unpackPCharString(cacheDirPath)
 	__ret := C.fil_clear_cache(csectorSize, ccacheDirPath)
 	runtime.KeepAlive(cacheDirPath)
+	runtime.KeepAlive(ccacheDirPathAllocMap)
+	runtime.KeepAlive(csectorSizeAllocMap)
 	__v := NewFilClearCacheResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
 
 // FilDestroyAggregateResponse function as declared in filecoin-ffi/filcrypto.h:288
 func FilDestroyAggregateResponse(ptr *FilAggregateResponse) {
-	cptr, _ := ptr.PassRef()
+	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_aggregate_response(cptr)
+	runtime.KeepAlive(cptrAllocMap)
 }
 
 // FilDestroyClearCacheResponse function as declared in filecoin-ffi/filcrypto.h:290
 func FilDestroyClearCacheResponse(ptr *FilClearCacheResponse) {
-	cptr, _ := ptr.PassRef()
+	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_clear_cache_response(cptr)
+	runtime.KeepAlive(cptrAllocMap)
 }
 
 // FilDestroyFinalizeTicketResponse function as declared in filecoin-ffi/filcrypto.h:292
 func FilDestroyFinalizeTicketResponse(ptr *FilFinalizeTicketResponse) {
-	cptr, _ := ptr.PassRef()
+	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_finalize_ticket_response(cptr)
+	runtime.KeepAlive(cptrAllocMap)
 }
 
 // FilDestroyGenerateDataCommitmentResponse function as declared in filecoin-ffi/filcrypto.h:294
 func FilDestroyGenerateDataCommitmentResponse(ptr *FilGenerateDataCommitmentResponse) {
-	cptr, _ := ptr.PassRef()
+	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_generate_data_commitment_response(cptr)
+	runtime.KeepAlive(cptrAllocMap)
 }
 
 // FilDestroyGeneratePieceCommitmentResponse function as declared in filecoin-ffi/filcrypto.h:296
 func FilDestroyGeneratePieceCommitmentResponse(ptr *FilGeneratePieceCommitmentResponse) {
-	cptr, _ := ptr.PassRef()
+	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_generate_piece_commitment_response(cptr)
+	runtime.KeepAlive(cptrAllocMap)
 }
 
 // FilDestroyGenerateWindowPostResponse function as declared in filecoin-ffi/filcrypto.h:298
 func FilDestroyGenerateWindowPostResponse(ptr *FilGenerateWindowPoStResponse) {
-	cptr, _ := ptr.PassRef()
+	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_generate_window_post_response(cptr)
+	runtime.KeepAlive(cptrAllocMap)
 }
 
 // FilDestroyGenerateWinningPostResponse function as declared in filecoin-ffi/filcrypto.h:300
 func FilDestroyGenerateWinningPostResponse(ptr *FilGenerateWinningPoStResponse) {
-	cptr, _ := ptr.PassRef()
+	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_generate_winning_post_response(cptr)
+	runtime.KeepAlive(cptrAllocMap)
 }
 
 // FilDestroyGenerateWinningPostSectorChallenge function as declared in filecoin-ffi/filcrypto.h:302
 func FilDestroyGenerateWinningPostSectorChallenge(ptr *FilGenerateWinningPoStSectorChallenge) {
-	cptr, _ := ptr.PassRef()
+	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_generate_winning_post_sector_challenge(cptr)
+	runtime.KeepAlive(cptrAllocMap)
 }
 
 // FilDestroyGpuDeviceResponse function as declared in filecoin-ffi/filcrypto.h:304
 func FilDestroyGpuDeviceResponse(ptr *FilGpuDeviceResponse) {
-	cptr, _ := ptr.PassRef()
+	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_gpu_device_response(cptr)
+	runtime.KeepAlive(cptrAllocMap)
 }
 
 // FilDestroyHashResponse function as declared in filecoin-ffi/filcrypto.h:306
 func FilDestroyHashResponse(ptr *FilHashResponse) {
-	cptr, _ := ptr.PassRef()
+	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_hash_response(cptr)
+	runtime.KeepAlive(cptrAllocMap)
 }
 
 // FilDestroyInitLogFdResponse function as declared in filecoin-ffi/filcrypto.h:308
 func FilDestroyInitLogFdResponse(ptr *FilInitLogFdResponse) {
-	cptr, _ := ptr.PassRef()
+	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_init_log_fd_response(cptr)
+	runtime.KeepAlive(cptrAllocMap)
 }
 
 // FilDestroyPrivateKeyGenerateResponse function as declared in filecoin-ffi/filcrypto.h:310
 func FilDestroyPrivateKeyGenerateResponse(ptr *FilPrivateKeyGenerateResponse) {
-	cptr, _ := ptr.PassRef()
+	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_private_key_generate_response(cptr)
+	runtime.KeepAlive(cptrAllocMap)
 }
 
 // FilDestroyPrivateKeyPublicKeyResponse function as declared in filecoin-ffi/filcrypto.h:312
 func FilDestroyPrivateKeyPublicKeyResponse(ptr *FilPrivateKeyPublicKeyResponse) {
-	cptr, _ := ptr.PassRef()
+	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_private_key_public_key_response(cptr)
+	runtime.KeepAlive(cptrAllocMap)
 }
 
 // FilDestroyPrivateKeySignResponse function as declared in filecoin-ffi/filcrypto.h:314
 func FilDestroyPrivateKeySignResponse(ptr *FilPrivateKeySignResponse) {
-	cptr, _ := ptr.PassRef()
+	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_private_key_sign_response(cptr)
+	runtime.KeepAlive(cptrAllocMap)
 }
 
 // FilDestroySealCommitPhase1Response function as declared in filecoin-ffi/filcrypto.h:316
 func FilDestroySealCommitPhase1Response(ptr *FilSealCommitPhase1Response) {
-	cptr, _ := ptr.PassRef()
+	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_seal_commit_phase1_response(cptr)
+	runtime.KeepAlive(cptrAllocMap)
 }
 
 // FilDestroySealCommitPhase2Response function as declared in filecoin-ffi/filcrypto.h:318
 func FilDestroySealCommitPhase2Response(ptr *FilSealCommitPhase2Response) {
-	cptr, _ := ptr.PassRef()
+	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_seal_commit_phase2_response(cptr)
+	runtime.KeepAlive(cptrAllocMap)
 }
 
 // FilDestroySealPreCommitPhase1Response function as declared in filecoin-ffi/filcrypto.h:320
 func FilDestroySealPreCommitPhase1Response(ptr *FilSealPreCommitPhase1Response) {
-	cptr, _ := ptr.PassRef()
+	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_seal_pre_commit_phase1_response(cptr)
+	runtime.KeepAlive(cptrAllocMap)
 }
 
 // FilDestroySealPreCommitPhase2Response function as declared in filecoin-ffi/filcrypto.h:322
 func FilDestroySealPreCommitPhase2Response(ptr *FilSealPreCommitPhase2Response) {
-	cptr, _ := ptr.PassRef()
+	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_seal_pre_commit_phase2_response(cptr)
+	runtime.KeepAlive(cptrAllocMap)
 }
 
 // FilDestroyStringResponse function as declared in filecoin-ffi/filcrypto.h:324
 func FilDestroyStringResponse(ptr *FilStringResponse) {
-	cptr, _ := ptr.PassRef()
+	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_string_response(cptr)
+	runtime.KeepAlive(cptrAllocMap)
 }
 
 // FilDestroyUnsealRangeResponse function as declared in filecoin-ffi/filcrypto.h:326
 func FilDestroyUnsealRangeResponse(ptr *FilUnsealRangeResponse) {
-	cptr, _ := ptr.PassRef()
+	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_unseal_range_response(cptr)
+	runtime.KeepAlive(cptrAllocMap)
 }
 
 // FilDestroyUnsealResponse function as declared in filecoin-ffi/filcrypto.h:328
 func FilDestroyUnsealResponse(ptr *FilUnsealResponse) {
-	cptr, _ := ptr.PassRef()
+	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_unseal_response(cptr)
+	runtime.KeepAlive(cptrAllocMap)
 }
 
 // FilDestroyVerifySealResponse function as declared in filecoin-ffi/filcrypto.h:334
 func FilDestroyVerifySealResponse(ptr *FilVerifySealResponse) {
-	cptr, _ := ptr.PassRef()
+	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_verify_seal_response(cptr)
+	runtime.KeepAlive(cptrAllocMap)
 }
 
 // FilDestroyVerifyWindowPostResponse function as declared in filecoin-ffi/filcrypto.h:336
 func FilDestroyVerifyWindowPostResponse(ptr *FilVerifyWindowPoStResponse) {
-	cptr, _ := ptr.PassRef()
+	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_verify_window_post_response(cptr)
+	runtime.KeepAlive(cptrAllocMap)
 }
 
 // FilDestroyVerifyWinningPostResponse function as declared in filecoin-ffi/filcrypto.h:342
 func FilDestroyVerifyWinningPostResponse(ptr *FilVerifyWinningPoStResponse) {
-	cptr, _ := ptr.PassRef()
+	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_verify_winning_post_response(cptr)
+	runtime.KeepAlive(cptrAllocMap)
 }
 
 // FilDestroyWriteWithAlignmentResponse function as declared in filecoin-ffi/filcrypto.h:344
 func FilDestroyWriteWithAlignmentResponse(ptr *FilWriteWithAlignmentResponse) {
-	cptr, _ := ptr.PassRef()
+	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_write_with_alignment_response(cptr)
+	runtime.KeepAlive(cptrAllocMap)
 }
 
 // FilDestroyWriteWithoutAlignmentResponse function as declared in filecoin-ffi/filcrypto.h:346
 func FilDestroyWriteWithoutAlignmentResponse(ptr *FilWriteWithoutAlignmentResponse) {
-	cptr, _ := ptr.PassRef()
+	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_write_without_alignment_response(cptr)
+	runtime.KeepAlive(cptrAllocMap)
 }
 
 // FilGenerateDataCommitment function as declared in filecoin-ffi/filcrypto.h:351
 func FilGenerateDataCommitment(registeredProof FilRegisteredSealProof, piecesPtr []FilPublicPieceInfo, piecesLen uint) *FilGenerateDataCommitmentResponse {
-	cregisteredProof, _ := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
-	cpiecesPtr, _ := unpackArgSFilPublicPieceInfo(piecesPtr)
-	cpiecesLen, _ := (C.size_t)(piecesLen), cgoAllocsUnknown
+	cregisteredProof, cregisteredProofAllocMap := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
+	cpiecesPtr, cpiecesPtrAllocMap := unpackArgSFilPublicPieceInfo(piecesPtr)
+	cpiecesLen, cpiecesLenAllocMap := (C.size_t)(piecesLen), cgoAllocsUnknown
 	__ret := C.fil_generate_data_commitment(cregisteredProof, cpiecesPtr, cpiecesLen)
+	runtime.KeepAlive(cpiecesLenAllocMap)
 	packSFilPublicPieceInfo(piecesPtr, cpiecesPtr)
+	runtime.KeepAlive(cpiecesPtrAllocMap)
+	runtime.KeepAlive(cregisteredProofAllocMap)
 	__v := NewFilGenerateDataCommitmentResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
 
 // FilGeneratePieceCommitment function as declared in filecoin-ffi/filcrypto.h:359
 func FilGeneratePieceCommitment(registeredProof FilRegisteredSealProof, pieceFdRaw int32, unpaddedPieceSize uint64) *FilGeneratePieceCommitmentResponse {
-	cregisteredProof, _ := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
-	cpieceFdRaw, _ := (C.int)(pieceFdRaw), cgoAllocsUnknown
-	cunpaddedPieceSize, _ := (C.uint64_t)(unpaddedPieceSize), cgoAllocsUnknown
+	cregisteredProof, cregisteredProofAllocMap := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
+	cpieceFdRaw, cpieceFdRawAllocMap := (C.int)(pieceFdRaw), cgoAllocsUnknown
+	cunpaddedPieceSize, cunpaddedPieceSizeAllocMap := (C.uint64_t)(unpaddedPieceSize), cgoAllocsUnknown
 	__ret := C.fil_generate_piece_commitment(cregisteredProof, cpieceFdRaw, cunpaddedPieceSize)
+	runtime.KeepAlive(cunpaddedPieceSizeAllocMap)
+	runtime.KeepAlive(cpieceFdRawAllocMap)
+	runtime.KeepAlive(cregisteredProofAllocMap)
 	__v := NewFilGeneratePieceCommitmentResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
 
 // FilGenerateWindowPost function as declared in filecoin-ffi/filcrypto.h:367
 func FilGenerateWindowPost(randomness Fil32ByteArray, replicasPtr []FilPrivateReplicaInfo, replicasLen uint, proverId Fil32ByteArray) *FilGenerateWindowPoStResponse {
-	crandomness, _ := randomness.PassValue()
-	creplicasPtr, _ := unpackArgSFilPrivateReplicaInfo(replicasPtr)
-	creplicasLen, _ := (C.size_t)(replicasLen), cgoAllocsUnknown
-	cproverId, _ := proverId.PassValue()
+	crandomness, crandomnessAllocMap := randomness.PassValue()
+	creplicasPtr, creplicasPtrAllocMap := unpackArgSFilPrivateReplicaInfo(replicasPtr)
+	creplicasLen, creplicasLenAllocMap := (C.size_t)(replicasLen), cgoAllocsUnknown
+	cproverId, cproverIdAllocMap := proverId.PassValue()
 	__ret := C.fil_generate_window_post(crandomness, creplicasPtr, creplicasLen, cproverId)
+	runtime.KeepAlive(cproverIdAllocMap)
+	runtime.KeepAlive(creplicasLenAllocMap)
 	packSFilPrivateReplicaInfo(replicasPtr, creplicasPtr)
+	runtime.KeepAlive(creplicasPtrAllocMap)
+	runtime.KeepAlive(crandomnessAllocMap)
 	__v := NewFilGenerateWindowPoStResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
 
 // FilGenerateWinningPost function as declared in filecoin-ffi/filcrypto.h:376
 func FilGenerateWinningPost(randomness Fil32ByteArray, replicasPtr []FilPrivateReplicaInfo, replicasLen uint, proverId Fil32ByteArray) *FilGenerateWinningPoStResponse {
-	crandomness, _ := randomness.PassValue()
-	creplicasPtr, _ := unpackArgSFilPrivateReplicaInfo(replicasPtr)
-	creplicasLen, _ := (C.size_t)(replicasLen), cgoAllocsUnknown
-	cproverId, _ := proverId.PassValue()
+	crandomness, crandomnessAllocMap := randomness.PassValue()
+	creplicasPtr, creplicasPtrAllocMap := unpackArgSFilPrivateReplicaInfo(replicasPtr)
+	creplicasLen, creplicasLenAllocMap := (C.size_t)(replicasLen), cgoAllocsUnknown
+	cproverId, cproverIdAllocMap := proverId.PassValue()
 	__ret := C.fil_generate_winning_post(crandomness, creplicasPtr, creplicasLen, cproverId)
+	runtime.KeepAlive(cproverIdAllocMap)
+	runtime.KeepAlive(creplicasLenAllocMap)
 	packSFilPrivateReplicaInfo(replicasPtr, creplicasPtr)
+	runtime.KeepAlive(creplicasPtrAllocMap)
+	runtime.KeepAlive(crandomnessAllocMap)
 	__v := NewFilGenerateWinningPoStResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
 
 // FilGenerateWinningPostSectorChallenge function as declared in filecoin-ffi/filcrypto.h:385
 func FilGenerateWinningPostSectorChallenge(registeredProof FilRegisteredPoStProof, randomness Fil32ByteArray, sectorSetLen uint64, proverId Fil32ByteArray) *FilGenerateWinningPoStSectorChallenge {
-	cregisteredProof, _ := (C.fil_RegisteredPoStProof)(registeredProof), cgoAllocsUnknown
-	crandomness, _ := randomness.PassValue()
-	csectorSetLen, _ := (C.uint64_t)(sectorSetLen), cgoAllocsUnknown
-	cproverId, _ := proverId.PassValue()
+	cregisteredProof, cregisteredProofAllocMap := (C.fil_RegisteredPoStProof)(registeredProof), cgoAllocsUnknown
+	crandomness, crandomnessAllocMap := randomness.PassValue()
+	csectorSetLen, csectorSetLenAllocMap := (C.uint64_t)(sectorSetLen), cgoAllocsUnknown
+	cproverId, cproverIdAllocMap := proverId.PassValue()
 	__ret := C.fil_generate_winning_post_sector_challenge(cregisteredProof, crandomness, csectorSetLen, cproverId)
+	runtime.KeepAlive(cproverIdAllocMap)
+	runtime.KeepAlive(csectorSetLenAllocMap)
+	runtime.KeepAlive(crandomnessAllocMap)
+	runtime.KeepAlive(cregisteredProofAllocMap)
 	__v := NewFilGenerateWinningPoStSectorChallengeRef(unsafe.Pointer(__ret))
 	return __v
 }
@@ -259,104 +307,117 @@ func FilGetGpuDevices() *FilGpuDeviceResponse {
 
 // FilGetMaxUserBytesPerStagedSector function as declared in filecoin-ffi/filcrypto.h:399
 func FilGetMaxUserBytesPerStagedSector(registeredProof FilRegisteredSealProof) uint64 {
-	cregisteredProof, _ := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
+	cregisteredProof, cregisteredProofAllocMap := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_max_user_bytes_per_staged_sector(cregisteredProof)
+	runtime.KeepAlive(cregisteredProofAllocMap)
 	__v := (uint64)(__ret)
 	return __v
 }
 
 // FilGetPostCircuitIdentifier function as declared in filecoin-ffi/filcrypto.h:405
 func FilGetPostCircuitIdentifier(registeredProof FilRegisteredPoStProof) *FilStringResponse {
-	cregisteredProof, _ := (C.fil_RegisteredPoStProof)(registeredProof), cgoAllocsUnknown
+	cregisteredProof, cregisteredProofAllocMap := (C.fil_RegisteredPoStProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_post_circuit_identifier(cregisteredProof)
+	runtime.KeepAlive(cregisteredProofAllocMap)
 	__v := NewFilStringResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
 
 // FilGetPostParamsCid function as declared in filecoin-ffi/filcrypto.h:411
 func FilGetPostParamsCid(registeredProof FilRegisteredPoStProof) *FilStringResponse {
-	cregisteredProof, _ := (C.fil_RegisteredPoStProof)(registeredProof), cgoAllocsUnknown
+	cregisteredProof, cregisteredProofAllocMap := (C.fil_RegisteredPoStProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_post_params_cid(cregisteredProof)
+	runtime.KeepAlive(cregisteredProofAllocMap)
 	__v := NewFilStringResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
 
 // FilGetPostParamsPath function as declared in filecoin-ffi/filcrypto.h:418
 func FilGetPostParamsPath(registeredProof FilRegisteredPoStProof) *FilStringResponse {
-	cregisteredProof, _ := (C.fil_RegisteredPoStProof)(registeredProof), cgoAllocsUnknown
+	cregisteredProof, cregisteredProofAllocMap := (C.fil_RegisteredPoStProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_post_params_path(cregisteredProof)
+	runtime.KeepAlive(cregisteredProofAllocMap)
 	__v := NewFilStringResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
 
 // FilGetPostVerifyingKeyCid function as declared in filecoin-ffi/filcrypto.h:424
 func FilGetPostVerifyingKeyCid(registeredProof FilRegisteredPoStProof) *FilStringResponse {
-	cregisteredProof, _ := (C.fil_RegisteredPoStProof)(registeredProof), cgoAllocsUnknown
+	cregisteredProof, cregisteredProofAllocMap := (C.fil_RegisteredPoStProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_post_verifying_key_cid(cregisteredProof)
+	runtime.KeepAlive(cregisteredProofAllocMap)
 	__v := NewFilStringResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
 
 // FilGetPostVerifyingKeyPath function as declared in filecoin-ffi/filcrypto.h:431
 func FilGetPostVerifyingKeyPath(registeredProof FilRegisteredPoStProof) *FilStringResponse {
-	cregisteredProof, _ := (C.fil_RegisteredPoStProof)(registeredProof), cgoAllocsUnknown
+	cregisteredProof, cregisteredProofAllocMap := (C.fil_RegisteredPoStProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_post_verifying_key_path(cregisteredProof)
+	runtime.KeepAlive(cregisteredProofAllocMap)
 	__v := NewFilStringResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
 
 // FilGetPostVersion function as declared in filecoin-ffi/filcrypto.h:437
 func FilGetPostVersion(registeredProof FilRegisteredPoStProof) *FilStringResponse {
-	cregisteredProof, _ := (C.fil_RegisteredPoStProof)(registeredProof), cgoAllocsUnknown
+	cregisteredProof, cregisteredProofAllocMap := (C.fil_RegisteredPoStProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_post_version(cregisteredProof)
+	runtime.KeepAlive(cregisteredProofAllocMap)
 	__v := NewFilStringResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
 
 // FilGetSealCircuitIdentifier function as declared in filecoin-ffi/filcrypto.h:443
 func FilGetSealCircuitIdentifier(registeredProof FilRegisteredSealProof) *FilStringResponse {
-	cregisteredProof, _ := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
+	cregisteredProof, cregisteredProofAllocMap := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_seal_circuit_identifier(cregisteredProof)
+	runtime.KeepAlive(cregisteredProofAllocMap)
 	__v := NewFilStringResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
 
 // FilGetSealParamsCid function as declared in filecoin-ffi/filcrypto.h:449
 func FilGetSealParamsCid(registeredProof FilRegisteredSealProof) *FilStringResponse {
-	cregisteredProof, _ := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
+	cregisteredProof, cregisteredProofAllocMap := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_seal_params_cid(cregisteredProof)
+	runtime.KeepAlive(cregisteredProofAllocMap)
 	__v := NewFilStringResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
 
 // FilGetSealParamsPath function as declared in filecoin-ffi/filcrypto.h:456
 func FilGetSealParamsPath(registeredProof FilRegisteredSealProof) *FilStringResponse {
-	cregisteredProof, _ := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
+	cregisteredProof, cregisteredProofAllocMap := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_seal_params_path(cregisteredProof)
+	runtime.KeepAlive(cregisteredProofAllocMap)
 	__v := NewFilStringResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
 
 // FilGetSealVerifyingKeyCid function as declared in filecoin-ffi/filcrypto.h:462
 func FilGetSealVerifyingKeyCid(registeredProof FilRegisteredSealProof) *FilStringResponse {
-	cregisteredProof, _ := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
+	cregisteredProof, cregisteredProofAllocMap := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_seal_verifying_key_cid(cregisteredProof)
+	runtime.KeepAlive(cregisteredProofAllocMap)
 	__v := NewFilStringResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
 
 // FilGetSealVerifyingKeyPath function as declared in filecoin-ffi/filcrypto.h:469
 func FilGetSealVerifyingKeyPath(registeredProof FilRegisteredSealProof) *FilStringResponse {
-	cregisteredProof, _ := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
+	cregisteredProof, cregisteredProofAllocMap := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_seal_verifying_key_path(cregisteredProof)
+	runtime.KeepAlive(cregisteredProofAllocMap)
 	__v := NewFilStringResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
 
 // FilGetSealVersion function as declared in filecoin-ffi/filcrypto.h:475
 func FilGetSealVersion(registeredProof FilRegisteredSealProof) *FilStringResponse {
-	cregisteredProof, _ := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
+	cregisteredProof, cregisteredProofAllocMap := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_seal_version(cregisteredProof)
+	runtime.KeepAlive(cregisteredProofAllocMap)
 	__v := NewFilStringResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
@@ -364,10 +425,12 @@ func FilGetSealVersion(registeredProof FilRegisteredSealProof) *FilStringRespons
 // FilHash function as declared in filecoin-ffi/filcrypto.h:485
 func FilHash(messagePtr string, messageLen uint) *FilHashResponse {
 	messagePtr = safeString(messagePtr)
-	cmessagePtr, _ := unpackPUint8TString(messagePtr)
-	cmessageLen, _ := (C.size_t)(messageLen), cgoAllocsUnknown
+	cmessagePtr, cmessagePtrAllocMap := unpackPUint8TString(messagePtr)
+	cmessageLen, cmessageLenAllocMap := (C.size_t)(messageLen), cgoAllocsUnknown
 	__ret := C.fil_hash(cmessagePtr, cmessageLen)
+	runtime.KeepAlive(cmessageLenAllocMap)
 	runtime.KeepAlive(messagePtr)
+	runtime.KeepAlive(cmessagePtrAllocMap)
 	__v := NewFilHashResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
@@ -375,25 +438,32 @@ func FilHash(messagePtr string, messageLen uint) *FilHashResponse {
 // FilHashVerify function as declared in filecoin-ffi/filcrypto.h:499
 func FilHashVerify(signaturePtr string, messagesPtr []string, messagesSizesPtr []uint, messagesLen uint, flattenedPublicKeysPtr string, flattenedPublicKeysLen uint) int32 {
 	signaturePtr = safeString(signaturePtr)
-	csignaturePtr, _ := unpackPUint8TString(signaturePtr)
-	cmessagesPtr, _ := unpackArgSUString(messagesPtr)
-	cmessagesSizesPtr, _ := (*C.size_t)(unsafe.Pointer((*sliceHeader)(unsafe.Pointer(&messagesSizesPtr)).Data)), cgoAllocsUnknown
-	cmessagesLen, _ := (C.size_t)(messagesLen), cgoAllocsUnknown
+	csignaturePtr, csignaturePtrAllocMap := unpackPUint8TString(signaturePtr)
+	cmessagesPtr, cmessagesPtrAllocMap := unpackArgSUString(messagesPtr)
+	cmessagesSizesPtr, cmessagesSizesPtrAllocMap := (*C.size_t)(unsafe.Pointer((*sliceHeader)(unsafe.Pointer(&messagesSizesPtr)).Data)), cgoAllocsUnknown
+	cmessagesLen, cmessagesLenAllocMap := (C.size_t)(messagesLen), cgoAllocsUnknown
 	flattenedPublicKeysPtr = safeString(flattenedPublicKeysPtr)
-	cflattenedPublicKeysPtr, _ := unpackPUint8TString(flattenedPublicKeysPtr)
-	cflattenedPublicKeysLen, _ := (C.size_t)(flattenedPublicKeysLen), cgoAllocsUnknown
+	cflattenedPublicKeysPtr, cflattenedPublicKeysPtrAllocMap := unpackPUint8TString(flattenedPublicKeysPtr)
+	cflattenedPublicKeysLen, cflattenedPublicKeysLenAllocMap := (C.size_t)(flattenedPublicKeysLen), cgoAllocsUnknown
 	__ret := C.fil_hash_verify(csignaturePtr, cmessagesPtr, cmessagesSizesPtr, cmessagesLen, cflattenedPublicKeysPtr, cflattenedPublicKeysLen)
+	runtime.KeepAlive(cflattenedPublicKeysLenAllocMap)
 	runtime.KeepAlive(flattenedPublicKeysPtr)
+	runtime.KeepAlive(cflattenedPublicKeysPtrAllocMap)
+	runtime.KeepAlive(cmessagesLenAllocMap)
+	runtime.KeepAlive(cmessagesSizesPtrAllocMap)
 	packSUString(messagesPtr, cmessagesPtr)
+	runtime.KeepAlive(cmessagesPtrAllocMap)
 	runtime.KeepAlive(signaturePtr)
+	runtime.KeepAlive(csignaturePtrAllocMap)
 	__v := (int32)(__ret)
 	return __v
 }
 
 // FilInitLogFd function as declared in filecoin-ffi/filcrypto.h:515
 func FilInitLogFd(logFd int32) *FilInitLogFdResponse {
-	clogFd, _ := (C.int)(logFd), cgoAllocsUnknown
+	clogFd, clogFdAllocMap := (C.int)(logFd), cgoAllocsUnknown
 	__ret := C.fil_init_log_fd(clogFd)
+	runtime.KeepAlive(clogFdAllocMap)
 	__v := NewFilInitLogFdResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
@@ -407,8 +477,9 @@ func FilPrivateKeyGenerate() *FilPrivateKeyGenerateResponse {
 
 // FilPrivateKeyGenerateWithSeed function as declared in filecoin-ffi/filcrypto.h:533
 func FilPrivateKeyGenerateWithSeed(rawSeed Fil32ByteArray) *FilPrivateKeyGenerateResponse {
-	crawSeed, _ := rawSeed.PassValue()
+	crawSeed, crawSeedAllocMap := rawSeed.PassValue()
 	__ret := C.fil_private_key_generate_with_seed(crawSeed)
+	runtime.KeepAlive(crawSeedAllocMap)
 	__v := NewFilPrivateKeyGenerateResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
@@ -416,9 +487,10 @@ func FilPrivateKeyGenerateWithSeed(rawSeed Fil32ByteArray) *FilPrivateKeyGenerat
 // FilPrivateKeyPublicKey function as declared in filecoin-ffi/filcrypto.h:544
 func FilPrivateKeyPublicKey(rawPrivateKeyPtr string) *FilPrivateKeyPublicKeyResponse {
 	rawPrivateKeyPtr = safeString(rawPrivateKeyPtr)
-	crawPrivateKeyPtr, _ := unpackPUint8TString(rawPrivateKeyPtr)
+	crawPrivateKeyPtr, crawPrivateKeyPtrAllocMap := unpackPUint8TString(rawPrivateKeyPtr)
 	__ret := C.fil_private_key_public_key(crawPrivateKeyPtr)
 	runtime.KeepAlive(rawPrivateKeyPtr)
+	runtime.KeepAlive(crawPrivateKeyPtrAllocMap)
 	__v := NewFilPrivateKeyPublicKeyResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
@@ -426,36 +498,50 @@ func FilPrivateKeyPublicKey(rawPrivateKeyPtr string) *FilPrivateKeyPublicKeyResp
 // FilPrivateKeySign function as declared in filecoin-ffi/filcrypto.h:557
 func FilPrivateKeySign(rawPrivateKeyPtr string, messagePtr string, messageLen uint) *FilPrivateKeySignResponse {
 	rawPrivateKeyPtr = safeString(rawPrivateKeyPtr)
-	crawPrivateKeyPtr, _ := unpackPUint8TString(rawPrivateKeyPtr)
+	crawPrivateKeyPtr, crawPrivateKeyPtrAllocMap := unpackPUint8TString(rawPrivateKeyPtr)
 	messagePtr = safeString(messagePtr)
-	cmessagePtr, _ := unpackPUint8TString(messagePtr)
-	cmessageLen, _ := (C.size_t)(messageLen), cgoAllocsUnknown
+	cmessagePtr, cmessagePtrAllocMap := unpackPUint8TString(messagePtr)
+	cmessageLen, cmessageLenAllocMap := (C.size_t)(messageLen), cgoAllocsUnknown
 	__ret := C.fil_private_key_sign(crawPrivateKeyPtr, cmessagePtr, cmessageLen)
+	runtime.KeepAlive(cmessageLenAllocMap)
 	runtime.KeepAlive(messagePtr)
+	runtime.KeepAlive(cmessagePtrAllocMap)
 	runtime.KeepAlive(rawPrivateKeyPtr)
+	runtime.KeepAlive(crawPrivateKeyPtrAllocMap)
 	__v := NewFilPrivateKeySignResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
 
 // FilSealCommitPhase1 function as declared in filecoin-ffi/filcrypto.h:565
 func FilSealCommitPhase1(registeredProof FilRegisteredSealProof, commR Fil32ByteArray, commD Fil32ByteArray, cacheDirPath string, replicaPath string, sectorId uint64, proverId Fil32ByteArray, ticket Fil32ByteArray, seed Fil32ByteArray, piecesPtr []FilPublicPieceInfo, piecesLen uint) *FilSealCommitPhase1Response {
-	cregisteredProof, _ := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
-	ccommR, _ := commR.PassValue()
-	ccommD, _ := commD.PassValue()
+	cregisteredProof, cregisteredProofAllocMap := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
+	ccommR, ccommRAllocMap := commR.PassValue()
+	ccommD, ccommDAllocMap := commD.PassValue()
 	cacheDirPath = safeString(cacheDirPath)
-	ccacheDirPath, _ := unpackPCharString(cacheDirPath)
+	ccacheDirPath, ccacheDirPathAllocMap := unpackPCharString(cacheDirPath)
 	replicaPath = safeString(replicaPath)
-	creplicaPath, _ := unpackPCharString(replicaPath)
-	csectorId, _ := (C.uint64_t)(sectorId), cgoAllocsUnknown
-	cproverId, _ := proverId.PassValue()
-	cticket, _ := ticket.PassValue()
-	cseed, _ := seed.PassValue()
-	cpiecesPtr, _ := unpackArgSFilPublicPieceInfo(piecesPtr)
-	cpiecesLen, _ := (C.size_t)(piecesLen), cgoAllocsUnknown
+	creplicaPath, creplicaPathAllocMap := unpackPCharString(replicaPath)
+	csectorId, csectorIdAllocMap := (C.uint64_t)(sectorId), cgoAllocsUnknown
+	cproverId, cproverIdAllocMap := proverId.PassValue()
+	cticket, cticketAllocMap := ticket.PassValue()
+	cseed, cseedAllocMap := seed.PassValue()
+	cpiecesPtr, cpiecesPtrAllocMap := unpackArgSFilPublicPieceInfo(piecesPtr)
+	cpiecesLen, cpiecesLenAllocMap := (C.size_t)(piecesLen), cgoAllocsUnknown
 	__ret := C.fil_seal_commit_phase1(cregisteredProof, ccommR, ccommD, ccacheDirPath, creplicaPath, csectorId, cproverId, cticket, cseed, cpiecesPtr, cpiecesLen)
+	runtime.KeepAlive(cpiecesLenAllocMap)
 	packSFilPublicPieceInfo(piecesPtr, cpiecesPtr)
+	runtime.KeepAlive(cpiecesPtrAllocMap)
+	runtime.KeepAlive(cseedAllocMap)
+	runtime.KeepAlive(cticketAllocMap)
+	runtime.KeepAlive(cproverIdAllocMap)
+	runtime.KeepAlive(csectorIdAllocMap)
 	runtime.KeepAlive(replicaPath)
+	runtime.KeepAlive(creplicaPathAllocMap)
 	runtime.KeepAlive(cacheDirPath)
+	runtime.KeepAlive(ccacheDirPathAllocMap)
+	runtime.KeepAlive(ccommDAllocMap)
+	runtime.KeepAlive(ccommRAllocMap)
+	runtime.KeepAlive(cregisteredProofAllocMap)
 	__v := NewFilSealCommitPhase1ResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
@@ -463,35 +549,48 @@ func FilSealCommitPhase1(registeredProof FilRegisteredSealProof, commR Fil32Byte
 // FilSealCommitPhase2 function as declared in filecoin-ffi/filcrypto.h:577
 func FilSealCommitPhase2(sealCommitPhase1OutputPtr string, sealCommitPhase1OutputLen uint, sectorId uint64, proverId Fil32ByteArray) *FilSealCommitPhase2Response {
 	sealCommitPhase1OutputPtr = safeString(sealCommitPhase1OutputPtr)
-	csealCommitPhase1OutputPtr, _ := unpackPUint8TString(sealCommitPhase1OutputPtr)
-	csealCommitPhase1OutputLen, _ := (C.size_t)(sealCommitPhase1OutputLen), cgoAllocsUnknown
-	csectorId, _ := (C.uint64_t)(sectorId), cgoAllocsUnknown
-	cproverId, _ := proverId.PassValue()
+	csealCommitPhase1OutputPtr, csealCommitPhase1OutputPtrAllocMap := unpackPUint8TString(sealCommitPhase1OutputPtr)
+	csealCommitPhase1OutputLen, csealCommitPhase1OutputLenAllocMap := (C.size_t)(sealCommitPhase1OutputLen), cgoAllocsUnknown
+	csectorId, csectorIdAllocMap := (C.uint64_t)(sectorId), cgoAllocsUnknown
+	cproverId, cproverIdAllocMap := proverId.PassValue()
 	__ret := C.fil_seal_commit_phase2(csealCommitPhase1OutputPtr, csealCommitPhase1OutputLen, csectorId, cproverId)
+	runtime.KeepAlive(cproverIdAllocMap)
+	runtime.KeepAlive(csectorIdAllocMap)
+	runtime.KeepAlive(csealCommitPhase1OutputLenAllocMap)
 	runtime.KeepAlive(sealCommitPhase1OutputPtr)
+	runtime.KeepAlive(csealCommitPhase1OutputPtrAllocMap)
 	__v := NewFilSealCommitPhase2ResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
 
 // FilSealPreCommitPhase1 function as declared in filecoin-ffi/filcrypto.h:586
 func FilSealPreCommitPhase1(registeredProof FilRegisteredSealProof, cacheDirPath string, stagedSectorPath string, sealedSectorPath string, sectorId uint64, proverId Fil32ByteArray, ticket Fil32ByteArray, piecesPtr []FilPublicPieceInfo, piecesLen uint) *FilSealPreCommitPhase1Response {
-	cregisteredProof, _ := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
+	cregisteredProof, cregisteredProofAllocMap := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	cacheDirPath = safeString(cacheDirPath)
-	ccacheDirPath, _ := unpackPCharString(cacheDirPath)
+	ccacheDirPath, ccacheDirPathAllocMap := unpackPCharString(cacheDirPath)
 	stagedSectorPath = safeString(stagedSectorPath)
-	cstagedSectorPath, _ := unpackPCharString(stagedSectorPath)
+	cstagedSectorPath, cstagedSectorPathAllocMap := unpackPCharString(stagedSectorPath)
 	sealedSectorPath = safeString(sealedSectorPath)
-	csealedSectorPath, _ := unpackPCharString(sealedSectorPath)
-	csectorId, _ := (C.uint64_t)(sectorId), cgoAllocsUnknown
-	cproverId, _ := proverId.PassValue()
-	cticket, _ := ticket.PassValue()
-	cpiecesPtr, _ := unpackArgSFilPublicPieceInfo(piecesPtr)
-	cpiecesLen, _ := (C.size_t)(piecesLen), cgoAllocsUnknown
+	csealedSectorPath, csealedSectorPathAllocMap := unpackPCharString(sealedSectorPath)
+	csectorId, csectorIdAllocMap := (C.uint64_t)(sectorId), cgoAllocsUnknown
+	cproverId, cproverIdAllocMap := proverId.PassValue()
+	cticket, cticketAllocMap := ticket.PassValue()
+	cpiecesPtr, cpiecesPtrAllocMap := unpackArgSFilPublicPieceInfo(piecesPtr)
+	cpiecesLen, cpiecesLenAllocMap := (C.size_t)(piecesLen), cgoAllocsUnknown
 	__ret := C.fil_seal_pre_commit_phase1(cregisteredProof, ccacheDirPath, cstagedSectorPath, csealedSectorPath, csectorId, cproverId, cticket, cpiecesPtr, cpiecesLen)
+	runtime.KeepAlive(cpiecesLenAllocMap)
 	packSFilPublicPieceInfo(piecesPtr, cpiecesPtr)
+	runtime.KeepAlive(cpiecesPtrAllocMap)
+	runtime.KeepAlive(cticketAllocMap)
+	runtime.KeepAlive(cproverIdAllocMap)
+	runtime.KeepAlive(csectorIdAllocMap)
 	runtime.KeepAlive(sealedSectorPath)
+	runtime.KeepAlive(csealedSectorPathAllocMap)
 	runtime.KeepAlive(stagedSectorPath)
+	runtime.KeepAlive(cstagedSectorPathAllocMap)
 	runtime.KeepAlive(cacheDirPath)
+	runtime.KeepAlive(ccacheDirPathAllocMap)
+	runtime.KeepAlive(cregisteredProofAllocMap)
 	__v := NewFilSealPreCommitPhase1ResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
@@ -499,60 +598,82 @@ func FilSealPreCommitPhase1(registeredProof FilRegisteredSealProof, cacheDirPath
 // FilSealPreCommitPhase2 function as declared in filecoin-ffi/filcrypto.h:600
 func FilSealPreCommitPhase2(sealPreCommitPhase1OutputPtr string, sealPreCommitPhase1OutputLen uint, cacheDirPath string, sealedSectorPath string) *FilSealPreCommitPhase2Response {
 	sealPreCommitPhase1OutputPtr = safeString(sealPreCommitPhase1OutputPtr)
-	csealPreCommitPhase1OutputPtr, _ := unpackPUint8TString(sealPreCommitPhase1OutputPtr)
-	csealPreCommitPhase1OutputLen, _ := (C.size_t)(sealPreCommitPhase1OutputLen), cgoAllocsUnknown
+	csealPreCommitPhase1OutputPtr, csealPreCommitPhase1OutputPtrAllocMap := unpackPUint8TString(sealPreCommitPhase1OutputPtr)
+	csealPreCommitPhase1OutputLen, csealPreCommitPhase1OutputLenAllocMap := (C.size_t)(sealPreCommitPhase1OutputLen), cgoAllocsUnknown
 	cacheDirPath = safeString(cacheDirPath)
-	ccacheDirPath, _ := unpackPCharString(cacheDirPath)
+	ccacheDirPath, ccacheDirPathAllocMap := unpackPCharString(cacheDirPath)
 	sealedSectorPath = safeString(sealedSectorPath)
-	csealedSectorPath, _ := unpackPCharString(sealedSectorPath)
+	csealedSectorPath, csealedSectorPathAllocMap := unpackPCharString(sealedSectorPath)
 	__ret := C.fil_seal_pre_commit_phase2(csealPreCommitPhase1OutputPtr, csealPreCommitPhase1OutputLen, ccacheDirPath, csealedSectorPath)
 	runtime.KeepAlive(sealedSectorPath)
+	runtime.KeepAlive(csealedSectorPathAllocMap)
 	runtime.KeepAlive(cacheDirPath)
+	runtime.KeepAlive(ccacheDirPathAllocMap)
+	runtime.KeepAlive(csealPreCommitPhase1OutputLenAllocMap)
 	runtime.KeepAlive(sealPreCommitPhase1OutputPtr)
+	runtime.KeepAlive(csealPreCommitPhase1OutputPtrAllocMap)
 	__v := NewFilSealPreCommitPhase2ResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
 
 // FilUnseal function as declared in filecoin-ffi/filcrypto.h:608
 func FilUnseal(registeredProof FilRegisteredSealProof, cacheDirPath string, sealedSectorPath string, unsealOutputPath string, sectorId uint64, proverId Fil32ByteArray, ticket Fil32ByteArray, commD Fil32ByteArray) *FilUnsealResponse {
-	cregisteredProof, _ := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
+	cregisteredProof, cregisteredProofAllocMap := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	cacheDirPath = safeString(cacheDirPath)
-	ccacheDirPath, _ := unpackPCharString(cacheDirPath)
+	ccacheDirPath, ccacheDirPathAllocMap := unpackPCharString(cacheDirPath)
 	sealedSectorPath = safeString(sealedSectorPath)
-	csealedSectorPath, _ := unpackPCharString(sealedSectorPath)
+	csealedSectorPath, csealedSectorPathAllocMap := unpackPCharString(sealedSectorPath)
 	unsealOutputPath = safeString(unsealOutputPath)
-	cunsealOutputPath, _ := unpackPCharString(unsealOutputPath)
-	csectorId, _ := (C.uint64_t)(sectorId), cgoAllocsUnknown
-	cproverId, _ := proverId.PassValue()
-	cticket, _ := ticket.PassValue()
-	ccommD, _ := commD.PassValue()
+	cunsealOutputPath, cunsealOutputPathAllocMap := unpackPCharString(unsealOutputPath)
+	csectorId, csectorIdAllocMap := (C.uint64_t)(sectorId), cgoAllocsUnknown
+	cproverId, cproverIdAllocMap := proverId.PassValue()
+	cticket, cticketAllocMap := ticket.PassValue()
+	ccommD, ccommDAllocMap := commD.PassValue()
 	__ret := C.fil_unseal(cregisteredProof, ccacheDirPath, csealedSectorPath, cunsealOutputPath, csectorId, cproverId, cticket, ccommD)
+	runtime.KeepAlive(ccommDAllocMap)
+	runtime.KeepAlive(cticketAllocMap)
+	runtime.KeepAlive(cproverIdAllocMap)
+	runtime.KeepAlive(csectorIdAllocMap)
 	runtime.KeepAlive(unsealOutputPath)
+	runtime.KeepAlive(cunsealOutputPathAllocMap)
 	runtime.KeepAlive(sealedSectorPath)
+	runtime.KeepAlive(csealedSectorPathAllocMap)
 	runtime.KeepAlive(cacheDirPath)
+	runtime.KeepAlive(ccacheDirPathAllocMap)
+	runtime.KeepAlive(cregisteredProofAllocMap)
 	__v := NewFilUnsealResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
 
 // FilUnsealRange function as declared in filecoin-ffi/filcrypto.h:620
 func FilUnsealRange(registeredProof FilRegisteredSealProof, cacheDirPath string, sealedSectorPath string, unsealOutputPath string, sectorId uint64, proverId Fil32ByteArray, ticket Fil32ByteArray, commD Fil32ByteArray, offset uint64, length uint64) *FilUnsealRangeResponse {
-	cregisteredProof, _ := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
+	cregisteredProof, cregisteredProofAllocMap := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	cacheDirPath = safeString(cacheDirPath)
-	ccacheDirPath, _ := unpackPCharString(cacheDirPath)
+	ccacheDirPath, ccacheDirPathAllocMap := unpackPCharString(cacheDirPath)
 	sealedSectorPath = safeString(sealedSectorPath)
-	csealedSectorPath, _ := unpackPCharString(sealedSectorPath)
+	csealedSectorPath, csealedSectorPathAllocMap := unpackPCharString(sealedSectorPath)
 	unsealOutputPath = safeString(unsealOutputPath)
-	cunsealOutputPath, _ := unpackPCharString(unsealOutputPath)
-	csectorId, _ := (C.uint64_t)(sectorId), cgoAllocsUnknown
-	cproverId, _ := proverId.PassValue()
-	cticket, _ := ticket.PassValue()
-	ccommD, _ := commD.PassValue()
-	coffset, _ := (C.uint64_t)(offset), cgoAllocsUnknown
-	clength, _ := (C.uint64_t)(length), cgoAllocsUnknown
+	cunsealOutputPath, cunsealOutputPathAllocMap := unpackPCharString(unsealOutputPath)
+	csectorId, csectorIdAllocMap := (C.uint64_t)(sectorId), cgoAllocsUnknown
+	cproverId, cproverIdAllocMap := proverId.PassValue()
+	cticket, cticketAllocMap := ticket.PassValue()
+	ccommD, ccommDAllocMap := commD.PassValue()
+	coffset, coffsetAllocMap := (C.uint64_t)(offset), cgoAllocsUnknown
+	clength, clengthAllocMap := (C.uint64_t)(length), cgoAllocsUnknown
 	__ret := C.fil_unseal_range(cregisteredProof, ccacheDirPath, csealedSectorPath, cunsealOutputPath, csectorId, cproverId, cticket, ccommD, coffset, clength)
+	runtime.KeepAlive(clengthAllocMap)
+	runtime.KeepAlive(coffsetAllocMap)
+	runtime.KeepAlive(ccommDAllocMap)
+	runtime.KeepAlive(cticketAllocMap)
+	runtime.KeepAlive(cproverIdAllocMap)
+	runtime.KeepAlive(csectorIdAllocMap)
 	runtime.KeepAlive(unsealOutputPath)
+	runtime.KeepAlive(cunsealOutputPathAllocMap)
 	runtime.KeepAlive(sealedSectorPath)
+	runtime.KeepAlive(csealedSectorPathAllocMap)
 	runtime.KeepAlive(cacheDirPath)
+	runtime.KeepAlive(ccacheDirPathAllocMap)
+	runtime.KeepAlive(cregisteredProofAllocMap)
 	__v := NewFilUnsealRangeResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
@@ -560,89 +681,125 @@ func FilUnsealRange(registeredProof FilRegisteredSealProof, cacheDirPath string,
 // FilVerify function as declared in filecoin-ffi/filcrypto.h:642
 func FilVerify(signaturePtr string, flattenedDigestsPtr string, flattenedDigestsLen uint, flattenedPublicKeysPtr string, flattenedPublicKeysLen uint) int32 {
 	signaturePtr = safeString(signaturePtr)
-	csignaturePtr, _ := unpackPUint8TString(signaturePtr)
+	csignaturePtr, csignaturePtrAllocMap := unpackPUint8TString(signaturePtr)
 	flattenedDigestsPtr = safeString(flattenedDigestsPtr)
-	cflattenedDigestsPtr, _ := unpackPUint8TString(flattenedDigestsPtr)
-	cflattenedDigestsLen, _ := (C.size_t)(flattenedDigestsLen), cgoAllocsUnknown
+	cflattenedDigestsPtr, cflattenedDigestsPtrAllocMap := unpackPUint8TString(flattenedDigestsPtr)
+	cflattenedDigestsLen, cflattenedDigestsLenAllocMap := (C.size_t)(flattenedDigestsLen), cgoAllocsUnknown
 	flattenedPublicKeysPtr = safeString(flattenedPublicKeysPtr)
-	cflattenedPublicKeysPtr, _ := unpackPUint8TString(flattenedPublicKeysPtr)
-	cflattenedPublicKeysLen, _ := (C.size_t)(flattenedPublicKeysLen), cgoAllocsUnknown
+	cflattenedPublicKeysPtr, cflattenedPublicKeysPtrAllocMap := unpackPUint8TString(flattenedPublicKeysPtr)
+	cflattenedPublicKeysLen, cflattenedPublicKeysLenAllocMap := (C.size_t)(flattenedPublicKeysLen), cgoAllocsUnknown
 	__ret := C.fil_verify(csignaturePtr, cflattenedDigestsPtr, cflattenedDigestsLen, cflattenedPublicKeysPtr, cflattenedPublicKeysLen)
+	runtime.KeepAlive(cflattenedPublicKeysLenAllocMap)
 	runtime.KeepAlive(flattenedPublicKeysPtr)
+	runtime.KeepAlive(cflattenedPublicKeysPtrAllocMap)
+	runtime.KeepAlive(cflattenedDigestsLenAllocMap)
 	runtime.KeepAlive(flattenedDigestsPtr)
+	runtime.KeepAlive(cflattenedDigestsPtrAllocMap)
 	runtime.KeepAlive(signaturePtr)
+	runtime.KeepAlive(csignaturePtrAllocMap)
 	__v := (int32)(__ret)
 	return __v
 }
 
 // FilVerifySeal function as declared in filecoin-ffi/filcrypto.h:652
 func FilVerifySeal(registeredProof FilRegisteredSealProof, commR Fil32ByteArray, commD Fil32ByteArray, proverId Fil32ByteArray, ticket Fil32ByteArray, seed Fil32ByteArray, sectorId uint64, proofPtr string, proofLen uint) *FilVerifySealResponse {
-	cregisteredProof, _ := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
-	ccommR, _ := commR.PassValue()
-	ccommD, _ := commD.PassValue()
-	cproverId, _ := proverId.PassValue()
-	cticket, _ := ticket.PassValue()
-	cseed, _ := seed.PassValue()
-	csectorId, _ := (C.uint64_t)(sectorId), cgoAllocsUnknown
+	cregisteredProof, cregisteredProofAllocMap := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
+	ccommR, ccommRAllocMap := commR.PassValue()
+	ccommD, ccommDAllocMap := commD.PassValue()
+	cproverId, cproverIdAllocMap := proverId.PassValue()
+	cticket, cticketAllocMap := ticket.PassValue()
+	cseed, cseedAllocMap := seed.PassValue()
+	csectorId, csectorIdAllocMap := (C.uint64_t)(sectorId), cgoAllocsUnknown
 	proofPtr = safeString(proofPtr)
-	cproofPtr, _ := unpackPUint8TString(proofPtr)
-	cproofLen, _ := (C.size_t)(proofLen), cgoAllocsUnknown
+	cproofPtr, cproofPtrAllocMap := unpackPUint8TString(proofPtr)
+	cproofLen, cproofLenAllocMap := (C.size_t)(proofLen), cgoAllocsUnknown
 	__ret := C.fil_verify_seal(cregisteredProof, ccommR, ccommD, cproverId, cticket, cseed, csectorId, cproofPtr, cproofLen)
+	runtime.KeepAlive(cproofLenAllocMap)
 	runtime.KeepAlive(proofPtr)
+	runtime.KeepAlive(cproofPtrAllocMap)
+	runtime.KeepAlive(csectorIdAllocMap)
+	runtime.KeepAlive(cseedAllocMap)
+	runtime.KeepAlive(cticketAllocMap)
+	runtime.KeepAlive(cproverIdAllocMap)
+	runtime.KeepAlive(ccommDAllocMap)
+	runtime.KeepAlive(ccommRAllocMap)
+	runtime.KeepAlive(cregisteredProofAllocMap)
 	__v := NewFilVerifySealResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
 
 // FilVerifyWindowPost function as declared in filecoin-ffi/filcrypto.h:665
 func FilVerifyWindowPost(randomness Fil32ByteArray, replicasPtr []FilPublicReplicaInfo, replicasLen uint, proofsPtr []FilPoStProof, proofsLen uint, proverId Fil32ByteArray) *FilVerifyWindowPoStResponse {
-	crandomness, _ := randomness.PassValue()
-	creplicasPtr, _ := unpackArgSFilPublicReplicaInfo(replicasPtr)
-	creplicasLen, _ := (C.size_t)(replicasLen), cgoAllocsUnknown
-	cproofsPtr, _ := unpackArgSFilPoStProof(proofsPtr)
-	cproofsLen, _ := (C.size_t)(proofsLen), cgoAllocsUnknown
-	cproverId, _ := proverId.PassValue()
+	crandomness, crandomnessAllocMap := randomness.PassValue()
+	creplicasPtr, creplicasPtrAllocMap := unpackArgSFilPublicReplicaInfo(replicasPtr)
+	creplicasLen, creplicasLenAllocMap := (C.size_t)(replicasLen), cgoAllocsUnknown
+	cproofsPtr, cproofsPtrAllocMap := unpackArgSFilPoStProof(proofsPtr)
+	cproofsLen, cproofsLenAllocMap := (C.size_t)(proofsLen), cgoAllocsUnknown
+	cproverId, cproverIdAllocMap := proverId.PassValue()
 	__ret := C.fil_verify_window_post(crandomness, creplicasPtr, creplicasLen, cproofsPtr, cproofsLen, cproverId)
+	runtime.KeepAlive(cproverIdAllocMap)
+	runtime.KeepAlive(cproofsLenAllocMap)
 	packSFilPoStProof(proofsPtr, cproofsPtr)
+	runtime.KeepAlive(cproofsPtrAllocMap)
+	runtime.KeepAlive(creplicasLenAllocMap)
 	packSFilPublicReplicaInfo(replicasPtr, creplicasPtr)
+	runtime.KeepAlive(creplicasPtrAllocMap)
+	runtime.KeepAlive(crandomnessAllocMap)
 	__v := NewFilVerifyWindowPoStResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
 
 // FilVerifyWinningPost function as declared in filecoin-ffi/filcrypto.h:675
 func FilVerifyWinningPost(randomness Fil32ByteArray, replicasPtr []FilPublicReplicaInfo, replicasLen uint, proofsPtr []FilPoStProof, proofsLen uint, proverId Fil32ByteArray) *FilVerifyWinningPoStResponse {
-	crandomness, _ := randomness.PassValue()
-	creplicasPtr, _ := unpackArgSFilPublicReplicaInfo(replicasPtr)
-	creplicasLen, _ := (C.size_t)(replicasLen), cgoAllocsUnknown
-	cproofsPtr, _ := unpackArgSFilPoStProof(proofsPtr)
-	cproofsLen, _ := (C.size_t)(proofsLen), cgoAllocsUnknown
-	cproverId, _ := proverId.PassValue()
+	crandomness, crandomnessAllocMap := randomness.PassValue()
+	creplicasPtr, creplicasPtrAllocMap := unpackArgSFilPublicReplicaInfo(replicasPtr)
+	creplicasLen, creplicasLenAllocMap := (C.size_t)(replicasLen), cgoAllocsUnknown
+	cproofsPtr, cproofsPtrAllocMap := unpackArgSFilPoStProof(proofsPtr)
+	cproofsLen, cproofsLenAllocMap := (C.size_t)(proofsLen), cgoAllocsUnknown
+	cproverId, cproverIdAllocMap := proverId.PassValue()
 	__ret := C.fil_verify_winning_post(crandomness, creplicasPtr, creplicasLen, cproofsPtr, cproofsLen, cproverId)
+	runtime.KeepAlive(cproverIdAllocMap)
+	runtime.KeepAlive(cproofsLenAllocMap)
 	packSFilPoStProof(proofsPtr, cproofsPtr)
+	runtime.KeepAlive(cproofsPtrAllocMap)
+	runtime.KeepAlive(creplicasLenAllocMap)
 	packSFilPublicReplicaInfo(replicasPtr, creplicasPtr)
+	runtime.KeepAlive(creplicasPtrAllocMap)
+	runtime.KeepAlive(crandomnessAllocMap)
 	__v := NewFilVerifyWinningPoStResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
 
 // FilWriteWithAlignment function as declared in filecoin-ffi/filcrypto.h:686
 func FilWriteWithAlignment(registeredProof FilRegisteredSealProof, srcFd int32, srcSize uint64, dstFd int32, existingPieceSizesPtr []uint64, existingPieceSizesLen uint) *FilWriteWithAlignmentResponse {
-	cregisteredProof, _ := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
-	csrcFd, _ := (C.int)(srcFd), cgoAllocsUnknown
-	csrcSize, _ := (C.uint64_t)(srcSize), cgoAllocsUnknown
-	cdstFd, _ := (C.int)(dstFd), cgoAllocsUnknown
-	cexistingPieceSizesPtr, _ := (*C.uint64_t)(unsafe.Pointer((*sliceHeader)(unsafe.Pointer(&existingPieceSizesPtr)).Data)), cgoAllocsUnknown
-	cexistingPieceSizesLen, _ := (C.size_t)(existingPieceSizesLen), cgoAllocsUnknown
+	cregisteredProof, cregisteredProofAllocMap := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
+	csrcFd, csrcFdAllocMap := (C.int)(srcFd), cgoAllocsUnknown
+	csrcSize, csrcSizeAllocMap := (C.uint64_t)(srcSize), cgoAllocsUnknown
+	cdstFd, cdstFdAllocMap := (C.int)(dstFd), cgoAllocsUnknown
+	cexistingPieceSizesPtr, cexistingPieceSizesPtrAllocMap := (*C.uint64_t)(unsafe.Pointer((*sliceHeader)(unsafe.Pointer(&existingPieceSizesPtr)).Data)), cgoAllocsUnknown
+	cexistingPieceSizesLen, cexistingPieceSizesLenAllocMap := (C.size_t)(existingPieceSizesLen), cgoAllocsUnknown
 	__ret := C.fil_write_with_alignment(cregisteredProof, csrcFd, csrcSize, cdstFd, cexistingPieceSizesPtr, cexistingPieceSizesLen)
+	runtime.KeepAlive(cexistingPieceSizesLenAllocMap)
+	runtime.KeepAlive(cexistingPieceSizesPtrAllocMap)
+	runtime.KeepAlive(cdstFdAllocMap)
+	runtime.KeepAlive(csrcSizeAllocMap)
+	runtime.KeepAlive(csrcFdAllocMap)
+	runtime.KeepAlive(cregisteredProofAllocMap)
 	__v := NewFilWriteWithAlignmentResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
 
 // FilWriteWithoutAlignment function as declared in filecoin-ffi/filcrypto.h:697
 func FilWriteWithoutAlignment(registeredProof FilRegisteredSealProof, srcFd int32, srcSize uint64, dstFd int32) *FilWriteWithoutAlignmentResponse {
-	cregisteredProof, _ := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
-	csrcFd, _ := (C.int)(srcFd), cgoAllocsUnknown
-	csrcSize, _ := (C.uint64_t)(srcSize), cgoAllocsUnknown
-	cdstFd, _ := (C.int)(dstFd), cgoAllocsUnknown
+	cregisteredProof, cregisteredProofAllocMap := (C.fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
+	csrcFd, csrcFdAllocMap := (C.int)(srcFd), cgoAllocsUnknown
+	csrcSize, csrcSizeAllocMap := (C.uint64_t)(srcSize), cgoAllocsUnknown
+	cdstFd, cdstFdAllocMap := (C.int)(dstFd), cgoAllocsUnknown
 	__ret := C.fil_write_without_alignment(cregisteredProof, csrcFd, csrcSize, cdstFd)
+	runtime.KeepAlive(cdstFdAllocMap)
+	runtime.KeepAlive(csrcSizeAllocMap)
+	runtime.KeepAlive(csrcFdAllocMap)
+	runtime.KeepAlive(cregisteredProofAllocMap)
 	__v := NewFilWriteWithoutAlignmentResponseRef(unsafe.Pointer(__ret))
 	return __v
 }


### PR DESCRIPTION
## Why does this PR exist?

The c-for-go binary generates code that, under certain conditions, produces ENOMEM errors. A very helpful user, @dtynn, has patched c-for-go - but [their patch has yet to be merged into upstream](https://github.com/xlab/c-for-go/pull/91).

## What's in this PR?

This PR updates CGO bindings to those generated by dtynn's patch. It also updates CircleCI to generate using that same, forked c-for-go.

## Warnings

With the last lotus network reset, we are no longer able to reproduce this issue. So, we don't know if this patch actually fixes the issues. We're going to merge, deploy, and if it causes problems - we'll revert and pursue some other fix.