### PR TITLE
feat: proofs-aip v5.3.0 (new blst backend and optimizations)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,8 @@ jobs:
           version: 1.32.0
       - run:
           command: LD_LIBRARY_PATH="/tmp/__fil-hwloc/lib" make go-lint
-  build_and_test_linux_cgo_bindings:
+
+  build_and_test_linux_cgo_bindings_pairing:
     parameters:
       run_leak_detector:
         type: boolean
@@ -51,6 +52,24 @@ jobs:
       - save_parameter_cache
       - run_tests:
           run_leak_detector: << parameters.run_leak_detector >>
+
+  build_and_test_linux_cgo_bindings_blst:
+    parameters:
+      run_leak_detector:
+        type: boolean
+        default: false
+    executor: golang
+    working_directory: ~/go/src/github.com/filecoin-project/filecoin-ffi
+    steps:
+      - configure_environment_variables
+      - prepare
+      - build_project
+      - restore_parameter_cache
+      - obtain_filecoin_parameters
+      - save_parameter_cache
+      - run_tests:
+          run_leak_detector: << parameters.run_leak_detector >>
+
   build_darwin_cgo_bindings:
     macos:
       xcode: "10.0.0"
@@ -160,18 +179,32 @@ workflows:
             - cargo_fetch
       - gofmt
       - go_lint
-      - build_and_test_linux_cgo_bindings:
+      - build_and_test_linux_cgo_bindings_pairing:
           filters:
             branches:
               only:
                 - master
           run_leak_detector: true
-      - build_and_test_linux_cgo_bindings:
+      - build_and_test_linux_cgo_bindings_pairing:
           filters:
             branches:
               ignore:
                 - master
           run_leak_detector: false
+
+      - build_and_test_linux_cgo_bindings_blst:
+          filters:
+            branches:
+              only:
+                - master
+          run_leak_detector: true
+      - build_and_test_linux_cgo_bindings_blst:
+          filters:
+            branches:
+              ignore:
+                - master
+          run_leak_detector: false
+
       - publish_linux_staticlib:
           filters:
             branches:
@@ -308,14 +341,25 @@ commands:
           GOPATH=/tmp GO111MODULE=off go get github.com/filecoin-project/go-paramfetch/paramfetch
           GOPATH=/tmp GO111MODULE=off go build -o go-paramfetch github.com/filecoin-project/go-paramfetch/paramfetch
           ./go-paramfetch 2048 "${DIR}/parameters.json"
+
   build_project:
+    parameters:
+      blst:
+        default: false
+        description: build with blst backend?
+        type: boolean
     steps:
+      - when:
+          condition: << parameters.blst >>
+          steps:
+            - run: export FFI_USE_BLST=1
       - run:
           name: Build project
           command: make
       - run:
           name: Build project without CGO
           command: env CGO_ENABLED=0 go build .
+
   ensure_generated_cgo_up_to_date:
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           gobin: $HOME/.local/bin
           version: 1.32.0
       - run:
-          command: LIBRARY_PATH="/tmp/__fil-hwloc/lib" make go-lint
+          command: make go-lint
 
   build_and_test_linux_cgo_bindings_pairing:
     parameters:
@@ -237,7 +237,7 @@ commands:
             - go/install-ssh
             - go/install: {package: git}
             - run: sudo apt-get update
-            - run: sudo apt-get install -y jq valgrind ocl-icd-opencl-dev clang libssl-dev
+            - run: sudo apt-get install -y jq valgrind ocl-icd-opencl-dev clang libssl-dev libhwloc-dev
             - run: curl https://sh.rustup.rs -sSf | sh -s -- -y
       - when:
           condition: << parameters.darwin >>
@@ -385,15 +385,15 @@ commands:
           steps:
             - run:
                 name: Run leak detector
-                command: LIBRARY_PATH="/tmp/__fil-hwloc/lib" make cgo-leakdetect
+                command: make cgo-leakdetect
                 no_output_timeout: 60m
       - run:
           name: Run the Rust tests
-          command: cd rust && FIL_PROOFS_PARAMETER_CACHE="${HOME}/filecoin-proof-parameters/" RUSTFLAGS="-L/tmp/__fil-hwloc/lib -lhwloc" RUST_LOG=info LD_LIBRARY_PATH="/tmp/__fil-hwloc/lib" cargo test --all --release && cd ..
+          command: cd rust && FIL_PROOFS_PARAMETER_CACHE="${HOME}/filecoin-proof-parameters/" RUST_LOG=info cargo test --all --release && cd ..
           no_output_timeout: 60m
       - run:
           name: Run the Go tests
-          command: CGO_LDFLAGS="-L/tmp/__fil-hwloc/lib -lhwloc" LD_LIBRARY_PATH="/tmp/__fil-hwloc/lib" GODEBUG=cgocheck=2 RUST_LOG=info go test -p 1 -timeout 60m
+          command: GODEBUG=cgocheck=2 RUST_LOG=info go test -p 1 -timeout 60m
           no_output_timeout: 60m
   compile_tests:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,8 +138,11 @@ jobs:
       - run: cd rust && rustup component add clippy
       - run: cd rust && cargo fetch
       - run:
-          name: Run cargo clippy
-          command: cd rust && cargo +$(cat rust-toolchain) clippy --all-targets --all-features -- -D warnings
+          name: Run cargo clippy (pairing)
+          command: cd rust && cargo +$(cat rust-toolchain) clippy --all-targets -- -D warnings
+      - run:
+          name: Run cargo clippy (blst)
+          command: cd rust && cargo +$(cat rust-toolchain) clippy --all-targets --no-default-features --features blst -- -D warnings
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,29 +254,25 @@ commands:
             ./scripts/package-release.sh $TARBALL_PATH
             ./scripts/publish-release.sh $TARBALL_PATH $RELEASE_NAME
       - run:
-          name: Build and publish the optimized release (pairing)
+          name: Build the optimized release (pairing)
           command: |
             cd rust
 
             TARBALL_PATH="/tmp/${CIRCLE_PROJECT_REPONAME}-$(uname)-optimized.tar.gz"
-            RELEASE_NAME="${CIRCLE_PROJECT_REPONAME}-$(uname)-optimized"
             RUSTFLAGS="-C target-feature=$(cat rustc-target-features-optimized.json | jq -r '.[].rustc_target_feature' | tr '\n' ',')"
 
             ./scripts/build-release.sh filcrypto $(cat ./rust-toolchain) --verbose --locked --no-default-features --features pairing
             ./scripts/package-release.sh $TARBALL_PATH
-            ./scripts/publish-release.sh $TARBALL_PATH $RELEASE_NAME
       - run:
-          name: Build and publish the optimized release (blst)
+          name: Build the optimized release (blst)
           command: |
             cd rust
 
             TARBALL_PATH="/tmp/${CIRCLE_PROJECT_REPONAME}-$(uname)-optimized.tar.gz"
-            RELEASE_NAME="${CIRCLE_PROJECT_REPONAME}-$(uname)-optimized-blst"
             RUSTFLAGS="-C target-feature=$(cat rustc-target-features-optimized.json | jq -r '.[].rustc_target_feature' | tr '\n' ',')"
 
             ./scripts/build-release.sh filcrypto $(cat ./rust-toolchain) --verbose --locked --all
             ./scripts/package-release.sh $TARBALL_PATH
-            ./scripts/publish-release.sh $TARBALL_PATH $RELEASE_NAME
   configure_environment_variables:
     parameters:
       linux:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -356,13 +356,12 @@ commands:
             - run:
                 name: Build project (blst)
                 command: FFI_USE_BLST=1 make
-      - when:
-          condition:
-            not: << parameters.blst >>
-            steps:
-              - run:
-                  name: Build project (pairing)
-                  command: make
+      - unless:
+          condition: << parameters.blst >>
+          steps:
+            - run:
+                name: Build project (pairing)
+                command: make
                 
       - run:
           name: Build project without CGO

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
       - go/mod-download
       - go/install-golangci-lint:
           gobin: $HOME/.local/bin
-          version: 1.23.8
+          version: 1.32.0
       - run:
           command: LD_LIBRARY_PATH="/tmp/__fil-hwloc/lib" make go-lint
   build_and_test_linux_cgo_bindings:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,23 +229,46 @@ commands:
   publish_release:
     steps:
       - run:
-          name: Build and publish the standard release
+          name: Build and publish the standard release (pairing)
           command: |
             cd rust
 
             TARBALL_PATH="/tmp/${CIRCLE_PROJECT_REPONAME}-$(uname)-standard.tar.gz"
             RELEASE_NAME="${CIRCLE_PROJECT_REPONAME}-$(uname)-standard"
 
-            ./scripts/build-release.sh filcrypto $(cat ./rust-toolchain) --verbose --locked --all
+            ./scripts/build-release.sh filcrypto $(cat ./rust-toolchain) --verbose --locked --no-default-features --features pairing
             ./scripts/package-release.sh $TARBALL_PATH
             ./scripts/publish-release.sh $TARBALL_PATH $RELEASE_NAME
       - run:
-          name: Build and publish the optimized release
+          name: Build and publish the standard release (blst)
+          command: |
+            cd rust
+
+            TARBALL_PATH="/tmp/${CIRCLE_PROJECT_REPONAME}-$(uname)-standard-blst.tar.gz"
+            RELEASE_NAME="${CIRCLE_PROJECT_REPONAME}-$(uname)-standard-blst"
+
+            ./scripts/build-release.sh filcrypto $(cat ./rust-toolchain) --verbose --locked --no-default-features --features blst
+            ./scripts/package-release.sh $TARBALL_PATH
+            ./scripts/publish-release.sh $TARBALL_PATH $RELEASE_NAME
+      - run:
+          name: Build and publish the optimized release (pairing)
           command: |
             cd rust
 
             TARBALL_PATH="/tmp/${CIRCLE_PROJECT_REPONAME}-$(uname)-optimized.tar.gz"
             RELEASE_NAME="${CIRCLE_PROJECT_REPONAME}-$(uname)-optimized"
+            RUSTFLAGS="-C target-feature=$(cat rustc-target-features-optimized.json | jq -r '.[].rustc_target_feature' | tr '\n' ',')"
+
+            ./scripts/build-release.sh filcrypto $(cat ./rust-toolchain) --verbose --locked --no-default-features --features pairing
+            ./scripts/package-release.sh $TARBALL_PATH
+            ./scripts/publish-release.sh $TARBALL_PATH $RELEASE_NAME
+      - run:
+          name: Build and publish the optimized release (blst)
+          command: |
+            cd rust
+
+            TARBALL_PATH="/tmp/${CIRCLE_PROJECT_REPONAME}-$(uname)-optimized.tar.gz"
+            RELEASE_NAME="${CIRCLE_PROJECT_REPONAME}-$(uname)-optimized-blst"
             RUSTFLAGS="-C target-feature=$(cat rustc-target-features-optimized.json | jq -r '.[].rustc_target_feature' | tr '\n' ',')"
 
             ./scripts/build-release.sh filcrypto $(cat ./rust-toolchain) --verbose --locked --all

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -353,10 +353,17 @@ commands:
       - when:
           condition: << parameters.blst >>
           steps:
-            - run: export FFI_USE_BLST=1
-      - run:
-          name: Build project
-          command: make
+            - run:
+                name: Build project (blst)
+                command: FFI_USE_BLST=1 make
+      - when:
+          condition:
+            not: << parameters.blst >>
+            steps:
+              - run:
+                  name: Build project (pairing)
+                  command: make
+                
       - run:
           name: Build project without CGO
           command: env CGO_ENABLED=0 go build .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,8 @@ jobs:
     steps:
       - configure_environment_variables
       - prepare
-      - build_project
+      - build_project:
+          blst: true
       - restore_parameter_cache
       - obtain_filecoin_parameters
       - save_parameter_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           gobin: $HOME/.local/bin
           version: 1.32.0
       - run:
-          command: LD_LIBRARY_PATH="/tmp/__fil-hwloc/lib" make go-lint
+          command: LIBRARY_PATH="/tmp/__fil-hwloc/lib" make go-lint
 
   build_and_test_linux_cgo_bindings_pairing:
     parameters:
@@ -385,7 +385,7 @@ commands:
           steps:
             - run:
                 name: Run leak detector
-                command: LD_LIBRARY_PATH="/tmp/__fil-hwloc/lib" make cgo-leakdetect
+                command: LIBRARY_PATH="/tmp/__fil-hwloc/lib" make cgo-leakdetect
                 no_output_timeout: 60m
       - run:
           name: Run the Rust tests

--- a/build.sh
+++ b/build.sh
@@ -9,6 +9,6 @@ cargo update -p "filecoin-proofs-api"
 cargo install cbindgen
 cbindgen --clean --config cbindgen.toml --crate filcrypto --output ../include/filcrypto.h
 cd ..
-FFI_BUILD_FROM_SOURCE=1 make
+FFI_BUILD_FROM_SOURCE=1 FFI_USE_BLST=1 make
 make cgo-gen
 go mod tidy

--- a/filcrypto.yml
+++ b/filcrypto.yml
@@ -8,8 +8,8 @@ GENERATOR:
   Includes:
     - ../filcrypto.h
   FlagGroups:
-    - {name: LDFLAGS, flags: ["-L${SRCDIR}/.. -lfilcrypto -L/tmp/__fil-hwloc/lib -lhwloc"]}
-    - {name: pkg-config, flags: ["${SRCDIR}/../filcrypto.pc --static"]}
+    - {name: LDFLAGS, flags: ["-L${SRCDIR}/.."]}
+    - {name: pkg-config, flags: ["${SRCDIR}/../filcrypto.pc"]}
 
 PARSER:
   Defines:

--- a/generated/cgo_helpers.go
+++ b/generated/cgo_helpers.go
@@ -4,8 +4,8 @@
 package generated
 
 /*
-#cgo LDFLAGS: -L${SRCDIR}/.. -lfilcrypto -L/tmp/__fil-hwloc/lib -lhwloc
-#cgo pkg-config: ${SRCDIR}/../filcrypto.pc --static
+#cgo LDFLAGS: -L${SRCDIR}/..
+#cgo pkg-config: ${SRCDIR}/../filcrypto.pc
 #include "../filcrypto.h"
 #include <stdlib.h>
 #include "cgo_helpers.h"

--- a/generated/const.go
+++ b/generated/const.go
@@ -4,8 +4,8 @@
 package generated
 
 /*
-#cgo LDFLAGS: -L${SRCDIR}/.. -lfilcrypto -L/tmp/__fil-hwloc/lib -lhwloc
-#cgo pkg-config: ${SRCDIR}/../filcrypto.pc --static
+#cgo LDFLAGS: -L${SRCDIR}/..
+#cgo pkg-config: ${SRCDIR}/../filcrypto.pc
 #include "../filcrypto.h"
 #include <stdlib.h>
 #include "cgo_helpers.h"

--- a/generated/generated.go
+++ b/generated/generated.go
@@ -4,8 +4,8 @@
 package generated
 
 /*
-#cgo LDFLAGS: -L${SRCDIR}/.. -lfilcrypto -L/tmp/__fil-hwloc/lib -lhwloc
-#cgo pkg-config: ${SRCDIR}/../filcrypto.pc --static
+#cgo LDFLAGS: -L${SRCDIR}/..
+#cgo pkg-config: ${SRCDIR}/../filcrypto.pc
 #include "../filcrypto.h"
 #include <stdlib.h>
 #include "cgo_helpers.h"

--- a/generated/types.go
+++ b/generated/types.go
@@ -4,8 +4,8 @@
 package generated
 
 /*
-#cgo LDFLAGS: -L${SRCDIR}/.. -lfilcrypto -L/tmp/__fil-hwloc/lib -lhwloc
-#cgo pkg-config: ${SRCDIR}/../filcrypto.pc --static
+#cgo LDFLAGS: -L${SRCDIR}/..
+#cgo pkg-config: ${SRCDIR}/../filcrypto.pc
 #include "../filcrypto.h"
 #include <stdlib.h>
 #include "cgo_helpers.h"

--- a/install-filcrypto
+++ b/install-filcrypto
@@ -131,23 +131,6 @@ build_from_source() {
     local __repo_sha1=$(git rev-parse HEAD)
     local __repo_sha1_truncated="${__repo_sha1:0:16}"
 
-    if [ "$(uname)" = "Linux" ]; then
-        # Install hwloc2 on Linux dependency from source.
-        HWLOC_PACKAGE="hwloc-2.3.0"
-        HWLOC_DOWNLOAD_URL="https://download.open-mpi.org/release/hwloc/v2.3/hwloc-2.3.0.tar.gz"
-        HWLOC_INSTALL_DIR="/tmp/__fil-hwloc"
-        rm -rf ${HWLOC_INSTALL_DIR}
-
-        curl ${HWLOC_DOWNLOAD_URL} --location --output /tmp/${HWLOC_PACKAGE}.tar.gz
-        pushd /tmp/
-        tar -xf ${HWLOC_PACKAGE}.tar.gz
-        rm -f /tmp/${HWLOC_PACKAGE}.tar.gz
-        cd ${HWLOC_PACKAGE}
-        ./configure --prefix=${HWLOC_INSTALL_DIR} && make && make install
-        popd
-        rm -rf /tmp/${HWLOC_PACKAGE}
-    fi
-
     (>&2 echo "building from source @ ${__repo_sha1_truncated}")
 
     if ! [ -x "$(command -v cargo)" ]; then
@@ -170,7 +153,7 @@ build_from_source() {
     if [ "${FFI_USE_BLST}" == "1" ]; then
         additional_flags="--no-default-features --features blst"
     else
-        additional_flags=""
+        additional_flags="--no-default-features --features pairing"
     fi
 
     if [ -n "${__release_flags}" ]; then

--- a/install-filcrypto
+++ b/install-filcrypto
@@ -76,12 +76,12 @@ download_release_tarball() {
     local __release_tag="${__release_sha1:0:16}"
     local __release_tag_url="https://api.github.com/repos/filecoin-project/${__repo_name}/releases/tags/${__release_tag}"
 
-    # FIXME: Disable optimized release download, as it can't support properly support all native cpu flag detections
-    #if [ -z $release_flags ]; then
+    # Download either the non-optimized standard or standard-blst release.
+    if [ "${FFI_USE_BLST}" == "1" ]; then
+        release_flag_name="standard-blst"
+    else
         release_flag_name="standard"
-    #else
-    #    release_flag_name="optimized"
-    #fi
+    fi
 
     # TODO: This function shouldn't make assumptions about how these releases'
     # names are constructed. Marginally less-bad would be to require that this
@@ -166,10 +166,17 @@ build_from_source() {
 
     cargo --version
 
-    if [ -n "${__release_flags}" ]; then
-        RUSTFLAGS="-C target-feature=${__release_flags}" ./scripts/build-release.sh "${__library_name}" "$(cat rust-toolchain)"
+    # Add feature specific rust flags as needed here.
+    if [ "${FFI_USE_BLST}" == "1" ]; then
+        additional_flags="--no-default-features --features blst"
     else
-        ./scripts/build-release.sh "${__library_name}" "$(cat rust-toolchain)"
+        additional_flags=""
+    fi
+
+    if [ -n "${__release_flags}" ]; then
+        RUSTFLAGS="-C target-feature=${__release_flags}" ./scripts/build-release.sh "${__library_name}" "$(cat rust-toolchain)" "${additional_flags}"
+    else
+        ./scripts/build-release.sh "${__library_name}" "$(cat rust-toolchain)" "${additional_flags}"
     fi
 
     popd

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-RUST_LOG=info go test --ldflags '-extldflags "-L/tmp/__fil-hwloc/lib -lhwloc"' -count=1 ./... && cd rust && cargo test --release --all && cd ..
+RUST_LOG=info go test -count=1 ./... && cd rust && cargo test --release --all && cd ..

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -17,34 +17,33 @@ checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
 name = "aes"
-version = "0.3.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54eb1d8fe354e5fc611daf4f2ea97dd45a765f4f1e4512306ec183ae2e8f20c9"
+checksum = "884391ef1066acaa41e766ba8f596341b96e93ce34f9a43e7d24bf0a0eaf0561"
 dependencies = [
  "aes-soft",
  "aesni",
- "block-cipher-trait",
+ "cipher",
 ]
 
 [[package]]
 name = "aes-soft"
-version = "0.3.3"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd7e7ae3f9a1fb5c03b389fc6bb9a51400d0c13053f0dca698c832bfd893a0d"
+checksum = "e39964420d0ab27e20c12b348bf901ef3f69e43694dd25ca4dbafe050781a7fe"
 dependencies = [
- "block-cipher-trait",
- "byteorder 1.3.4",
- "opaque-debug 0.2.3",
+ "cipher",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
 name = "aesni"
-version = "0.6.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f70a6b5f971e473091ab7cfb5ffac6cde81666c4556751d8d5620ead8abf100"
+checksum = "ea2e11f5e94c2f7d386164cc2aa1f97823fed6f259e486940a71c174dd01b0ce"
 dependencies = [
- "block-cipher-trait",
- "opaque-debug 0.2.3",
+ "cipher",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -54,6 +53,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
 dependencies = [
  "const-random",
+]
+
+[[package]]
+name = "ahash"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2deff5792519f5985c9cdd5a0399df3ca3419114841d282bae646acadbf0a99"
+dependencies = [
+ "getrandom 0.2.0",
+ "lazy_static",
 ]
 
 [[package]]
@@ -88,9 +97,9 @@ checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "arrayvec"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "atty"
@@ -135,11 +144,35 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9655742fc4c6f41f1412dba38342af29ef2a4ad05ba44613785b0d34edff0382"
 dependencies = [
- "ahash",
+ "ahash 0.3.8",
  "bit-vec",
  "blake2s_simd",
  "byteorder 1.3.4",
  "crossbeam-channel 0.4.4",
+ "fff",
+ "groupy",
+ "lazy_static",
+ "log",
+ "memmap",
+ "num_cpus",
+ "paired 0.20.1",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
+ "rayon",
+ "thiserror",
+]
+
+[[package]]
+name = "bellperson"
+version = "0.9.3"
+source = "git+https://github.com/filecoin-project/bellperson?branch=blstrs-9#c4d5ba5a85603c64d036fec4fb1f89e43b0d03d5"
+dependencies = [
+ "ahash 0.5.6",
+ "bit-vec",
+ "blake2s_simd",
+ "blstrs",
+ "byteorder 1.3.4",
+ "crossbeam-channel 0.5.0",
  "ff-cl-gen",
  "fff",
  "fil-ocl",
@@ -149,7 +182,7 @@ dependencies = [
  "log",
  "memmap",
  "num_cpus",
- "paired",
+ "paired 0.21.0",
  "rand 0.7.3",
  "rand_core 0.5.1",
  "rayon",
@@ -167,34 +200,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "bindgen"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c0bb6167449588ff70803f4127f0684f9063097eca5016f37eb52b92c2cf36"
-dependencies = [
- "bitflags",
- "cexpr",
- "cfg-if 0.1.10",
- "clang-sys",
- "clap",
- "env_logger",
- "lazy_static",
- "lazycell",
- "log",
- "peeking_take_while",
- "proc-macro2 1.0.24",
- "quote 1.0.7",
- "regex",
- "rustc-hash",
- "shlex",
- "which",
-]
-
-[[package]]
 name = "bit-vec"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0dc55f2d8a1a85650ac47858bb001b4c0dd73d79e3c455a842925e68d29cd3"
+
+[[package]]
+name = "bitflags"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dead7461c1127cf637931a1e50934eb6eee8bff2f74433ac7909e9afcee04a3"
 
 [[package]]
 name = "bitflags"
@@ -246,7 +261,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
- "block-padding",
+ "block-padding 0.1.5",
  "byte-tools",
  "byteorder 1.3.4",
  "generic-array 0.12.3",
@@ -262,22 +277,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-cipher-trait"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
-dependencies = [
- "generic-array 0.12.3",
-]
-
-[[package]]
 name = "block-modes"
-version = "0.3.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31aa8410095e39fdb732909fb5730a48d5bd7c2e3cd76bd1b07b3dbea130c529"
+checksum = "57a0e8073e8baa88212fb5823574c02ebccb395136ba9a164ab89379ec6072f0"
 dependencies = [
- "block-cipher-trait",
- "block-padding",
+ "block-padding 0.2.1",
+ "cipher",
 ]
 
 [[package]]
@@ -290,6 +296,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
+
+[[package]]
 name = "bls-signatures"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,12 +309,36 @@ checksum = "863020d4fead1c6090d754cf542cd723c124859543f595c65e8c6f11377a4223"
 dependencies = [
  "fff",
  "groupy",
- "hkdf",
- "paired",
+ "hkdf 0.8.0",
+ "paired 0.20.1",
  "rand_core 0.5.1",
  "rayon",
  "sha2ni",
  "thiserror",
+]
+
+[[package]]
+name = "blst"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce0ad2fe12998eb01f41b8ba29e697927b26b5ce04b60856bd8254658ba0fbb"
+dependencies = [
+ "cc",
+ "glob",
+ "threadpool",
+]
+
+[[package]]
+name = "blstrs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a4284735e22f7104c7983d95ad876aa1447c7be815080190ff32ba169c9fca0"
+dependencies = [
+ "blst",
+ "fff",
+ "groupy",
+ "rand_core 0.5.1",
+ "serde",
 ]
 
 [[package]]
@@ -313,9 +349,9 @@ checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
 
 [[package]]
 name = "byte-slice-cast"
-version = "0.3.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0a5e3906bcbf133e33c1d4d95afc664ad37fbdb9f6568d8043e7ea8c27d93d3"
+checksum = "65c1bf4a04a88c54f589125563643d773f3254b5c38571395e2b591c693bbc81"
 
 [[package]]
 name = "byte-tools"
@@ -353,7 +389,7 @@ dependencies = [
  "quote 1.0.7",
  "serde",
  "serde_json",
- "syn 1.0.46",
+ "syn 1.0.48",
  "tempfile",
  "toml",
 ]
@@ -363,15 +399,6 @@ name = "cc"
 version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed67cbde08356238e75fc4656be4749481eeffb09e19f320a25237d5221c985d"
-
-[[package]]
-name = "cexpr"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
-dependencies = [
- "nom",
-]
 
 [[package]]
 name = "cfg-if"
@@ -399,23 +426,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f7954ae5588102b35257639b1c36a2e7425cc6540fcdb4de19dcb91055d659"
+dependencies = [
+ "generic-array 0.14.4",
+]
+
+[[package]]
 name = "cl-sys"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8573fa3ff8acd6c49e8e113296c54277e82376b96c6ca6307848632cce38e44"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "clang-sys"
-version = "0.29.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6837df1d5cba2397b835c8530f51723267e16abbf83892e9e5af4f0e5dd10a"
-dependencies = [
- "glob",
- "libc",
- "libloading",
 ]
 
 [[package]]
@@ -426,7 +451,7 @@ checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
  "ansi_term",
  "atty",
- "bitflags",
+ "bitflags 1.2.1",
  "strsim",
  "textwrap",
  "unicode-width",
@@ -443,23 +468,6 @@ dependencies = [
  "nom",
  "serde",
  "toml",
-]
-
-[[package]]
-name = "console"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c0994e656bba7b922d8dd1245db90672ffb701e684e45be58f20719d69abc5a"
-dependencies = [
- "encode_unicode",
- "lazy_static",
- "libc",
- "regex",
- "terminal_size",
- "termios",
- "unicode-width",
- "winapi 0.3.9",
- "winapi-util",
 ]
 
 [[package]]
@@ -551,8 +559,22 @@ dependencies = [
  "crossbeam-channel 0.4.4",
  "crossbeam-deque 0.7.3",
  "crossbeam-epoch 0.8.2",
- "crossbeam-queue",
+ "crossbeam-queue 0.2.3",
  "crossbeam-utils 0.7.2",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd01a6eb3daaafa260f6fc94c3a6c36390abc2080e38e3e34ced87393fb77d80"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-channel 0.5.0",
+ "crossbeam-deque 0.8.0",
+ "crossbeam-epoch 0.9.0",
+ "crossbeam-queue 0.3.0",
+ "crossbeam-utils 0.8.0",
 ]
 
 [[package]]
@@ -638,6 +660,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b2a58563f049aa3bae172bc4120f093b5901161c629f280a1f40ba55317d774"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.0",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -667,7 +699,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 dependencies = [
  "generic-array 0.12.3",
- "subtle",
+ "subtle 1.0.0",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
+dependencies = [
+ "generic-array 0.14.4",
+ "subtle 2.3.0",
 ]
 
 [[package]]
@@ -677,18 +719,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fbaabec2c953050352311293be5c6aba8e141ba19d6811862b232d6fd020484"
 dependencies = [
  "quote 1.0.7",
- "syn 1.0.46",
+ "syn 1.0.48",
 ]
 
 [[package]]
 name = "dialoguer"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4aa86af7b19b40ef9cbef761ed411a49f0afa06b7b6dcd3dfe2f96a3c546138"
+checksum = "70f807b2943dc90f9747497d9d65d7e92472149be0b88bf4ce1201b4ac979c26"
 dependencies = [
- "console 0.11.3",
+ "console",
  "lazy_static",
  "tempfile",
+ "zeroize",
 ]
 
 [[package]]
@@ -763,19 +806,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "env_proxy"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,6 +813,17 @@ checksum = "3a5019be18538406a43b5419a5501461f0c8b49ea7dfda0cfc32f4e51fc44be1"
 dependencies = [
  "log",
  "url",
+]
+
+[[package]]
+name = "errno"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e2b2decb0484e15560df3210cf0d78654bb0864b2c138977c07e377a1bae0e2"
+dependencies = [
+ "kernel32-sys",
+ "libc",
+ "winapi 0.2.8",
 ]
 
 [[package]]
@@ -803,7 +844,7 @@ checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.46",
+ "syn 1.0.48",
  "synstructure",
 ]
 
@@ -848,7 +889,7 @@ dependencies = [
  "num-traits 0.2.12",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.46",
+ "syn 1.0.48",
 ]
 
 [[package]]
@@ -859,20 +900,6 @@ checksum = "5c95b7fe28637086befd927caf2c920b3c8c80c9a707d354bf80a7397cd8d9f2"
 dependencies = [
  "drop_struct_macro_derive",
  "libc",
-]
-
-[[package]]
-name = "fil-blst"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe1006774dcb6e0656cdab321651ded5cbaa2c0a6eeb27972f980973b24cbe4"
-dependencies = [
- "bindgen",
- "cc",
- "fff",
- "glob",
- "groupy",
- "paired",
 ]
 
 [[package]]
@@ -895,7 +922,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecd0aa5895d05824d7eaa38b999c91e9071acb74b304488220e8f8bb555d1ad1"
 dependencies = [
- "bitflags",
+ "bitflags 1.2.1",
  "cl-sys",
  "enum_primitive",
  "failure",
@@ -903,24 +930,6 @@ dependencies = [
  "num-traits 0.2.12",
  "ocl-core-vector",
  "rustc_version 0.1.7",
-]
-
-[[package]]
-name = "fil-sapling-crypto"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca2b7386602eb7eaa95b74a7c9acf152d06a28e4ce6d0e725035b4f628ff7"
-dependencies = [
- "bellperson",
- "blake2b_simd",
- "blake2s_simd",
- "byteorder 1.3.4",
- "cc",
- "fff",
- "lazy_static",
- "paired",
- "rand 0.7.3",
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -939,7 +948,7 @@ name = "filcrypto"
 version = "0.7.5"
 dependencies = [
  "anyhow",
- "bellperson",
+ "bellperson 0.9.3 (git+https://github.com/filecoin-project/bellperson?branch=blstrs-9)",
  "bls-signatures",
  "byteorder 1.3.4",
  "cbindgen",
@@ -950,8 +959,7 @@ dependencies = [
  "filecoin-proofs-api",
  "libc",
  "log",
- "neptune",
- "paired",
+ "neptune 1.2.3",
  "rand 0.7.3",
  "rand_chacha",
  "rayon",
@@ -962,11 +970,10 @@ dependencies = [
 [[package]]
 name = "filecoin-proofs"
 version = "5.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e32bff3a15dcce2ae34966ba6032ed4f90832c958b62dc615eba2fcf55cd3934"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=blstrs-9#5ae5c4704248f2cf3df81a1bf5b6576fd51c5240"
 dependencies = [
  "anyhow",
- "bellperson",
+ "bellperson 0.9.3 (git+https://github.com/filecoin-project/bellperson?branch=blstrs-9)",
  "bincode",
  "bitintr",
  "bitvec",
@@ -978,10 +985,9 @@ dependencies = [
  "dialoguer",
  "env_proxy",
  "fff",
- "fil-sapling-crypto",
  "fil_logger",
  "flate2",
- "generic-array 0.13.2",
+ "generic-array 0.14.4",
  "groupy",
  "hex",
  "humansize",
@@ -991,7 +997,6 @@ dependencies = [
  "log",
  "memmap",
  "merkletree",
- "paired",
  "pbr",
  "phase21",
  "rand 0.7.3",
@@ -1013,13 +1018,12 @@ dependencies = [
 [[package]]
 name = "filecoin-proofs-api"
 version = "5.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0cd82d2ae0577885bd03f742d627c6ffd424294a1163db172b9382715d382d"
+source = "git+https://github.com/filecoin-project/rust-filecoin-proofs-api?branch=blstrs#cdbc9c440e7b838d1abba06065074bb582554749"
 dependencies = [
  "anyhow",
+ "bellperson 0.9.3 (git+https://github.com/filecoin-project/bellperson?branch=blstrs-9)",
  "bincode",
  "filecoin-proofs",
- "paired",
  "serde",
 ]
 
@@ -1103,7 +1107,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 dependencies = [
- "bitflags",
+ "bitflags 1.2.1",
  "fuchsia-zircon-sys",
 ]
 
@@ -1121,51 +1125,51 @@ checksum = "4c7e4c2612746b0df8fed4ce0c69156021b704c9aefa360311c04e6e9e002eed"
 
 [[package]]
 name = "futures-channel"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a4d35f7401e948629c9c3d6638fb9bf94e0b2121e96c3b428cc4e631f3eb74"
+checksum = "0448174b01148032eed37ac4aed28963aaaa8cfa93569a08e5b479bbc6c2c151"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d674eaa0056896d5ada519900dbf97ead2e46a7b6621e8160d79e2f2e1e2784b"
+checksum = "18eaa56102984bed2c88ea39026cff3ce3b4c7f508ca970cedf2450ea10d4e46"
 
 [[package]]
 name = "futures-io"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc94b64bb39543b4e432f1790b6bf18e3ee3b74653c5449f63310e9a74b123c"
+checksum = "6e1798854a4727ff944a7b12aa999f58ce7aa81db80d2dfaaf2ba06f065ddd2b"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8764258ed64ebc5d9ed185cf86a95db5cac810269c5d20ececb32e0088abbd"
+checksum = "0e3ca3f17d6e8804ae5d3df7a7d35b2b3a6fe89dac84b31872720fc3060a0b11"
 
 [[package]]
 name = "futures-task"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd26820a9f3637f1302da8bceba3ff33adbe53464b54ca24d4e2d4f1db30f94"
+checksum = "96d502af37186c4fef99453df03e374683f8a1eec9dcc1e66b3b82dc8278ce3c"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "futures-util"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a894a0acddba51a2d49a6f4263b1e64b8c579ece8af50fa86503d52cd1eea34"
+checksum = "abcb44342f62e6f3e8ac427b8aa815f724fd705dfad060b18ac7866c15bb8e34"
 dependencies = [
  "futures-core",
  "futures-io",
  "futures-task",
  "memchr",
- "pin-project",
+ "pin-project 1.0.1",
  "pin-utils",
  "slab",
 ]
@@ -1246,9 +1250,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993f9e0baeed60001cf565546b0d3dbe6a6ad23f2bd31644a133c641eccf6d53"
+checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
 dependencies = [
  "bytes",
  "fnv",
@@ -1261,6 +1265,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
@@ -1300,7 +1305,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fa08a006102488bd9cd5b8013aabe84955cf5ae22e304c2caf655b633aefae3"
 dependencies = [
  "digest 0.8.1",
- "hmac",
+ "hmac 0.7.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51ab2f639c231793c5f6114bdb9bbe50a7dbbfcd7c7c6bd8475dec2d991e964f"
+dependencies = [
+ "digest 0.9.0",
+ "hmac 0.10.1",
 ]
 
 [[package]]
@@ -1309,8 +1324,18 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
 dependencies = [
- "crypto-mac",
+ "crypto-mac 0.7.0",
  "digest 0.8.1",
+]
+
+[[package]]
+name = "hmac"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
+dependencies = [
+ "crypto-mac 0.10.0",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -1353,12 +1378,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6cab2627acfc432780848602f3f558f7e9dd427352224b0d9324025796d2a5e"
 
 [[package]]
-name = "humantime"
-version = "1.3.0"
+name = "hwloc"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
+checksum = "657dd2f25a0ff8c4f19c4f7ab42d3ffad0a7f282b6e73adafa4b4448d95f60cf"
 dependencies = [
- "quick-error",
+ "bitflags 0.4.0",
+ "errno",
+ "libc",
+ "num",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1377,7 +1406,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project",
+ "pin-project 0.4.27",
  "socket2",
  "tokio",
  "tower-service",
@@ -1421,11 +1450,11 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a68371cf417889c9d7f98235b7102ea7c54fc59bcbd22f3dea785be9d27e40"
+checksum = "7baab56125e25686df467fe470785512329883aab42696d661247aca2a2896e4"
 dependencies = [
- "console 0.13.0",
+ "console",
  "lazy_static",
  "number_prefix",
  "regex",
@@ -1499,19 +1528,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "lexical-core"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db65c6da02e61f55dae90a0ae427b2a5f6b3e8db09f58d10efab23af92592616"
 dependencies = [
  "arrayvec",
- "bitflags",
+ "bitflags 1.2.1",
  "cfg-if 0.1.10",
  "ryu",
  "static_assertions",
@@ -1519,19 +1542,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
-
-[[package]]
-name = "libloading"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
-dependencies = [
- "cc",
- "winapi 0.3.9",
-]
+checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
 
 [[package]]
 name = "log"
@@ -1689,22 +1702,36 @@ version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18e2bdb23c45859609d624dddc0cddab4ac1a02132a9d9e180757243e3813cd2"
 dependencies = [
- "bellperson",
+ "bellperson 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2s_simd",
  "byteorder 1.3.4",
  "fff",
  "generic-array 0.13.2",
  "lazy_static",
  "log",
+ "paired 0.20.1",
+]
+
+[[package]]
+name = "neptune"
+version = "2.0.0"
+source = "git+https://github.com/filecoin-project/neptune?branch=blstrs-9#011b1dc971c1abb97c23439765c71ed51cb7ab0d"
+dependencies = [
+ "bellperson 0.9.3 (git+https://github.com/filecoin-project/bellperson?branch=blstrs-9)",
+ "blake2s_simd",
+ "byteorder 1.3.4",
+ "fff",
+ "generic-array 0.14.4",
+ "lazy_static",
+ "log",
  "neptune-triton",
- "paired",
 ]
 
 [[package]]
 name = "neptune-triton"
-version = "1.1.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c06d221737d1bc51247c5e82865a908fa4e821347933fa34de1a5adee6511ab"
+checksum = "9f9b8b2d3deb9989812a85ac2562eeacab362ad30de3fae867bdb6cc9be75935"
 dependencies = [
  "cc",
 ]
@@ -1890,7 +1917,7 @@ version = "0.10.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
 dependencies = [
- "bitflags",
+ "bitflags 1.2.1",
  "cfg-if 0.1.10",
  "foreign-types",
  "lazy_static",
@@ -1947,7 +1974,22 @@ dependencies = [
  "digest 0.8.1",
  "fff",
  "groupy",
- "hkdf",
+ "hkdf 0.8.0",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "paired"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42fc2daf8d5a8e22a9833f798e72c0d6862b5f0288f0a2d289b37cd03fa5e283"
+dependencies = [
+ "blake2b_simd",
+ "byteorder 1.3.4",
+ "digest 0.9.0",
+ "fff",
+ "groupy",
+ "hkdf 0.10.0",
  "rand_core 0.5.1",
  "serde",
 ]
@@ -1965,12 +2007,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
-
-[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1978,19 +2014,17 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "phase21"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0f11d2cea752b0c881f90b7c19208af1d08bb6d4e7cebe97c98af5ed0e3cd57"
+version = "0.9.0"
+source = "git+https://github.com/filecoin-project/phase2?branch=blstrs-9#aeaeb89125cd92baca6cdb732a9fae655d8f9833"
 dependencies = [
- "bellperson",
+ "bellperson 0.9.3 (git+https://github.com/filecoin-project/bellperson?branch=blstrs-9)",
  "blake2b_simd",
  "byteorder 1.3.4",
- "crossbeam",
+ "crossbeam 0.8.0",
  "fff",
  "groupy",
  "log",
  "num_cpus",
- "paired",
  "rand 0.7.3",
  "rand_chacha",
  "rayon",
@@ -2002,7 +2036,16 @@ version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
 dependencies = [
- "pin-project-internal",
+ "pin-project-internal 0.4.27",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee41d838744f60d959d7074e3afb6b35c7456d0f61cad38a24e35e6553f73841"
+dependencies = [
+ "pin-project-internal 1.0.1",
 ]
 
 [[package]]
@@ -2013,7 +2056,18 @@ checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.46",
+ "syn 1.0.48",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81a4ffa594b66bff340084d4081df649a7dc049ac8d7fc458d8e628bfbbb2f86"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.48",
 ]
 
 [[package]]
@@ -2073,7 +2127,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.46",
+ "syn 1.0.48",
  "version_check",
 ]
 
@@ -2090,9 +2144,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.18"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
@@ -2111,12 +2165,6 @@ checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid 0.2.1",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -2142,7 +2190,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "084325f9fb9f2c23e4c225be1a4799583badd1666c3c6bbc67bacc6147f20ba1"
 dependencies = [
- "crossbeam",
+ "crossbeam 0.7.3",
  "futures",
 ]
 
@@ -2236,7 +2284,7 @@ version = "7.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4a349ca83373cfa5d6dbb66fd76e58b2cca08da71a5f6400de0a0a6a9bceeaf"
 dependencies = [
- "bitflags",
+ "bitflags 1.2.1",
  "cc",
  "rustc_version 0.2.3",
 ]
@@ -2350,12 +2398,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
 
 [[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
 name = "rustc-serialize"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2407,7 +2449,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64808902d7d99f78eaddd2b4e2509713babc3dc3c85ad6f4c447680f3c01e535"
 dependencies = [
- "bitflags",
+ "bitflags 1.2.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2462,7 +2504,7 @@ checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.46",
+ "syn 1.0.48",
 ]
 
 [[package]]
@@ -2527,23 +2569,17 @@ dependencies = [
 [[package]]
 name = "sha2raw"
 version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57da614e847c49a01979ffa0d9a030d983c4bb6e78a13ff20203a0169deeff42"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=blstrs-9#5ae5c4704248f2cf3df81a1bf5b6576fd51c5240"
 dependencies = [
- "block-buffer 0.7.3",
+ "block-buffer 0.9.0",
+ "byteorder 1.3.4",
  "cpuid-bool",
  "digest 0.9.0",
  "fake-simd",
  "lazy_static",
- "opaque-debug 0.2.3",
+ "opaque-debug 0.3.0",
  "sha2-asm",
 ]
-
-[[package]]
-name = "shlex"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "simplelog"
@@ -2589,8 +2625,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "storage-proofs"
 version = "5.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22951abf58768eb8a6bdb91a2a7a6b92a82088add06a4939f478888f2c5bad72"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=blstrs-9#5ae5c4704248f2cf3df81a1bf5b6576fd51c5240"
 dependencies = [
  "storage-proofs-core",
  "storage-proofs-porep",
@@ -2599,32 +2634,28 @@ dependencies = [
 
 [[package]]
 name = "storage-proofs-core"
-version = "5.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed8f7b95d7bd3ad2a59846f6bdc320f41a409f14d1f498d2c9ccb2bb6b47bca"
+version = "5.2.3"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=blstrs-9#5ae5c4704248f2cf3df81a1bf5b6576fd51c5240"
 dependencies = [
  "aes",
  "anyhow",
- "bellperson",
+ "bellperson 0.9.3 (git+https://github.com/filecoin-project/bellperson?branch=blstrs-9)",
  "blake2b_simd",
  "blake2s_simd",
  "block-modes",
  "byteorder 1.3.4",
  "config",
  "fff",
- "fil-blst",
- "fil-sapling-crypto",
  "fs2",
- "generic-array 0.13.2",
+ "generic-array 0.14.4",
  "hex",
  "itertools 0.9.0",
  "lazy_static",
  "log",
  "memmap",
  "merkletree",
- "neptune",
+ "neptune 2.0.0",
  "num_cpus",
- "paired",
  "rand 0.7.3",
  "rand_chacha",
  "rayon",
@@ -2638,30 +2669,29 @@ dependencies = [
 
 [[package]]
 name = "storage-proofs-porep"
-version = "5.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b0fe4cd65e084e4dc5eb2a9133b21c67597dba77850e7ae785f9404232aef6"
+version = "5.2.3"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=blstrs-9#5ae5c4704248f2cf3df81a1bf5b6576fd51c5240"
 dependencies = [
  "anyhow",
- "bellperson",
+ "bellperson 0.9.3 (git+https://github.com/filecoin-project/bellperson?branch=blstrs-9)",
  "bincode",
  "byte-slice-cast",
  "byteorder 1.3.4",
- "crossbeam",
+ "crossbeam 0.8.0",
  "digest 0.9.0",
  "fff",
- "fil-sapling-crypto",
- "generic-array 0.13.2",
+ "generic-array 0.14.4",
  "hex",
+ "hwloc",
  "lazy_static",
+ "libc",
  "log",
  "mapr",
  "merkletree",
- "neptune",
+ "neptune 2.0.0",
  "num-bigint 0.2.6",
  "num-traits 0.2.12",
  "num_cpus",
- "paired",
  "pretty_assertions",
  "rand 0.7.3",
  "rayon",
@@ -2674,25 +2704,22 @@ dependencies = [
 
 [[package]]
 name = "storage-proofs-post"
-version = "5.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bdb4e40af847b14a869be21e8cbe6ff5755f2f3f56094071a46807a6fb70370"
+version = "5.2.3"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=blstrs-9#5ae5c4704248f2cf3df81a1bf5b6576fd51c5240"
 dependencies = [
  "anyhow",
- "bellperson",
+ "bellperson 0.9.3 (git+https://github.com/filecoin-project/bellperson?branch=blstrs-9)",
  "blake2b_simd",
  "blake2s_simd",
  "byteorder 1.3.4",
- "crossbeam",
+ "crossbeam 0.8.0",
  "fff",
- "fil-sapling-crypto",
- "generic-array 0.13.2",
+ "generic-array 0.14.4",
  "hex",
  "log",
  "merkletree",
- "neptune",
+ "neptune 2.0.0",
  "num_cpus",
- "paired",
  "rand 0.7.3",
  "rayon",
  "serde",
@@ -2727,7 +2754,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.46",
+ "syn 1.0.48",
 ]
 
 [[package]]
@@ -2735,6 +2762,12 @@ name = "subtle"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
+
+[[package]]
+name = "subtle"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
 
 [[package]]
 name = "syn"
@@ -2749,9 +2782,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.46"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad5de3220ea04da322618ded2c42233d02baca219d6f160a3e9c87cda16c942"
+checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -2766,7 +2799,7 @@ checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.46",
+ "syn 1.0.48",
  "unicode-xid 0.2.1",
 ]
 
@@ -2826,15 +2859,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termios"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2860,7 +2884,7 @@ checksum = "cae2447b6282786c3493999f40a9be2a6ad20cb8bd268b0a0dbf5a065535c0ab"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.46",
+ "syn 1.0.48",
 ]
 
 [[package]]
@@ -2870,6 +2894,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]
@@ -2965,6 +2998,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
+dependencies = [
+ "pin-project 0.4.27",
+ "tracing",
 ]
 
 [[package]]
@@ -3104,7 +3147,7 @@ dependencies = [
  "log",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.46",
+ "syn 1.0.48",
  "wasm-bindgen-shared",
 ]
 
@@ -3138,7 +3181,7 @@ checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
- "syn 1.0.46",
+ "syn 1.0.48",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3157,15 +3200,6 @@ checksum = "4bf6ef87ad7ae8008e15a355ce696bed26012b7caa21605188cfd8214ab51e2d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "which"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -3244,3 +3278,9 @@ name = "yansi"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc79f4a1e39857fc00c3f662cbf2651c771f00e9c15fe2abc341806bd46bd71"
+
+[[package]]
+name = "zeroize"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45af6a010d13e4cf5b54c94ba5a2b2eba5596b9e46bf5875612d332a1f2b3f86"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1716,7 +1716,7 @@ dependencies = [
 [[package]]
 name = "neptune"
 version = "2.0.0"
-source = "git+https://github.com/filecoin-project/neptune?branch=blstrs-9#3976fe9b7a24fbfc410a8ebc5bb375e8ff179b12"
+source = "git+https://github.com/filecoin-project/neptune?branch=blstrs-9#874c2969f6ad5ae25d58e425d240be4b7993e5b0"
 dependencies = [
  "bellperson 0.11.0",
  "blake2s_simd",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1716,7 +1716,7 @@ dependencies = [
 [[package]]
 name = "neptune"
 version = "2.0.0"
-source = "git+https://github.com/filecoin-project/neptune?branch=blstrs-9#07c4761c66d9e006f87f2efebaf5128a5005db3c"
+source = "git+https://github.com/filecoin-project/neptune?branch=blstrs-9#3976fe9b7a24fbfc410a8ebc5bb375e8ff179b12"
 dependencies = [
  "bellperson 0.11.0",
  "blake2s_simd",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "addr2line"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6a2d3371669ab3ca9797670853d61402b03d0b4b9ebf33d677dfa720203072"
+checksum = "7c0929d69e78dd9bf5408269919fcbcaeb2e35e5d43e5815517cdc6a8e11a423"
 dependencies = [
  "gimli",
 ]
@@ -111,9 +111,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.53"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707b586e0e2f247cbde68cdd2c3ce69ea7b7be43e1c5b426e37c9319c4b9838e"
+checksum = "2baad346b2d4e94a24347adeee9c7a93f412ee94b9cc26e5b59dea23848e9f28"
 dependencies = [
  "addr2line",
  "cfg-if 1.0.0",
@@ -388,7 +388,7 @@ checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
  "libc",
  "num-integer",
- "num-traits 0.2.12",
+ "num-traits 0.2.14",
  "time",
  "winapi 0.3.9",
 ]
@@ -834,7 +834,7 @@ checksum = "844b389fbe323d3b35ed1b3b119e75b11dca536d291d31342acea5b4c8984558"
 dependencies = [
  "num-bigint 0.2.6",
  "num-integer",
- "num-traits 0.2.12",
+ "num-traits 0.2.14",
  "proc-macro2 1.0.24",
  "quote 1.0.7",
  "syn 1.0.48",
@@ -860,7 +860,7 @@ dependencies = [
  "fil-ocl-core",
  "futures",
  "nodrop",
- "num-traits 0.2.12",
+ "num-traits 0.2.14",
  "qutex",
 ]
 
@@ -875,7 +875,7 @@ dependencies = [
  "enum_primitive",
  "failure",
  "num-complex",
- "num-traits 0.2.12",
+ "num-traits 0.2.14",
  "ocl-core-vector",
  "rustc_version 0.1.7",
 ]
@@ -1166,9 +1166,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
+checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
 name = "glob"
@@ -1638,9 +1638,9 @@ dependencies = [
 
 [[package]]
 name = "neptune"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799bb163055559f5baf86c76fa86f808a7ecb132ac8a2a1e53af0b904bfe5767"
+checksum = "9544fd96d146785c717b0b5373d3480f0a55a1d8169f668fb88df9760ea826fc"
 dependencies = [
  "bellperson",
  "blake2s_simd",
@@ -1700,7 +1700,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-rational",
- "num-traits 0.2.12",
+ "num-traits 0.2.14",
 ]
 
 [[package]]
@@ -1710,7 +1710,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1"
 dependencies = [
  "num-integer",
- "num-traits 0.2.12",
+ "num-traits 0.2.14",
  "rand 0.4.6",
  "rustc-serialize",
 ]
@@ -1723,7 +1723,7 @@ checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits 0.2.12",
+ "num-traits 0.2.14",
 ]
 
 [[package]]
@@ -1732,29 +1732,29 @@ version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b288631d7878aaf59442cffd36910ea604ecd7745c36054328595114001c9656"
 dependencies = [
- "num-traits 0.2.12",
+ "num-traits 0.2.14",
  "rustc-serialize",
 ]
 
 [[package]]
 name = "num-integer"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
- "num-traits 0.2.12",
+ "num-traits 0.2.14",
 ]
 
 [[package]]
 name = "num-iter"
-version = "0.1.41"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e6b7c748f995c4c29c5f5ae0248536e04a5739927c74ec0fa564805094b9f"
+checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits 0.2.12",
+ "num-traits 0.2.14",
 ]
 
 [[package]]
@@ -1765,7 +1765,7 @@ checksum = "ee314c74bd753fc86b4780aa9475da469155f3848473a261d2d18e35245a784e"
 dependencies = [
  "num-bigint 0.1.44",
  "num-integer",
- "num-traits 0.2.12",
+ "num-traits 0.2.14",
  "rustc-serialize",
 ]
 
@@ -1775,14 +1775,14 @@ version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 dependencies = [
- "num-traits 0.2.12",
+ "num-traits 0.2.14",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
 ]
@@ -1805,9 +1805,9 @@ checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
 
 [[package]]
 name = "object"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37fd5004feb2ce328a52b0b3d01dbf4ffff72583493900ed15f22d4111c51693"
+checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
 
 [[package]]
 name = "ocl-core-vector"
@@ -2613,7 +2613,7 @@ dependencies = [
  "merkletree",
  "neptune",
  "num-bigint 0.2.6",
- "num-traits 0.2.12",
+ "num-traits 0.2.14",
  "num_cpus",
  "pretty_assertions",
  "rand 0.7.3",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -164,8 +164,9 @@ dependencies = [
 
 [[package]]
 name = "bellperson"
-version = "0.9.3"
-source = "git+https://github.com/filecoin-project/bellperson?branch=blstrs-9#c4d5ba5a85603c64d036fec4fb1f89e43b0d03d5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab0cebe27517c36c61d88fc7d2b88f3b1680a918c862c731b08442d6a1d44141"
 dependencies = [
  "ahash 0.5.6",
  "bit-vec",
@@ -948,7 +949,7 @@ name = "filcrypto"
 version = "0.7.5"
 dependencies = [
  "anyhow",
- "bellperson 0.9.3 (git+https://github.com/filecoin-project/bellperson?branch=blstrs-9)",
+ "bellperson 0.11.0",
  "bls-signatures",
  "byteorder 1.3.4",
  "cbindgen",
@@ -970,10 +971,10 @@ dependencies = [
 [[package]]
 name = "filecoin-proofs"
 version = "5.2.3"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=blstrs-9#5ae5c4704248f2cf3df81a1bf5b6576fd51c5240"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=blstrs-9#2e9ff71ad49bb2317ddb7652d8bc004faba0f94a"
 dependencies = [
  "anyhow",
- "bellperson 0.9.3 (git+https://github.com/filecoin-project/bellperson?branch=blstrs-9)",
+ "bellperson 0.11.0",
  "bincode",
  "bitintr",
  "bitvec",
@@ -1018,10 +1019,10 @@ dependencies = [
 [[package]]
 name = "filecoin-proofs-api"
 version = "5.2.0"
-source = "git+https://github.com/filecoin-project/rust-filecoin-proofs-api?branch=blstrs#cdbc9c440e7b838d1abba06065074bb582554749"
+source = "git+https://github.com/filecoin-project/rust-filecoin-proofs-api?branch=blstrs#7c42d54b22848985dcc403669b2097d7d617ca4e"
 dependencies = [
  "anyhow",
- "bellperson 0.9.3 (git+https://github.com/filecoin-project/bellperson?branch=blstrs-9)",
+ "bellperson 0.11.0",
  "bincode",
  "filecoin-proofs",
  "serde",
@@ -1579,9 +1580,9 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
-version = "2.3.3"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "memmap"
@@ -1702,7 +1703,7 @@ version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18e2bdb23c45859609d624dddc0cddab4ac1a02132a9d9e180757243e3813cd2"
 dependencies = [
- "bellperson 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bellperson 0.9.3",
  "blake2s_simd",
  "byteorder 1.3.4",
  "fff",
@@ -1715,9 +1716,9 @@ dependencies = [
 [[package]]
 name = "neptune"
 version = "2.0.0"
-source = "git+https://github.com/filecoin-project/neptune?branch=blstrs-9#011b1dc971c1abb97c23439765c71ed51cb7ab0d"
+source = "git+https://github.com/filecoin-project/neptune?branch=blstrs-9#2e442c283ed3025a629d4983b5a63f83fa110afd"
 dependencies = [
- "bellperson 0.9.3 (git+https://github.com/filecoin-project/bellperson?branch=blstrs-9)",
+ "bellperson 0.11.0",
  "blake2s_simd",
  "byteorder 1.3.4",
  "fff",
@@ -2014,10 +2015,11 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "phase21"
-version = "0.9.0"
-source = "git+https://github.com/filecoin-project/phase2?branch=blstrs-9#aeaeb89125cd92baca6cdb732a9fae655d8f9833"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5fa3912a0a09b9e91c962676339c09eda05a5eabd5d6df3a71851cd1d926d6c"
 dependencies = [
- "bellperson 0.9.3 (git+https://github.com/filecoin-project/bellperson?branch=blstrs-9)",
+ "bellperson 0.11.0",
  "blake2b_simd",
  "byteorder 1.3.4",
  "crossbeam 0.8.0",
@@ -2569,7 +2571,7 @@ dependencies = [
 [[package]]
 name = "sha2raw"
 version = "2.0.0"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=blstrs-9#5ae5c4704248f2cf3df81a1bf5b6576fd51c5240"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=blstrs-9#2e9ff71ad49bb2317ddb7652d8bc004faba0f94a"
 dependencies = [
  "block-buffer 0.9.0",
  "byteorder 1.3.4",
@@ -2625,7 +2627,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "storage-proofs"
 version = "5.2.3"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=blstrs-9#5ae5c4704248f2cf3df81a1bf5b6576fd51c5240"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=blstrs-9#2e9ff71ad49bb2317ddb7652d8bc004faba0f94a"
 dependencies = [
  "storage-proofs-core",
  "storage-proofs-porep",
@@ -2635,11 +2637,11 @@ dependencies = [
 [[package]]
 name = "storage-proofs-core"
 version = "5.2.3"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=blstrs-9#5ae5c4704248f2cf3df81a1bf5b6576fd51c5240"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=blstrs-9#2e9ff71ad49bb2317ddb7652d8bc004faba0f94a"
 dependencies = [
  "aes",
  "anyhow",
- "bellperson 0.9.3 (git+https://github.com/filecoin-project/bellperson?branch=blstrs-9)",
+ "bellperson 0.11.0",
  "blake2b_simd",
  "blake2s_simd",
  "block-modes",
@@ -2670,10 +2672,10 @@ dependencies = [
 [[package]]
 name = "storage-proofs-porep"
 version = "5.2.3"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=blstrs-9#5ae5c4704248f2cf3df81a1bf5b6576fd51c5240"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=blstrs-9#2e9ff71ad49bb2317ddb7652d8bc004faba0f94a"
 dependencies = [
  "anyhow",
- "bellperson 0.9.3 (git+https://github.com/filecoin-project/bellperson?branch=blstrs-9)",
+ "bellperson 0.11.0",
  "bincode",
  "byte-slice-cast",
  "byteorder 1.3.4",
@@ -2705,10 +2707,10 @@ dependencies = [
 [[package]]
 name = "storage-proofs-post"
 version = "5.2.3"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=blstrs-9#5ae5c4704248f2cf3df81a1bf5b6576fd51c5240"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=blstrs-9#2e9ff71ad49bb2317ddb7652d8bc004faba0f94a"
 dependencies = [
  "anyhow",
- "bellperson 0.9.3 (git+https://github.com/filecoin-project/bellperson?branch=blstrs-9)",
+ "bellperson 0.11.0",
  "blake2b_simd",
  "blake2s_simd",
  "byteorder 1.3.4",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -48,15 +48,6 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
-dependencies = [
- "const-random",
-]
-
-[[package]]
-name = "ahash"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2deff5792519f5985c9cdd5a0399df3ca3419114841d282bae646acadbf0a99"
@@ -140,35 +131,11 @@ checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "bellperson"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9655742fc4c6f41f1412dba38342af29ef2a4ad05ba44613785b0d34edff0382"
-dependencies = [
- "ahash 0.3.8",
- "bit-vec",
- "blake2s_simd",
- "byteorder 1.3.4",
- "crossbeam-channel 0.4.4",
- "fff",
- "groupy",
- "lazy_static",
- "log",
- "memmap",
- "num_cpus",
- "paired 0.20.1",
- "rand 0.7.3",
- "rand_core 0.5.1",
- "rayon",
- "thiserror",
-]
-
-[[package]]
-name = "bellperson"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab0cebe27517c36c61d88fc7d2b88f3b1680a918c862c731b08442d6a1d44141"
 dependencies = [
- "ahash 0.5.6",
+ "ahash",
  "bit-vec",
  "blake2s_simd",
  "blstrs",
@@ -485,26 +452,6 @@ dependencies = [
  "unicode-width",
  "winapi 0.3.9",
  "winapi-util",
-]
-
-[[package]]
-name = "const-random"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02dc82c12dc2ee6e1ded861cf7d582b46f66f796d1b6c93fa28b911ead95da02"
-dependencies = [
- "const-random-macro",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "const-random-macro"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc757bbb9544aa296c2ae00c679e81f886b37e28e59097defe0cf524306f6685"
-dependencies = [
- "getrandom 0.2.0",
- "proc-macro-hack",
 ]
 
 [[package]]
@@ -949,7 +896,7 @@ name = "filcrypto"
 version = "0.7.5"
 dependencies = [
  "anyhow",
- "bellperson 0.11.0",
+ "bellperson",
  "bls-signatures",
  "byteorder 1.3.4",
  "cbindgen",
@@ -960,7 +907,6 @@ dependencies = [
  "filecoin-proofs-api",
  "libc",
  "log",
- "neptune 1.2.3",
  "rand 0.7.3",
  "rand_chacha",
  "rayon",
@@ -970,11 +916,12 @@ dependencies = [
 
 [[package]]
 name = "filecoin-proofs"
-version = "5.2.3"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=blstrs-9#2e9ff71ad49bb2317ddb7652d8bc004faba0f94a"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16844ea3ba6ac49ab40b2c8bd45e1fcc25f2580f4460658f0bfdddbdc3a75aed"
 dependencies = [
  "anyhow",
- "bellperson 0.11.0",
+ "bellperson",
  "bincode",
  "bitintr",
  "bitvec",
@@ -1018,11 +965,12 @@ dependencies = [
 
 [[package]]
 name = "filecoin-proofs-api"
-version = "5.2.0"
-source = "git+https://github.com/filecoin-project/rust-filecoin-proofs-api?branch=blstrs#7c42d54b22848985dcc403669b2097d7d617ca4e"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c2d38ac0a9f9ef88d8e82c964fb47d3da52a186ca6a9527ecb6407ac29d457"
 dependencies = [
  "anyhow",
- "bellperson 0.11.0",
+ "bellperson",
  "bincode",
  "filecoin-proofs",
  "serde",
@@ -1180,15 +1128,6 @@ name = "generic-array"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
-dependencies = [
- "typenum",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed1e761351b56f54eb9dcd0cfaca9fd0daecf93918e1cfc01c8a3d26ee7adcd"
 dependencies = [
  "typenum",
 ]
@@ -1699,26 +1638,11 @@ dependencies = [
 
 [[package]]
 name = "neptune"
-version = "1.2.3"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e2bdb23c45859609d624dddc0cddab4ac1a02132a9d9e180757243e3813cd2"
+checksum = "799bb163055559f5baf86c76fa86f808a7ecb132ac8a2a1e53af0b904bfe5767"
 dependencies = [
- "bellperson 0.9.3",
- "blake2s_simd",
- "byteorder 1.3.4",
- "fff",
- "generic-array 0.13.2",
- "lazy_static",
- "log",
- "paired 0.20.1",
-]
-
-[[package]]
-name = "neptune"
-version = "2.0.0"
-source = "git+https://github.com/filecoin-project/neptune?branch=blstrs-9#874c2969f6ad5ae25d58e425d240be4b7993e5b0"
-dependencies = [
- "bellperson 0.11.0",
+ "bellperson",
  "blake2s_simd",
  "byteorder 1.3.4",
  "fff",
@@ -2019,7 +1943,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5fa3912a0a09b9e91c962676339c09eda05a5eabd5d6df3a71851cd1d926d6c"
 dependencies = [
- "bellperson 0.11.0",
+ "bellperson",
  "blake2b_simd",
  "byteorder 1.3.4",
  "crossbeam 0.8.0",
@@ -2143,12 +2067,6 @@ dependencies = [
  "quote 1.0.7",
  "version_check",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
@@ -2571,15 +2489,15 @@ dependencies = [
 [[package]]
 name = "sha2raw"
 version = "2.0.0"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=blstrs-9#2e9ff71ad49bb2317ddb7652d8bc004faba0f94a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57da614e847c49a01979ffa0d9a030d983c4bb6e78a13ff20203a0169deeff42"
 dependencies = [
- "block-buffer 0.9.0",
- "byteorder 1.3.4",
+ "block-buffer 0.7.3",
  "cpuid-bool",
  "digest 0.9.0",
  "fake-simd",
  "lazy_static",
- "opaque-debug 0.3.0",
+ "opaque-debug 0.2.3",
  "sha2-asm",
 ]
 
@@ -2626,8 +2544,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-proofs"
-version = "5.2.3"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=blstrs-9#2e9ff71ad49bb2317ddb7652d8bc004faba0f94a"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f0b9cb2af1e4687e95168a160ce75af1e780ce277083975cfffee19535f2927"
 dependencies = [
  "storage-proofs-core",
  "storage-proofs-porep",
@@ -2636,12 +2555,13 @@ dependencies = [
 
 [[package]]
 name = "storage-proofs-core"
-version = "5.2.3"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=blstrs-9#2e9ff71ad49bb2317ddb7652d8bc004faba0f94a"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7168624bf6fde20d30effdaf60b792e35c4631d4c90272623e085fb561f7b362"
 dependencies = [
  "aes",
  "anyhow",
- "bellperson 0.11.0",
+ "bellperson",
  "blake2b_simd",
  "blake2s_simd",
  "block-modes",
@@ -2656,7 +2576,7 @@ dependencies = [
  "log",
  "memmap",
  "merkletree",
- "neptune 2.0.0",
+ "neptune",
  "num_cpus",
  "rand 0.7.3",
  "rand_chacha",
@@ -2671,11 +2591,12 @@ dependencies = [
 
 [[package]]
 name = "storage-proofs-porep"
-version = "5.2.3"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=blstrs-9#2e9ff71ad49bb2317ddb7652d8bc004faba0f94a"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c978e4d0b24810eb6fff2d733c79244a9edf15e462c507c373484243bb916158"
 dependencies = [
  "anyhow",
- "bellperson 0.11.0",
+ "bellperson",
  "bincode",
  "byte-slice-cast",
  "byteorder 1.3.4",
@@ -2690,7 +2611,7 @@ dependencies = [
  "log",
  "mapr",
  "merkletree",
- "neptune 2.0.0",
+ "neptune",
  "num-bigint 0.2.6",
  "num-traits 0.2.12",
  "num_cpus",
@@ -2706,11 +2627,12 @@ dependencies = [
 
 [[package]]
 name = "storage-proofs-post"
-version = "5.2.3"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=blstrs-9#2e9ff71ad49bb2317ddb7652d8bc004faba0f94a"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "905e4d1a409b859c4d7a0feae7f753f05741426fdfdd84c2d61b8ed333bb1dca"
 dependencies = [
  "anyhow",
- "bellperson 0.11.0",
+ "bellperson",
  "blake2b_simd",
  "blake2s_simd",
  "byteorder 1.3.4",
@@ -2720,7 +2642,7 @@ dependencies = [
  "hex",
  "log",
  "merkletree",
- "neptune 2.0.0",
+ "neptune",
  "num_cpus",
  "rand 0.7.3",
  "rayon",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1716,7 +1716,7 @@ dependencies = [
 [[package]]
 name = "neptune"
 version = "2.0.0"
-source = "git+https://github.com/filecoin-project/neptune?branch=blstrs-9#2e442c283ed3025a629d4983b5a63f83fa110afd"
+source = "git+https://github.com/filecoin-project/neptune?branch=blstrs-9#07c4761c66d9e006f87f2efebaf5128a5005db3c"
 dependencies = [
  "bellperson 0.11.0",
  "blake2s_simd",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -27,13 +27,10 @@ rayon = "1.2.1"
 anyhow = "1.0.23"
 bellperson = { version = "0.11", default-features = false, features = ["gpu"] }
 serde_json = "1.0.46"
-neptune = "~1.2"
 
 [dependencies.filecoin-proofs-api]
 package = "filecoin-proofs-api"
-# version = "5.2.0"
-git = "https://github.com/filecoin-project/rust-filecoin-proofs-api"
-branch = "blstrs"
+version = "5.3.0"
 default-features = false
 
 [build-dependencies]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -20,22 +20,29 @@ ff = { version = "0.2.1", package = "fff" }
 ffi-toolkit = "0.4.0"
 libc = "0.2.58"
 log = "0.4.7"
-paired = "0.20.0"
 fil_logger = "0.1.0"
 rand = "0.7"
 rand_chacha = "0.2.1"
 rayon = "1.2.1"
 anyhow = "1.0.23"
-bellperson = { version = "0.9.2", features = ["gpu"] }
+bellperson = { git = "https://github.com/filecoin-project/bellperson", branch = "blstrs-9", default-features = false, features = ["gpu"] }
 serde_json = "1.0.46"
 neptune = "~1.2"
 
 [dependencies.filecoin-proofs-api]
 package = "filecoin-proofs-api"
-version = "5.2.0"
+# version = "5.2.0"
+git = "https://github.com/filecoin-project/rust-filecoin-proofs-api"
+branch = "blstrs"
+default-features = false
 
 [build-dependencies]
 cbindgen = "= 0.14.0"
 
 [dev-dependencies]
 tempfile = "3.0.8"
+
+[features]
+default = ["pairing"]
+pairing = ["filecoin-proofs-api/pairing", "bellperson/pairing"]
+blst = ["filecoin-proofs-api/blst", "bellperson/blst"]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -25,7 +25,7 @@ rand = "0.7"
 rand_chacha = "0.2.1"
 rayon = "1.2.1"
 anyhow = "1.0.23"
-bellperson = { git = "https://github.com/filecoin-project/bellperson", branch = "blstrs-9", default-features = false, features = ["gpu"] }
+bellperson = { version = "0.11", default-features = false, features = ["gpu"] }
 serde_json = "1.0.46"
 neptune = "~1.2"
 


### PR DESCRIPTION
Depends on 

- [x] https://github.com/filecoin-project/rust-filecoin-proofs-api/pull/46 -> 5.3.0

TODO

- [x] update make file and ci