### PR TITLE
explicitly close os.File to force release of file descriptor

### DIFF
--- a/proofs.go
+++ b/proofs.go
@@ -137,7 +137,12 @@ func GeneratePieceCID(proofType abi.RegisteredProof, piecePath string, pieceSize
 		return cid.Undef, err
 	}
 
-	return GeneratePieceCIDFromFile(proofType, pieceFile, pieceSize)
+	pcd, err := GeneratePieceCIDFromFile(proofType, pieceFile, pieceSize)
+	if err != nil {
+		return cid.Undef, pieceFile.Close()
+	}
+
+	return pcd, pieceFile.Close()
 }
 
 // GenerateDataCommitment produces a commitment for the sector containing the


### PR DESCRIPTION
Fixes #94 .

## Why does this PR exist?

Running `GeneratePieceCommitment` in a loop can occasionally produce (depending on the quantity of iterations) a `too many open files` error.

## What's in this PR?

In Go, the file descriptor associated with an `*os.File` is cleaned up when the file is closed or when the `*os.File` is garbage collected. This changeset adds an explicit `File#Close` call instead of relying on garbage collection to free the file descriptor. When run in a loop, this keeps the file descriptor list at a constant size.