### PR TITLE
Remove tmp prefix from tar path

### DIFF
--- a/rust/scripts/package-release.sh
+++ b/rust/scripts/package-release.sh
@@ -24,13 +24,14 @@ main() {
 
     # copy assets into temporary directory
     #
-    find -L . -type f -name filcrypto.h -exec cp -- "{}" $__tmp_dir/ \;
-    find -L . -type f -name libfilcrypto.a -exec cp -- "{}" $__tmp_dir/ \;
-    find -L . -type f -name filcrypto.pc -exec cp -- "{}" $__tmp_dir/ \;
+    mkdir $__tmp_dir/filcrypto
+    find -L . -type f -name filcrypto.h -exec cp -- "{}" $__tmp_dir/filcrypto \;
+    find -L . -type f -name libfilcrypto.a -exec cp -- "{}" $__tmp_dir/filcrypto \;
+    find -L . -type f -name filcrypto.pc -exec cp -- "{}" $__tmp_dir/filcrypto \;
 
     # create gzipped tarball from contents of temporary directory
     #
-    tar -czf $__tarball_output_path $__tmp_dir/*
+    tar -czf $__tarball_output_path -C $__tmp_dir filcrypto/*
 
     (>&2 echo "[package-release/main] release file created: $__tarball_output_path")
 }


### PR DESCRIPTION
Currently release tarballs contain temporary path in filenames.
It requires extra scripting to extract and use the files (e.g. using `find`).
```
$ tar -tf <(curl -Ls https://github.com/filecoin-project/filecoin-ffi/releases/download/1d9cb3e8ff53f51f/filecoin-ffi-Darwin-standard-pairing.tar.gz)

var/folders/gk/lkr9pm5x039fx6d3j9r52rv80000gn/T/tmp.M9Jia6UQ/filcrypto.h
var/folders/gk/lkr9pm5x039fx6d3j9r52rv80000gn/T/tmp.M9Jia6UQ/filcrypto.pc
var/folders/gk/lkr9pm5x039fx6d3j9r52rv80000gn/T/tmp.M9Jia6UQ/libfilcrypto.a
```

This PR suggests changes that make tarball paths clear and simple like
```
filcrypto/filcrypto.h
filcrypto/filcrypto.pc
filcrypto/libfilcrypto.a
```