### PR TITLE
feat: add -Zfeatures=itarget to support conditional compilation of dependency feature based on target

### DIFF
--- a/install-filcrypto
+++ b/install-filcrypto
@@ -150,12 +150,13 @@ build_from_source() {
     cargo --version
 
     # Add feature specific rust flags as needed here.
+    additional_flags="-Zfeatures=itarget"
     if [ "${FFI_USE_BLST_PORTABLE}" == "1" ]; then
-        additional_flags="--no-default-features --features blst --features blst-portable"
+        additional_flags="--no-default-features --features blst --features blst-portable ${additional_flags}"
     elif [ "${FFI_USE_BLST}" == "1" ]; then
-        additional_flags="--no-default-features --features blst"
+        additional_flags="--no-default-features --features blst ${additional_flags}"
     else
-        additional_flags="--no-default-features --features pairing"
+        additional_flags="--no-default-features --features pairing ${additional_flags}"
     fi
 
     if [ -n "${__release_flags}" ]; then


### PR DESCRIPTION
This is related to https://github.com/filecoin-project/rust-fil-proofs/pull/1404.
We want to enable the feature `compress, asm` on aarch64 for `sha2`, while only enable feature `compress` on `x86`.
The `-Zfeatures=itarget` is necessary for supporting conditional compilation of dependency feature based on target [1][2].

[1] https://github.com/rust-lang/cargo/issues/2524
[2] https://github.com/rust-lang/cargo/issues/7914