### PR TITLE
Revert "Remove tmp prefix from tar path"

### DIFF
--- a/rust/scripts/package-release.sh
+++ b/rust/scripts/package-release.sh
@@ -24,14 +24,13 @@ main() {
 
     # copy assets into temporary directory
     #
-    mkdir $__tmp_dir/filcrypto
-    find -L . -type f -name filcrypto.h -exec cp -- "{}" $__tmp_dir/filcrypto \;
-    find -L . -type f -name libfilcrypto.a -exec cp -- "{}" $__tmp_dir/filcrypto \;
-    find -L . -type f -name filcrypto.pc -exec cp -- "{}" $__tmp_dir/filcrypto \;
+    find -L . -type f -name filcrypto.h -exec cp -- "{}" $__tmp_dir/ \;
+    find -L . -type f -name libfilcrypto.a -exec cp -- "{}" $__tmp_dir/ \;
+    find -L . -type f -name filcrypto.pc -exec cp -- "{}" $__tmp_dir/ \;
 
     # create gzipped tarball from contents of temporary directory
     #
-    tar -czf $__tarball_output_path -C $__tmp_dir filcrypto/*
+    tar -czf $__tarball_output_path $__tmp_dir/*
 
     (>&2 echo "[package-release/main] release file created: $__tarball_output_path")
 }


### PR DESCRIPTION
Reverts filecoin-project/filecoin-ffi#158 - it breaks the publish CI -> https://app.circleci.com/pipelines/github/filecoin-project/filecoin-ffi/975/workflows/37041e94-3dea-4c02-9878-f2c2369c2531/jobs/5277

```
...
+ trap '{ rm -rf $__tmp_dir; }' EXIT
+ mkdir /tmp/tmp.GpgYd9uoil/filcrypto
+ find -L . -type f -name filcrypto.h -exec cp -- '{}' /tmp/tmp.GpgYd9uoil/filcrypto ';'
+ find -L . -type f -name libfilcrypto.a -exec cp -- '{}' /tmp/tmp.GpgYd9uoil/filcrypto ';'
+ find -L . -type f -name filcrypto.pc -exec cp -- '{}' /tmp/tmp.GpgYd9uoil/filcrypto ';'
+ tar -czf /tmp/filecoin-ffi-Linux-standard-pairing.tar.gz -C /tmp/tmp.GpgYd9uoil 'filcrypto/*'
tar: filcrypto/*: Cannot stat: No such file or directory
tar: Exiting with failure status due to previous errors
+ rm -rf /tmp/tmp.GpgYd9uoil
```