### PR TITLE
fix: use single replica file when using sub-trees

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -786,7 +786,7 @@ dependencies = [
 [[package]]
 name = "filecoin-proofs"
 version = "1.0.0-alpha.0"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs?rev=138b4f9698f57526a7838fc6508122923116ea3d#138b4f9698f57526a7838fc6508122923116ea3d"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs?rev=74db4fdfd28dcc3a25581c9543338495552242eb#74db4fdfd28dcc3a25581c9543338495552242eb"
 dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "bellperson 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -812,7 +812,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "merkletree 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "merkletree 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "os_pipe 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "os_type 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "paired 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -828,7 +828,7 @@ dependencies = [
  "serde_cbor 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "simplelog 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "storage-proofs 1.0.0-alpha.0 (git+https://github.com/filecoin-project/rust-fil-proofs?rev=138b4f9698f57526a7838fc6508122923116ea3d)",
+ "storage-proofs 1.0.0-alpha.0 (git+https://github.com/filecoin-project/rust-fil-proofs?rev=74db4fdfd28dcc3a25581c9543338495552242eb)",
  "structopt 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "tee 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -838,10 +838,10 @@ dependencies = [
 [[package]]
 name = "filecoin-proofs-api"
 version = "0.1.0"
-source = "git+https://github.com/filecoin-project/rust-filecoin-proofs-api.git#5b8fad761f5418f560a3d42e179bf0d47977b174"
+source = "git+https://github.com/filecoin-project/rust-filecoin-proofs-api.git#a6f2cd61bd9593e1cbd8ce391773bac8a6629657"
 dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "filecoin-proofs 1.0.0-alpha.0 (git+https://github.com/filecoin-project/rust-fil-proofs?rev=138b4f9698f57526a7838fc6508122923116ea3d)",
+ "filecoin-proofs 1.0.0-alpha.0 (git+https://github.com/filecoin-project/rust-fil-proofs?rev=74db4fdfd28dcc3a25581c9543338495552242eb)",
  "paired 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1263,7 +1263,7 @@ dependencies = [
 
 [[package]]
 name = "merkletree"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2249,7 +2249,7 @@ dependencies = [
 [[package]]
 name = "sha2raw"
 version = "0.1.0"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs?rev=138b4f9698f57526a7838fc6508122923116ea3d#138b4f9698f57526a7838fc6508122923116ea3d"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs?rev=74db4fdfd28dcc3a25581c9543338495552242eb#74db4fdfd28dcc3a25581c9543338495552242eb"
 dependencies = [
  "block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2295,17 +2295,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "storage-proofs"
 version = "1.0.0-alpha.0"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs?rev=138b4f9698f57526a7838fc6508122923116ea3d#138b4f9698f57526a7838fc6508122923116ea3d"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs?rev=74db4fdfd28dcc3a25581c9543338495552242eb#74db4fdfd28dcc3a25581c9543338495552242eb"
 dependencies = [
- "storage-proofs-core 1.0.0-alpha.0 (git+https://github.com/filecoin-project/rust-fil-proofs?rev=138b4f9698f57526a7838fc6508122923116ea3d)",
- "storage-proofs-porep 1.0.0-alpha.0 (git+https://github.com/filecoin-project/rust-fil-proofs?rev=138b4f9698f57526a7838fc6508122923116ea3d)",
- "storage-proofs-post 1.0.0-alpha.0 (git+https://github.com/filecoin-project/rust-fil-proofs?rev=138b4f9698f57526a7838fc6508122923116ea3d)",
+ "storage-proofs-core 1.0.0-alpha.0 (git+https://github.com/filecoin-project/rust-fil-proofs?rev=74db4fdfd28dcc3a25581c9543338495552242eb)",
+ "storage-proofs-porep 1.0.0-alpha.0 (git+https://github.com/filecoin-project/rust-fil-proofs?rev=74db4fdfd28dcc3a25581c9543338495552242eb)",
+ "storage-proofs-post 1.0.0-alpha.0 (git+https://github.com/filecoin-project/rust-fil-proofs?rev=74db4fdfd28dcc3a25581c9543338495552242eb)",
 ]
 
 [[package]]
 name = "storage-proofs-core"
 version = "1.0.0-alpha.0"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs?rev=138b4f9698f57526a7838fc6508122923116ea3d#138b4f9698f57526a7838fc6508122923116ea3d"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs?rev=74db4fdfd28dcc3a25581c9543338495552242eb#74db4fdfd28dcc3a25581c9543338495552242eb"
 dependencies = [
  "aes 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2324,7 +2324,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "merkletree 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "merkletree 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "neptune 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "paired 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2341,7 +2341,7 @@ dependencies = [
 [[package]]
 name = "storage-proofs-porep"
 version = "1.0.0-alpha.0"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs?rev=138b4f9698f57526a7838fc6508122923116ea3d#138b4f9698f57526a7838fc6508122923116ea3d"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs?rev=74db4fdfd28dcc3a25581c9543338495552242eb#74db4fdfd28dcc3a25581c9543338495552242eb"
 dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "bellperson 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2350,7 +2350,7 @@ dependencies = [
  "generic-array 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "merkletree 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "merkletree 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "neptune 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2362,14 +2362,14 @@ dependencies = [
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2ni 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2raw 0.1.0 (git+https://github.com/filecoin-project/rust-fil-proofs?rev=138b4f9698f57526a7838fc6508122923116ea3d)",
- "storage-proofs-core 1.0.0-alpha.0 (git+https://github.com/filecoin-project/rust-fil-proofs?rev=138b4f9698f57526a7838fc6508122923116ea3d)",
+ "sha2raw 0.1.0 (git+https://github.com/filecoin-project/rust-fil-proofs?rev=74db4fdfd28dcc3a25581c9543338495552242eb)",
+ "storage-proofs-core 1.0.0-alpha.0 (git+https://github.com/filecoin-project/rust-fil-proofs?rev=74db4fdfd28dcc3a25581c9543338495552242eb)",
 ]
 
 [[package]]
 name = "storage-proofs-post"
 version = "1.0.0-alpha.0"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs?rev=138b4f9698f57526a7838fc6508122923116ea3d#138b4f9698f57526a7838fc6508122923116ea3d"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs?rev=74db4fdfd28dcc3a25581c9543338495552242eb#74db4fdfd28dcc3a25581c9543338495552242eb"
 dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "bellperson 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2381,14 +2381,14 @@ dependencies = [
  "generic-array 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "merkletree 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "merkletree 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "neptune 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "paired 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2ni 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "storage-proofs-core 1.0.0-alpha.0 (git+https://github.com/filecoin-project/rust-fil-proofs?rev=138b4f9698f57526a7838fc6508122923116ea3d)",
+ "storage-proofs-core 1.0.0-alpha.0 (git+https://github.com/filecoin-project/rust-fil-proofs?rev=74db4fdfd28dcc3a25581c9543338495552242eb)",
 ]
 
 [[package]]
@@ -3012,7 +3012,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fil-ocl-core 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ecd0aa5895d05824d7eaa38b999c91e9071acb74b304488220e8f8bb555d1ad1"
 "checksum fil-sapling-crypto 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3fb1ee58ef3ba4dd8e70858f28dfc25a426e01c9b3b74570ff6b235ab1b5eed3"
 "checksum fil_logger 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a4017ffdf45e6702db1d826eada1dc1df0b7f9eda427de3000959216b93cd676"
-"checksum filecoin-proofs 1.0.0-alpha.0 (git+https://github.com/filecoin-project/rust-fil-proofs?rev=138b4f9698f57526a7838fc6508122923116ea3d)" = "<none>"
+"checksum filecoin-proofs 1.0.0-alpha.0 (git+https://github.com/filecoin-project/rust-fil-proofs?rev=74db4fdfd28dcc3a25581c9543338495552242eb)" = "<none>"
 "checksum filecoin-proofs-api 0.1.0 (git+https://github.com/filecoin-project/rust-filecoin-proofs-api.git)" = "<none>"
 "checksum filetime 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f59efc38004c988e4201d11d263b8171f49a2e7ec0bdbb71773433f271504a5e"
 "checksum flate2 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2cfff41391129e0a856d6d822600b8d71179d46879e310417eb9c762eb178b42"
@@ -3064,7 +3064,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum memchr 2.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 "checksum memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 "checksum memoffset 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b4fc2c02a7e374099d4ee95a193111f72d2110197fe200272371758f6c3643d8"
-"checksum merkletree 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4d7e5ee24fd119b7f3199d211a952af248b06139cf588304652d62dd99d7bee2"
+"checksum merkletree 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b9a9c4292710ebd6d3e3b481adcc30c17347cc7542003a0f373b8c1d7475a38a"
 "checksum mime 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 "checksum mime_guess 2.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
 "checksum miniz_oxide 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aa679ff6578b1cddee93d7e82e263b94a575e0bfced07284eb0c037c1d2416a5"
@@ -3168,16 +3168,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde_test 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)" = "110b3dbdf8607ec493c22d5d947753282f3bae73c0f56d322af1e8c78e4c23d5"
 "checksum serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "642dd69105886af2efd227f75a520ec9b44a820d65bc133a9131f7d229fd165a"
 "checksum sha2ni 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "229896851bde067cb56bfb6cd669d9904c3441245bc32172f33d9a895ddef27d"
-"checksum sha2raw 0.1.0 (git+https://github.com/filecoin-project/rust-fil-proofs?rev=138b4f9698f57526a7838fc6508122923116ea3d)" = "<none>"
+"checksum sha2raw 0.1.0 (git+https://github.com/filecoin-project/rust-fil-proofs?rev=74db4fdfd28dcc3a25581c9543338495552242eb)" = "<none>"
 "checksum simplelog 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "bcacac97349a890d437921dfb23cbec52ab5b4752551cb637df2721371acd467"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
 "checksum smallvec 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-"checksum storage-proofs 1.0.0-alpha.0 (git+https://github.com/filecoin-project/rust-fil-proofs?rev=138b4f9698f57526a7838fc6508122923116ea3d)" = "<none>"
-"checksum storage-proofs-core 1.0.0-alpha.0 (git+https://github.com/filecoin-project/rust-fil-proofs?rev=138b4f9698f57526a7838fc6508122923116ea3d)" = "<none>"
-"checksum storage-proofs-porep 1.0.0-alpha.0 (git+https://github.com/filecoin-project/rust-fil-proofs?rev=138b4f9698f57526a7838fc6508122923116ea3d)" = "<none>"
-"checksum storage-proofs-post 1.0.0-alpha.0 (git+https://github.com/filecoin-project/rust-fil-proofs?rev=138b4f9698f57526a7838fc6508122923116ea3d)" = "<none>"
+"checksum storage-proofs 1.0.0-alpha.0 (git+https://github.com/filecoin-project/rust-fil-proofs?rev=74db4fdfd28dcc3a25581c9543338495552242eb)" = "<none>"
+"checksum storage-proofs-core 1.0.0-alpha.0 (git+https://github.com/filecoin-project/rust-fil-proofs?rev=74db4fdfd28dcc3a25581c9543338495552242eb)" = "<none>"
+"checksum storage-proofs-porep 1.0.0-alpha.0 (git+https://github.com/filecoin-project/rust-fil-proofs?rev=74db4fdfd28dcc3a25581c9543338495552242eb)" = "<none>"
+"checksum storage-proofs-post 1.0.0-alpha.0 (git+https://github.com/filecoin-project/rust-fil-proofs?rev=74db4fdfd28dcc3a25581c9543338495552242eb)" = "<none>"
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum structopt 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)" = "c8faa2719539bbe9d77869bfb15d4ee769f99525e707931452c97b693b3f159d"


### PR DESCRIPTION
The purpose of this commit is to get [this rust-fil-proofs](https://github.com/filecoin-project/rust-fil-proofs/pull/1101) patch into filecoin-ffi.