### PR TITLE
don't let Go garbage collect FD until FFI call returns

### DIFF
--- a/proofs.go
+++ b/proofs.go
@@ -174,7 +174,7 @@ func GeneratePieceCIDFromFile(proofType abi.RegisteredProof, pieceFile *os.File,
 	}
 
 	pieceFd := pieceFile.Fd()
-	runtime.KeepAlive(pieceFile)
+	defer runtime.KeepAlive(pieceFile)
 
 	resp := generated.FilGeneratePieceCommitment(sp, int32(pieceFd), uint64(pieceSize))
 	resp.Deref()
@@ -202,10 +202,10 @@ func WriteWithAlignment(
 	}
 
 	pieceFd := pieceFile.Fd()
-	runtime.KeepAlive(pieceFile)
+	defer runtime.KeepAlive(pieceFile)
 
 	stagedSectorFd := stagedSectorFile.Fd()
-	runtime.KeepAlive(stagedSectorFile)
+	defer runtime.KeepAlive(stagedSectorFile)
 
 	filExistingPieceSizes, filExistingPieceSizesLen := toFilExistingPieceSizes(existingPieceSizes)
 
@@ -234,10 +234,10 @@ func WriteWithoutAlignment(
 	}
 
 	pieceFd := pieceFile.Fd()
-	runtime.KeepAlive(pieceFile)
+	defer runtime.KeepAlive(pieceFile)
 
 	stagedSectorFd := stagedSectorFile.Fd()
-	runtime.KeepAlive(stagedSectorFile)
+	defer runtime.KeepAlive(stagedSectorFile)
 
 	resp := generated.FilWriteWithoutAlignment(sp, int32(pieceFd), uint64(pieceBytes), int32(stagedSectorFd))
 	resp.Deref()


### PR DESCRIPTION
For more background, see [this thread](https://filecoinproject.slack.com/archives/GTWHXDG0K/p1588866544131500).

## Why does this PR exist?

Occasionally, operators would report that piece CID generation would produce the following error:

```
0: failed to populate data
1: Bad file descriptor (os error 9)
```

## What's in this PR?

This changeset moves the `runtime.KeepAlive` calls to after the point in which the FFI call returns, which ensures that if we garbage collect in the middle of a CGO call that we don't reap the file descriptor backing the `*os.File`.