### PR TITLE
upgrade to specs-actors 0.4.1 (64GiB sector support)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/filecoin-project/go-address v0.0.2-0.20200218010043-eb9bb40ed5be
 	github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5
-	github.com/filecoin-project/specs-actors v0.3.0
+	github.com/filecoin-project/specs-actors v0.4.1-0.20200509020627-3c96f54f3d7d
 	github.com/ipfs/go-cid v0.0.5
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,7 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/filecoin-project/go-address v0.0.2-0.20200218010043-eb9bb40ed5be h1:TooKBwR/g8jG0hZ3lqe9S5sy2vTUcLOZLlz3M5wGn2E=
 github.com/filecoin-project/go-address v0.0.2-0.20200218010043-eb9bb40ed5be/go.mod h1:SAOwJoakQ8EPjwNIsiakIQKsoKdkcbx8U3IapgCg9R0=
 github.com/filecoin-project/go-amt-ipld/v2 v2.0.1-0.20200131012142-05d80eeccc5e/go.mod h1:boRtQhzmxNocrMxOXo1NYn4oUc1NGvR8tEa79wApNXg=
+github.com/filecoin-project/go-amt-ipld/v2 v2.0.1-0.20200424220931-6263827e49f2/go.mod h1:boRtQhzmxNocrMxOXo1NYn4oUc1NGvR8tEa79wApNXg=
 github.com/filecoin-project/go-bitfield v0.0.0-20200416002808-b3ee67ec9060 h1:/3qjGMn6ukXgZJHsIbuwGL7ipla8DOV3uHZDBJkBYfU=
 github.com/filecoin-project/go-bitfield v0.0.0-20200416002808-b3ee67ec9060/go.mod h1:iodsLxOFZnqKtjj2zkgqzoGNrv6vUqj69AT/J8DKXEw=
 github.com/filecoin-project/go-crypto v0.0.0-20191218222705-effae4ea9f03 h1:2pMXdBnCiXjfCYx/hLqFxccPoqsSveQFxVLvNxy9bus=
@@ -26,6 +27,8 @@ github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5 h1
 github.com/filecoin-project/go-fil-commcid v0.0.0-20200208005934-2b8bd03caca5/go.mod h1:JbkIgFF/Z9BDlvrJO1FuKkaWsH673/UdFaiVS6uIHlA=
 github.com/filecoin-project/specs-actors v0.3.0 h1:QxgAuTrZr5TPqjyprZk0nTYW5o0JWpzbb5v+4UHHvN0=
 github.com/filecoin-project/specs-actors v0.3.0/go.mod h1:nQYnFbQ7Y0bHZyq6HDEuVlCPR+U3z5Q3wMOQ+2aiV+Y=
+github.com/filecoin-project/specs-actors v0.4.1-0.20200509020627-3c96f54f3d7d h1:xK1KzVM6DAJABSnP5GhBMIk5zCDnJR5LSkxKJW1zFzA=
+github.com/filecoin-project/specs-actors v0.4.1-0.20200509020627-3c96f54f3d7d/go.mod h1:UW3ft23q6VS8wQoNqLWjENsu9gu1uh6lxOd+H8cwhT8=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=

--- a/proofs.go
+++ b/proofs.go
@@ -809,6 +809,8 @@ func fromFilRegisteredPoStProof(p generated.FilRegisteredPoStProof) (abi.Registe
 		return abi.RegisteredProof_StackedDRG512MiBWindowPoSt, nil
 	case generated.FilRegisteredPoStProofStackedDrgWindow32GiBV1:
 		return abi.RegisteredProof_StackedDRG32GiBWindowPoSt, nil
+	case generated.FilRegisteredPoStProofStackedDrgWindow64GiBV1:
+		return abi.RegisteredProof_StackedDRG64GiBWindowPoSt, nil
 	default:
 		return 0, errors.Errorf("no mapping to abi.RegisteredPoStProof value available for: %v", p)
 	}
@@ -848,6 +850,8 @@ func toFilRegisteredPoStProof(pp abi.RegisteredProof, typ string) (generated.Fil
 	switch p {
 	case abi.RegisteredProof_StackedDRG2KiBPoSt, abi.RegisteredProof_StackedDRG8MiBPoSt, abi.RegisteredProof_StackedDRG512MiBPoSt, abi.RegisteredProof_StackedDRG32GiBPoSt:
 		return 0, errors.Errorf("unsupported version of election post: %v", p)
+	case abi.RegisteredProof_StackedDRG64GiBWindowPoSt:
+		return generated.FilRegisteredPoStProofStackedDrgWindow64GiBV1, nil
 	case abi.RegisteredProof_StackedDRG32GiBWindowPoSt:
 		return generated.FilRegisteredPoStProofStackedDrgWindow32GiBV1, nil
 	case abi.RegisteredProof_StackedDRG512MiBWindowPoSt:
@@ -857,6 +861,8 @@ func toFilRegisteredPoStProof(pp abi.RegisteredProof, typ string) (generated.Fil
 	case abi.RegisteredProof_StackedDRG2KiBWindowPoSt:
 		return generated.FilRegisteredPoStProofStackedDrgWindow2KiBV1, nil
 
+	case abi.RegisteredProof_StackedDRG64GiBWinningPoSt:
+		return generated.FilRegisteredPoStProofStackedDrgWinning64GiBV1, nil
 	case abi.RegisteredProof_StackedDRG32GiBWinningPoSt:
 		return generated.FilRegisteredPoStProofStackedDrgWinning32GiBV1, nil
 	case abi.RegisteredProof_StackedDRG512MiBWinningPoSt:
@@ -886,6 +892,8 @@ func toFilRegisteredSealProof(p abi.RegisteredProof) (generated.FilRegisteredSea
 		return generated.FilRegisteredSealProofStackedDrg512MiBV1, nil
 	case abi.RegisteredProof_StackedDRG32GiBSeal:
 		return generated.FilRegisteredSealProofStackedDrg32GiBV1, nil
+	case abi.RegisteredProof_StackedDRG64GiBSeal:
+		return generated.FilRegisteredSealProofStackedDrg64GiBV1, nil
 	default:
 		return 0, errors.Errorf("no mapping to C.FFIRegisteredSealProof value available for: %v", p)
 	}

--- a/workflows.go
+++ b/workflows.go
@@ -239,6 +239,7 @@ func WorkflowRegisteredSealProofFunctions(t TestHelper) {
 		abi.RegisteredProof_StackedDRG2KiBSeal,
 		abi.RegisteredProof_StackedDRG512MiBSeal,
 		abi.RegisteredProof_StackedDRG32GiBSeal,
+		abi.RegisteredProof_StackedDRG64GiBSeal,
 	}
 
 	for _, st := range sealTypes {
@@ -254,10 +255,12 @@ func WorkflowRegisteredPoStProofFunctions(t TestHelper) {
 		abi.RegisteredProof_StackedDRG2KiBWindowPoSt,
 		abi.RegisteredProof_StackedDRG512MiBWindowPoSt,
 		abi.RegisteredProof_StackedDRG32GiBWindowPoSt,
+		abi.RegisteredProof_StackedDRG64GiBWindowPoSt,
 		abi.RegisteredProof_StackedDRG8MiBWinningPoSt,
 		abi.RegisteredProof_StackedDRG2KiBWinningPoSt,
 		abi.RegisteredProof_StackedDRG512MiBWinningPoSt,
 		abi.RegisteredProof_StackedDRG32GiBWinningPoSt,
+		abi.RegisteredProof_StackedDRG64GiBWinningPoSt,
 	}
 
 	for _, pt := range postTypes {


### PR DESCRIPTION
## Why does this PR exist?

@whyrusleeping attempted to [bench a 64GiB sector](https://filecoinproject.slack.com/archives/CP50PPW2X/p1589171154210100) and received an error `no mapping to C.FFIRegisteredSealProof value available for: 17`). Turns out that lotus was using specs-actors 0.4.1 and filecoin-ffi was using 0.3.0, which doesn't support 64GiB sectors.

## What's in this PR?

This PR updates specs-actors to 0.4.1 and all corresponding enum-mapping functions.