### PR TITLE
don't require rustup

### DIFF
--- a/install-filcrypto
+++ b/install-filcrypto
@@ -139,12 +139,6 @@ build_from_source() {
         exit 1
     fi
 
-    if ! [ -x "$(command -v rustup)" ]; then
-        (>&2 echo '[build_from_source] Error: rustup is not installed.')
-        (>&2 echo '[build_from_source] install Rust toolchain installer to resolve this problem.')
-        exit 1
-    fi
-
     pushd "${__rust_sources_path}"
 
     cargo --version

--- a/install-filcrypto
+++ b/install-filcrypto
@@ -139,9 +139,16 @@ build_from_source() {
         exit 1
     fi
 
+    if ! [ -x "$(command -v rustc)" ]; then
+        (>&2 echo '[build_from_source] Error: rust is not installed.')
+        (>&2 echo '[build_from_source] install Rust toolchain to resolve this problem.')
+        exit 1
+    fi
+
     pushd "${__rust_sources_path}"
 
     cargo --version
+    rustc --version
 
     # Default to use gpu flags, unless specified to disable
     gpu_flags=",gpu"


### PR DESCRIPTION
rustup isn't actually required to build.

The specific reason I'm requesting this change that the macos brew installation could include rust as a dependency, but it seems inappropriate to run rustup-init as part of the build. Instead, I should be able to use the system rust toolchain.

There are probably other situations where you want to build FFI and use the system rust.