### PR TITLE
don't flatten PoSt proofs - preserve the tuple of version and proof

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -838,7 +838,7 @@ dependencies = [
 [[package]]
 name = "filecoin-proofs-api"
 version = "0.1.0"
-source = "git+https://github.com/filecoin-project/rust-filecoin-proofs-api.git#0e1c7cb464707c7a7ad82b0f8303f000f6f3fc8a"
+source = "git+https://github.com/filecoin-project/rust-filecoin-proofs-api.git#5b8fad761f5418f560a3d42e179bf0d47977b174"
 dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "filecoin-proofs 1.0.0-alpha.0 (git+https://github.com/filecoin-project/rust-fil-proofs?rev=138b4f9698f57526a7838fc6508122923116ea3d)",

--- a/rust/src/proofs/api.rs
+++ b/rust/src/proofs/api.rs
@@ -603,7 +603,11 @@ pub unsafe extern "C" fn fil_verify_window_post(
 
         let result = convert.and_then(|replicas| {
             let post_proofs = c_to_rust_post_proofs(proofs_ptr, proofs_len)?;
-            let proofs: Vec<u8> = post_proofs.iter().flat_map(|pp| pp.clone().proof).collect();
+
+            let proofs: Vec<(RegisteredPoStProof, &[u8])> = post_proofs
+                .iter()
+                .map(|x| (x.registered_proof, x.proof.as_ref()))
+                .collect();
 
             filecoin_proofs_api::post::verify_window_post(
                 &randomness.inner,


### PR DESCRIPTION
For more information, see [this Slack thread](https://filecoinproject.slack.com/archives/CEGB67XJ8/p1589207615244400).