### PR TITLE
add changelog and changelog generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,98 @@
+# filecoin-ffi changelog
+
+## 0.26.2
+
+This release contains a fix for a bug which prevented unmodified miners from
+generating Winning PoSts for 64GiB sectors. It also contains a fix for a bug
+which was an occasional source of `bad file descriptor` errors observed during
+CommP generation (our hypothesis is that the `*os.File` was being GC'ed before
+the CGO call returned).
+
+### Changelog
+
+- github.com/filecoin-project/filecoin-ffi:
+  - don't let Go garbage collect FD until FFI call returns ([filecoin-project/filecoin-ffi#84](https://github.com/filecoin-project/filecoin-ffi/pull/84))
+  - fix: error if there is already a logger
+  - add winning PoSt for 64 GiB (#93) ([filecoin-project/filecoin-ffi#93](https://github.com/filecoin-project/filecoin-ffi/pull/93))
+
+### Contributors
+
+| Contributor | Commits | Lines ± | Files Changed |
+|-------------|---------|---------|---------------|
+| Volker Mische | 1 | +24/-7 | 1 |
+| laser | 1 | +5/-5 | 1 |
+| shannon-6block | 1 | +2/-0 | 1 |
+
+## 0.26.1
+
+This release updates to version 0.4.1 of specs-actors, which (among other
+things) extends the `RegisteredProof` types to include 64GiB sector sizes. It
+also includes a fix for Window PoSt (multiple proofs were being flattened into
+a single byte array) and various fixes for bellperson and neptune Rust crates.
+
+### Changelog
+
+- github.com/filecoin-project/filecoin-ffi:
+  - Update deps revisited ([filecoin-project/filecoin-ffi#91](https://github.com/filecoin-project/filecoin-ffi/pull/91))
+  - newest upstream (#88) ([filecoin-project/filecoin-ffi#88](https://github.com/filecoin-project/filecoin-ffi/pull/88))
+  - update rust-filecoin-proofs-api to include PoSt fix (#87) ([filecoin-project/filecoin-ffi#87](https://github.com/filecoin-project/filecoin-ffi/pull/87))
+  - upgrade to specs-actors 0.4.1 (64GiB sector support) ([filecoin-project/filecoin-ffi#85](https://github.com/filecoin-project/filecoin-ffi/pull/85))
+  - Upgrade to specs-actors v0.3.0 (#81) ([filecoin-project/filecoin-ffi#81](https://github.com/filecoin-project/filecoin-ffi/pull/81))
+- github.com/filecoin-project/go-amt-ipld (v2.0.1-0.20200131012142-05d80eeccc5e -> v2.0.1-0.20200424220931-6263827e49f2):
+  - implement method to get first index in amt ([filecoin-project/go-amt-ipld#11](https://github.com/filecoin-project/go-amt-ipld/pull/11))
+  - implement ForEachAt method to support iteration starting at a given i… ([filecoin-project/go-amt-ipld#10](https://github.com/filecoin-project/go-amt-ipld/pull/10))
+- github.com/filecoin-project/specs-actors (v0.2.0 -> v0.4.1-0.20200509020627-3c96f54f3d7d):
+  - Minting function maintainability (#356) ([filecoin-project/specs-actors#356](https://github.com/filecoin-project/specs-actors/pull/356))
+  - support for 64GiB sectors (#355) ([filecoin-project/specs-actors#355](https://github.com/filecoin-project/specs-actors/pull/355))
+  - Temporary param update (#352) ([filecoin-project/specs-actors#352](https://github.com/filecoin-project/specs-actors/pull/352))
+  - document reward minting function tests (#348) ([filecoin-project/specs-actors#348](https://github.com/filecoin-project/specs-actors/pull/348))
+  - puppet type and method for failed marshal to cbor (#347) ([filecoin-project/specs-actors#347](https://github.com/filecoin-project/specs-actors/pull/347))
+  - Unit tests for prove commit sector (#351) ([filecoin-project/specs-actors#351](https://github.com/filecoin-project/specs-actors/pull/351))
+  - Fix failure to detect faults of exactly-full top partition (#350) ([filecoin-project/specs-actors#350](https://github.com/filecoin-project/specs-actors/pull/350))
+  - Fix checking of fault/recovery declaration deadlines (#349) ([filecoin-project/specs-actors#349](https://github.com/filecoin-project/specs-actors/pull/349))
+  - Set ConsensusMinerMinPower to 10TiB (#344) ([filecoin-project/specs-actors#344](https://github.com/filecoin-project/specs-actors/pull/344))
+  - improve deal accounting performance (#309) ([filecoin-project/specs-actors#309](https://github.com/filecoin-project/specs-actors/pull/309))
+  - DeadlineInfo handles expired proving period (#343) ([filecoin-project/specs-actors#343](https://github.com/filecoin-project/specs-actors/pull/343))
+  - document reward-minting taylorSeriesExpansion (#338) ([filecoin-project/specs-actors#338](https://github.com/filecoin-project/specs-actors/pull/338))
+  - implement puppet actor (#290) ([filecoin-project/specs-actors#290](https://github.com/filecoin-project/specs-actors/pull/290))
+  - Fix the 32GiB Window PoSt partition size again (#337) ([filecoin-project/specs-actors#337](https://github.com/filecoin-project/specs-actors/pull/337))
+  - Fix seal proof type in miner actor and parameterize WPoSt partition size by it (#336) ([filecoin-project/specs-actors#336](https://github.com/filecoin-project/specs-actors/pull/336))
+  - Change WPoStPartitionSectors to 2349 (#332) ([filecoin-project/specs-actors#332](https://github.com/filecoin-project/specs-actors/pull/332))
+  - Remove unused SectorSize from VerifyDealsOnSectorProveCommitParams (#328) ([filecoin-project/specs-actors#328](https://github.com/filecoin-project/specs-actors/pull/328))
+  - require success in reward actor send reward (#331) ([filecoin-project/specs-actors#331](https://github.com/filecoin-project/specs-actors/pull/331))
+  - Power actor CreateMiner passes on value received to new actor (#327) ([filecoin-project/specs-actors#327](https://github.com/filecoin-project/specs-actors/pull/327))
+  - Specify cron genesis entries (#326) ([filecoin-project/specs-actors#326](https://github.com/filecoin-project/specs-actors/pull/326))
+  - Remove SysErrInternal definition, use of which is always a bug (#304) ([filecoin-project/specs-actors#304](https://github.com/filecoin-project/specs-actors/pull/304))
+
+### Contributors
+
+| Contributor | Commits | Lines ± | Files Changed |
+|-------------|---------|---------|---------------|
+| Alex North | 13 | +654/-280 | 35 |
+| Whyrusleeping | 2 | +273/-437 | 13 |
+| Frrist | 3 | +455/-6 | 7 |
+| davidad (David A. Dalrymple) | 3 | +245/-46 | 5 |
+| Jeromy | 2 | +166/-4 | 4 |
+| laser | 4 | +110/-48 | 6 |
+| Erin Swenson-Healey | 3 | +50/-30 | 5 |
+| ZX | 1 | +48/-20 | 5 |
+| nemo | 1 | +4/-56 | 2 |
+
+## 0.26.0
+
+This release migrates from v25 to v26 Groth parameters, which allows us to use
+64GiB sectors. It also adds some safety to the CGO bindings, which were
+previously sharing Go memory with C, resulting in some errors when running with
+`cgocheck=2`.
+
+### Changelog
+
+- github.com/filecoin-project/filecoin-ffi:
+  - update to v26 Groth parameters (#83) ([filecoin-project/filecoin-ffi#83](https://github.com/filecoin-project/filecoin-ffi/pull/83))
+  - handle allocations for problematic structs to avoid sharing pointers-to-pointers with C (from Go) (#82) ([filecoin-project/filecoin-ffi#82](https://github.com/filecoin-project/filecoin-ffi/pull/82))
+
+### Contributors
+
+| Contributor | Commits | Lines ± | Files Changed |
+|-------------|---------|---------|---------------|
+| Erin Swenson-Healey | 2 | +514/-375 | 15 |

--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ and committed to Git. To generate bindings yourself, install the c-for-go
 binary, ensure that it's on your path, and then run `make cgo-gen`. CI builds
 will fail if generated CGO diverges from what's checked into Git.
 
+## Updating the Changelog
+
+The `mkreleaselog` script (in the project root) can be used to generate a good
+portion of the filecoin-ffi changelog. For historical reasons, the script must
+be run from the root of a filecoin-ffi checkout which is in your `$GOPATH`.
+
+Run it like so:
+
+```shell
+./mkreleaselog v0.25.0 v0.26.0 > /tmp/v0.26.0.notes.txt
+```
+
 ## License
 
 MIT or Apache 2.0

--- a/mkreleaselog
+++ b/mkreleaselog
@@ -1,0 +1,240 @@
+#!/bin/zsh
+
+# Note: This script is a modified version of the mkreleaselog script used by
+# the go-ipfs team.
+#
+# Usage: ./mkreleaselog v0.25.0 v0.26.0 > /tmp/release.log
+
+set -euo pipefail
+export GO111MODULE=on
+export GOPATH="$(go env GOPATH)"
+
+alias jq="jq --unbuffered"
+
+REPO_SUFFIXES_TO_STRIP=(
+    "/v2"
+    "/v3"
+    "/v4"
+    "/v5"
+    "/v6"
+)
+
+AUTHORS=(
+    # orgs
+    filecoin-project
+
+    # Authors of personal repos used by filecoin-ffi that should be mentioned in the
+    # release notes.
+    xlab
+)
+
+[[ -n "${REPO_FILTER+x}" ]] || REPO_FILTER="github.com/(${$(printf "|%s" "${AUTHORS[@]}"):1})"
+
+[[ -n "${IGNORED_FILES+x}" ]] || IGNORED_FILES='^\(\.gx\|package\.json\|\.travis\.yml\|go.mod\|go\.sum|\.github|\.circleci\)$'
+
+NL=$'\n'
+
+msg() {
+    echo "$*" >&2
+}
+
+statlog() {
+    rpath="$GOPATH/src/$1"
+    for s in $REPO_SUFFIXES_TO_STRIP; do
+        rpath=${rpath%$s}
+    done
+
+    start="${2:-}"
+    end="${3:-HEAD}"
+
+    git -C "$rpath" log --shortstat --no-merges --pretty="tformat:%H%n%aN%n%aE" "$start..$end" | while
+        read hash
+        read name
+        read email
+        read _ # empty line
+        read changes
+    do
+        changed=0
+        insertions=0
+        deletions=0
+        while read count event; do
+            if [[ "$event" =~ ^file ]]; then
+                changed=$count
+            elif [[ "$event" =~ ^insertion ]]; then
+                insertions=$count
+            elif [[ "$event" =~ ^deletion ]]; then
+                deletions=$count
+            else
+                echo "unknown event $event" >&2
+                exit 1
+            fi
+        done<<<"${changes//,/$NL}"
+
+        jq -n \
+           --arg "hash" "$hash" \
+           --arg "name" "$name" \
+           --arg "email" "$email" \
+           --argjson "changed" "$changed" \
+           --argjson "insertions" "$insertions" \
+           --argjson "deletions" "$deletions" \
+           '{Commit: $hash, Author: $name, Email: $email, Files: $changed, Insertions: $insertions, Deletions: $deletions}'
+    done
+}
+
+# Returns a stream of deps changed between $1 and $2.
+dep_changes() {
+    {
+        <"$1"
+        <"$2"
+    } | jq -s 'JOIN(INDEX(.[0][]; .Path); .[1][]; .Path; {Path: .[0].Path, Old: (.[1] | del(.Path)), New: (.[0] | del(.Path))}) | select(.New.Version != .Old.Version)'
+}
+
+# resolve_commits resolves a git ref for each version.
+resolve_commits() {
+    jq '. + {Ref: (.Version|capture("^((?<ref1>.*)\\+incompatible|v.*-(0\\.)?[0-9]{14}-(?<ref2>[a-f0-9]{12})|(?<ref3>v.*))$") | .ref1 // .ref2 // .ref3)}'
+}
+
+pr_link() {
+    local repo="$1"
+    local prnum="$2"
+    local ghname="${repo##github.com/}"
+    printf -- "[%s#%s](https://%s/pull/%s)" "$ghname" "$prnum" "$repo" "$prnum"
+}
+
+# Generate a release log for a range of commits in a single repo.
+release_log() {
+    setopt local_options BASH_REMATCH
+
+    local repo="$1"
+    local start="$2"
+    local end="${3:-HEAD}"
+    local dir="$GOPATH/src/$repo"
+
+    local commit pr
+    git -C "$dir" log \
+        --format='tformat:%H %s' \
+        --first-parent \
+        "$start..$end" |
+        while read commit subject; do
+            # Skip gx-only PRs.
+            git -C "$dir" diff-tree --no-commit-id --name-only "$commit^" "$commit" |
+                grep -v "${IGNORED_FILES}" >/dev/null || continue
+
+            if [[ "$subject" =~ '^Merge pull request #([0-9]+) from' ]]; then
+                local prnum="${BASH_REMATCH[2]}"
+                local desc="$(git -C "$dir" show --summary --format='tformat:%b' "$commit" | head -1)"
+                printf -- "- %s (%s)\n" "$desc" "$(pr_link "$repo" "$prnum")"
+            elif [[ "$subject" =~ '\(#([0-9]+)\)$' ]]; then
+                local prnum="${BASH_REMATCH[2]}"
+                printf -- "- %s (%s)\n" "$subject" "$(pr_link "$repo" "$prnum")"
+            else
+                printf -- "- %s\n" "$subject"
+            fi
+        done
+}
+
+indent() {
+    sed -e 's/^/  /'
+}
+
+mod_deps() {
+    go list -json -m all | jq 'select(.Version != null)'
+}
+
+ensure() {
+    local repo="$1"
+    for s in $REPO_SUFFIXES_TO_STRIP; do
+        repo=${repo%$s}
+    done
+
+    local commit="$2"
+
+    local rpath="$GOPATH/src/$repo"
+    if [[ ! -d "$rpath" ]]; then
+        msg "Cloning $repo..."
+        git clone "http://$repo" "$rpath" >&2
+    fi
+
+    if ! git -C "$rpath" rev-parse --verify "$commit" >/dev/null; then
+        msg "Fetching $repo..."
+        git -C "$rpath" fetch --all >&2
+    fi
+
+    git -C "$rpath" rev-parse --verify "$commit" >/dev/null || return 1
+}
+
+statsummary() {
+    jq -s 'group_by(.Author)[] | {Author: .[0].Author, Commits: (. | length), Insertions: (map(.Insertions) | add), Deletions: (map(.Deletions) | add), Files: (map(.Files) | add)}' |
+        jq '. + {Lines: (.Deletions + .Insertions)}'
+}
+
+recursive_release_log() {
+    local start="${1:-$(git tag -l | sort -V | grep -v -- '-rc' | grep 'v'| tail -n1)}"
+    local end="${2:-$(git rev-parse HEAD)}"
+    local repo_root="$(git rev-parse --show-toplevel)"
+    local package="$(cd "$repo_root" && go list)"
+
+    if ! [[ "${GOPATH}/${package}" != "${repo_root}" ]]; then
+        echo "This script requires the target package and all dependencies to live in a GOPATH."
+        return 1
+    fi
+
+    (
+        local result=0
+        local workspace="$(mktemp -d)"
+        trap "$(printf 'rm -rf "%q"' "$workspace")" INT TERM EXIT
+        cd "$workspace"
+
+        echo "Computing old deps..." >&2
+        git -C "$repo_root" show "$start:go.mod" >go.mod
+        mod_deps | resolve_commits | jq -s > old_deps.json
+
+        echo "Computing new deps..." >&2
+        git -C "$repo_root" show "$end:go.mod" >go.mod
+        mod_deps | resolve_commits | jq -s > new_deps.json
+
+        rm -f go.mod go.sum
+
+        printf -- "Generating Changelog for %s %s..%s\n" "$package" "$start" "$end" >&2
+
+        printf -- "- %s:\n" "$package"
+        release_log "$package" "$start" "$end" | indent
+
+        statlog "$package" "$start" "$end" > statlog.json
+
+        dep_changes old_deps.json new_deps.json |
+            jq --arg filter "$REPO_FILTER" 'select(.Path | match($filter))' |
+            # Compute changelogs
+            jq -r '"\(.Path) \(.New.Version) \(.New.Ref) \(.Old.Version) \(.Old.Ref // "")"' |
+            while read repo new new_ref old old_ref; do
+                for s in $REPO_SUFFIXES_TO_STRIP; do
+                    repo=${repo%$s}
+                done
+
+                if ! ensure "$repo" "$new_ref"; then
+                    result=1
+                    local changelog="failed to fetch repo"
+                else
+                    statlog "$repo" "$old_ref" "$new_ref" >> statlog.json
+                    local changelog="$(release_log "$repo" "$old_ref" "$new_ref")"
+                fi
+                if [[ -n "$changelog" ]]; then
+                    printf -- "- %s (%s -> %s):\n" "$repo" "$old" "$new"
+                    echo "$changelog" | indent
+                fi
+            done
+
+        echo
+        echo "Contributors"
+        echo
+
+        echo "| Contributor | Commits | Lines ± | Files Changed |"
+        echo "|-------------|---------|---------|---------------|"
+        statsummary <statlog.json |
+            jq -s 'sort_by(.Lines) | reverse | .[]' |
+            jq -r '"| \(.Author) | \(.Commits) | +\(.Insertions)/-\(.Deletions) | \(.Files) |"'
+        return "$status"
+    )
+}
+
+recursive_release_log "$@"


### PR DESCRIPTION
## Why does this PR exist?

We need to get in the habit of combining a release with a changelog update so that we can easily communicate the features and bugfixes that go out with each release.

## What's in this changeset?

This changeset includes a changelog starting at v0.25.0 to current. It also includes a changelog-generating script which is [based off of the tool which go-ipfs uses](https://github.com/ipfs/go-ipfs/blob/master/bin/mkreleaselog).