### PR TITLE
Add Version const

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,0 +1,6 @@
+package ffi
+
+// Version is most similar to semver's minor version.
+// It is here as we cannot use gomod versioning due to local replace directives
+// for native dependencies.
+const Version int = 1


### PR DESCRIPTION
To avoid issues similar to the most recent upgrade where,
interface did not change but new proof type got introduced and some
users did not upgrade filecoin-ffi in Lotus.