### PR TITLE
feat: swap pairing for blst (vmx edition)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,12 @@ jobs:
       - prepare:
           linux: false
           darwin: true
+      - run: cd rust && rustup install $(cat rust-toolchain)
+      - run: cd rust && rustup target add x86_64-apple-darwin --toolchain $(cat rust-toolchain)
+      - run: cd rust && rustup target add aarch64-apple-darwin --toolchain $(cat rust-toolchain)
+      - run: cd rust && rustup default $(cat rust-toolchain)
+      - run: cd rust && cargo fetch
+      - run: cd rust && cargo install cargo-lipo
       - build_project
       - compile_tests
       - ensure_generated_cgo_up_to_date

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,10 +162,10 @@ jobs:
       - run: cd rust && cargo fetch
       - run:
           name: Run cargo clippy (pairing)
-          command: cd rust && cargo +$(cat rust-toolchain) clippy --all-targets -- -D warnings
+          command: cd rust && cargo +$(cat rust-toolchain) clippy --all-targets --no-default-features --features multicore-sdr,pairing,blst-portable -- -D warnings
       - run:
           name: Run cargo clippy (blst)
-          command: cd rust && cargo +$(cat rust-toolchain) clippy --all-targets --no-default-features --features multicore-sdr --features blst -- -D warnings
+          command: cd rust && cargo +$(cat rust-toolchain) clippy --all-targets --no-default-features --features multicore-sdr,blst,blst-portable -- -D warnings
 
 workflows:
   version: 2
@@ -262,7 +262,7 @@ commands:
             RELEASE_NAME="${CIRCLE_PROJECT_REPONAME}-$(uname)-standard-pairing"
 
             # Note: the blst dependency uses the portable configuration for maximum compatibility
-            ./scripts/build-release.sh filcrypto $(cat ./rust-toolchain) build --verbose --locked --no-default-features --features multicore-sdr --features pairing,gpu --features blst-portable
+            ./scripts/build-release.sh filcrypto $(cat ./rust-toolchain) build --verbose --locked --no-default-features --features multicore-sdr,pairing,gpu,blst-portable
             ./scripts/package-release.sh $TARBALL_PATH
             ./scripts/publish-release.sh $TARBALL_PATH $RELEASE_NAME
       - run:
@@ -274,7 +274,7 @@ commands:
             RELEASE_NAME="${CIRCLE_PROJECT_REPONAME}-$(uname)-standard-blst"
 
             # Note: the blst dependency uses the portable configuration for maximum compatibility
-            ./scripts/build-release.sh filcrypto $(cat ./rust-toolchain) build --verbose --locked --no-default-features --features multicore-sdr --features blst,gpu --features blst-portable
+            ./scripts/build-release.sh filcrypto $(cat ./rust-toolchain) build --verbose --locked --no-default-features --features multicore-sdr,blst,gpu,blst-portable
             ./scripts/package-release.sh $TARBALL_PATH
             ./scripts/publish-release.sh $TARBALL_PATH $RELEASE_NAME
       - run:
@@ -285,7 +285,7 @@ commands:
             TARBALL_PATH="/tmp/${CIRCLE_PROJECT_REPONAME}-$(uname)-optimized.tar.gz"
             RUSTFLAGS="-C target-feature=$(cat rustc-target-features-optimized.json | jq -r '.[].rustc_target_feature' | tr '\n' ',')"
 
-            ./scripts/build-release.sh filcrypto $(cat ./rust-toolchain) build --verbose --locked --no-default-features --features multicore-sdr --features pairing,gpu
+            ./scripts/build-release.sh filcrypto $(cat ./rust-toolchain) build --verbose --locked --no-default-features --features multicore-sdr,pairing,gpu
             ./scripts/package-release.sh $TARBALL_PATH
       - run:
           name: Build the optimized release (blst)
@@ -371,13 +371,13 @@ commands:
           steps:
             - run:
                 name: Build project (blst)
-                command: FFI_USE_BLST=1 make
+                command: make
       - unless:
           condition: << parameters.blst >>
           steps:
             - run:
                 name: Build project (pairing)
-                command: make
+                command: FFI_USE_PAIRING=1 make
                 
       - run:
           name: Build project without CGO

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
       - run: cd rust && rustup default $(cat rust-toolchain)
       - run: cd rust && cargo fetch
       - run: cd rust && cargo install cargo-lipo
-      - build_project
+      - build_project_no_gpu
       - compile_tests
       - ensure_generated_cgo_up_to_date
   publish_linux_staticlib:
@@ -385,6 +385,30 @@ commands:
                 name: Build project (pairing)
                 command: FFI_USE_PAIRING=1 make
                 
+      - run:
+          name: Build project without CGO
+          command: env CGO_ENABLED=0 go build .
+
+  build_project_no_gpu:
+    parameters:
+      blst:
+        default: false
+        description: build with blst backend?
+        type: boolean
+    steps:
+      - when:
+          condition: << parameters.blst >>
+          steps:
+            - run:
+                name: Build project (blst)
+                command: FFI_USE_GPU=0 make
+      - unless:
+          condition: << parameters.blst >>
+          steps:
+            - run:
+                name: Build project (pairing)
+                command: FFI_USE_GPU=0 FFI_USE_PAIRING=1 make
+
       - run:
           name: Build project without CGO
           command: env CGO_ENABLED=0 go build .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,6 +223,7 @@ commands:
           steps:
             - go/install-ssh
             - go/install: {package: git}
+            - run: sudo apt update
             - run: sudo apt-get update
             - run: sudo apt-get install -y jq valgrind ocl-icd-opencl-dev clang libssl-dev libhwloc-dev
             - run: curl https://sh.rustup.rs -sSf | sh -s -- -y

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
     parameters:
       run_leak_detector:
         type: boolean
-        default: false
+        default: true
     executor: golang
     working_directory: ~/go/src/github.com/filecoin-project/filecoin-ffi
     steps:
@@ -57,7 +57,7 @@ jobs:
     parameters:
       run_leak_detector:
         type: boolean
-        default: false
+        default: true
     executor: golang
     working_directory: ~/go/src/github.com/filecoin-project/filecoin-ffi
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,7 +314,7 @@ commands:
             TARBALL_PATH="/tmp/${RELEASE_NAME}.tar.gz"
 
             # Note: the blst dependency uses the portable configuration for maximum compatibility
-            ./scripts/build-release.sh filcrypto $(cat rust-toolchain) lipo --targets x86_64-apple-darwin,aarch64-apple-darwin --verbose --locked --no-default-features --features multicore-sdr,pairing,gpu,blst-portable
+            ./scripts/build-release.sh filcrypto $(cat rust-toolchain) lipo --targets x86_64-apple-darwin,aarch64-apple-darwin --verbose --locked --no-default-features --features multicore-sdr,pairing,blst-portable
             ./scripts/package-release.sh $TARBALL_PATH
             ./scripts/publish-release.sh $TARBALL_PATH $RELEASE_NAME
       - run:
@@ -326,7 +326,7 @@ commands:
             TARBALL_PATH="/tmp/${RELEASE_NAME}.tar.gz"
 
             # Note: the blst dependency uses the portable configuration for maximum compatibility
-            ./scripts/build-release.sh filcrypto $(cat rust-toolchain) lipo --targets x86_64-apple-darwin,aarch64-apple-darwin --verbose --locked --no-default-features --features multicore-sdr,blst,gpu,blst-portable
+            ./scripts/build-release.sh filcrypto $(cat rust-toolchain) lipo --targets x86_64-apple-darwin,aarch64-apple-darwin --verbose --locked --no-default-features --features multicore-sdr,blst,blst-portable
             ./scripts/package-release.sh $TARBALL_PATH
             ./scripts/publish-release.sh $TARBALL_PATH $RELEASE_NAME
   configure_environment_variables:
@@ -363,7 +363,7 @@ commands:
           cd $(mktemp -d)
           GOPATH=/tmp GO111MODULE=off go get github.com/filecoin-project/go-paramfetch/paramfetch
           GOPATH=/tmp GO111MODULE=off go build -o go-paramfetch github.com/filecoin-project/go-paramfetch/paramfetch
-          ./go-paramfetch 2048 "${DIR}/parameters.json"
+          ./go-paramfetch 2048 "${DIR}/parameters.json" "${DIR}/srs-inner-product.json"
 
   build_project:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
       - run: cd rust && rustup default $(cat rust-toolchain)
       - run: cd rust && cargo fetch
       - run: cd rust && cargo install cargo-lipo
-      - build_project_no_gpu
+      - build_project
       - compile_tests
       - ensure_generated_cgo_up_to_date
   publish_linux_staticlib:
@@ -314,7 +314,7 @@ commands:
             TARBALL_PATH="/tmp/${RELEASE_NAME}.tar.gz"
 
             # Note: the blst dependency uses the portable configuration for maximum compatibility
-            ./scripts/build-release.sh filcrypto $(cat rust-toolchain) lipo --targets x86_64-apple-darwin,aarch64-apple-darwin --verbose --locked --no-default-features --features multicore-sdr,pairing,blst-portable
+            ./scripts/build-release.sh filcrypto $(cat rust-toolchain) lipo --targets x86_64-apple-darwin,aarch64-apple-darwin --verbose --locked --no-default-features --features multicore-sdr,pairing,gpu,blst-portable
             ./scripts/package-release.sh $TARBALL_PATH
             ./scripts/publish-release.sh $TARBALL_PATH $RELEASE_NAME
       - run:
@@ -326,7 +326,7 @@ commands:
             TARBALL_PATH="/tmp/${RELEASE_NAME}.tar.gz"
 
             # Note: the blst dependency uses the portable configuration for maximum compatibility
-            ./scripts/build-release.sh filcrypto $(cat rust-toolchain) lipo --targets x86_64-apple-darwin,aarch64-apple-darwin --verbose --locked --no-default-features --features multicore-sdr,blst,blst-portable
+            ./scripts/build-release.sh filcrypto $(cat rust-toolchain) lipo --targets x86_64-apple-darwin,aarch64-apple-darwin --verbose --locked --no-default-features --features multicore-sdr,blst,gpu,blst-portable
             ./scripts/package-release.sh $TARBALL_PATH
             ./scripts/publish-release.sh $TARBALL_PATH $RELEASE_NAME
   configure_environment_variables:
@@ -385,30 +385,6 @@ commands:
                 name: Build project (pairing)
                 command: FFI_USE_PAIRING=1 make
                 
-      - run:
-          name: Build project without CGO
-          command: env CGO_ENABLED=0 go build .
-
-  build_project_no_gpu:
-    parameters:
-      blst:
-        default: false
-        description: build with blst backend?
-        type: boolean
-    steps:
-      - when:
-          condition: << parameters.blst >>
-          steps:
-            - run:
-                name: Build project (blst)
-                command: FFI_USE_GPU=0 make
-      - unless:
-          condition: << parameters.blst >>
-          steps:
-            - run:
-                name: Build project (pairing)
-                command: FFI_USE_GPU=0 FFI_USE_PAIRING=1 make
-
       - run:
           name: Build project without CGO
           command: env CGO_ENABLED=0 go build .

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ By default, the `blst` backend is used instead of `pairing`, but pairing can be 
 ```shell
 rm .install-filcrypto \
     ; make clean \
-    ; FFI_BUILD_FROM_SOURCE=1 make
+    ; FFI_BUILD_FROM_SOURCE=1 FFI_USE_PAIRING=1 make
 ```
 
 To allow portable building of the `blst` dependency, set `FFI_USE_BLST_PORTABLE=1`:
@@ -47,7 +47,7 @@ By default, a 'gpu' option is used in the proofs library*.  This feature is also
 ```shell
 rm .install-filcrypto \
     ; make clean \
-    ; FFI_BUILD_FROM_SOURCE=1 FFI_USE_PAIRING=1 FFI_USE_GPU=0 make
+    ; FFI_BUILD_FROM_SOURCE=1 FFI_USE_GPU=0 make
 ```
 
 *Note that OS X will always disable GPU support as it's not supported on that platform (the required opencl support is unavailable).

--- a/README.md
+++ b/README.md
@@ -42,15 +42,13 @@ rm .install-filcrypto \
     ; FFI_BUILD_FROM_SOURCE=1 FFI_USE_BLST_PORTABLE=1 make
 ```
 
-By default, a 'gpu' option is used in the proofs library*.  This feature is also used in FFI unless explicitly disabled.  To disable building with the 'gpu' dependency, set `FFI_USE_GPU=0`:
+By default, a 'gpu' option is used in the proofs library.  This feature is also used in FFI unless explicitly disabled.  To disable building with the 'gpu' dependency, set `FFI_USE_GPU=0`:
 
 ```shell
 rm .install-filcrypto \
     ; make clean \
     ; FFI_BUILD_FROM_SOURCE=1 FFI_USE_GPU=0 make
 ```
-
-*Note that OS X will always disable GPU support as it's not supported on that platform (the required opencl support is unavailable).
 
 By default, a 'multicore-sdr' option is used in the proofs library.  This feature is also used in FFI unless explicitly disabled.  To disable building with the 'multicore-sdr' dependency, set `FFI_USE_MULTICORE_SDR=0`:
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ The disadvantage to downloading the pre-built binary is that it will not be opti
 
 To opt out of downloading precompiled assets, set `FFI_BUILD_FROM_SOURCE=1`:
 
+By default, the `blst` backend is used instead of `pairing`, but this can be enabled using `FFI_USE_PAIRING=1` in the environment.
+
 ```shell
 rm .install-filcrypto \
     ; make clean \
@@ -45,7 +47,7 @@ By default, a 'gpu' option is used in the proofs library.  This feature is also 
 ```shell
 rm .install-filcrypto \
     ; make clean \
-    ; FFI_BUILD_FROM_SOURCE=1 FFI_USE_BLST=1 FFI_USE_GPU=0 make
+    ; FFI_BUILD_FROM_SOURCE=1 FFI_USE_PAIRING=1 FFI_USE_GPU=0 make
 ```
 
 By default, a 'multicore-sdr' option is used in the proofs library.  This feature is also used in FFI unless explicitly disabled.  To disable building with the 'multicore-sdr' dependency, set `FFI_USE_MULTICORE_SDR=0`:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The disadvantage to downloading the pre-built binary is that it will not be opti
 
 To opt out of downloading precompiled assets, set `FFI_BUILD_FROM_SOURCE=1`:
 
-By default, the `blst` backend is used instead of `pairing`, but this can be enabled using `FFI_USE_PAIRING=1` in the environment.
+By default, the `blst` backend is used instead of `pairing`, but pairing can be enabled using `FFI_USE_PAIRING=1` in the environment.
 
 ```shell
 rm .install-filcrypto \

--- a/README.md
+++ b/README.md
@@ -42,13 +42,15 @@ rm .install-filcrypto \
     ; FFI_BUILD_FROM_SOURCE=1 FFI_USE_BLST_PORTABLE=1 make
 ```
 
-By default, a 'gpu' option is used in the proofs library.  This feature is also used in FFI unless explicitly disabled.  To disable building with the 'gpu' dependency, set `FFI_USE_GPU=0`:
+By default, a 'gpu' option is used in the proofs library*.  This feature is also used in FFI unless explicitly disabled.  To disable building with the 'gpu' dependency, set `FFI_USE_GPU=0`:
 
 ```shell
 rm .install-filcrypto \
     ; make clean \
     ; FFI_BUILD_FROM_SOURCE=1 FFI_USE_PAIRING=1 FFI_USE_GPU=0 make
 ```
+
+*Note that OS X will always disable GPU support as it's not supported on that platform (the required opencl support is unavailable).
 
 By default, a 'multicore-sdr' option is used in the proofs library.  This feature is also used in FFI unless explicitly disabled.  To disable building with the 'multicore-sdr' dependency, set `FFI_USE_MULTICORE_SDR=0`:
 

--- a/build.sh
+++ b/build.sh
@@ -5,10 +5,13 @@ set -e
 make clean
 cd rust
 rm -f Cargo.lock
+rustup target add x86_64-apple-darwin --toolchain $(cat rust-toolchain)
+rustup target add aarch64-apple-darwin --toolchain $(cat rust-toolchain)
 cargo update -p "filecoin-proofs-api"
+cargo install cargo-lipo
 cargo install cbindgen
 cbindgen --clean --config cbindgen.toml --crate filcrypto --output ../include/filcrypto.h
 cd ..
-FFI_BUILD_FROM_SOURCE=1 FFI_USE_BLST=1 make
+FFI_BUILD_FROM_SOURCE=1 make
 make cgo-gen
 go mod tidy

--- a/install-filcrypto
+++ b/install-filcrypto
@@ -65,6 +65,9 @@ main() {
         find -L "${rust_sources_dir}/target/release" -type f -name filcrypto.h -exec cp -- "{}" . \;
         find -L "${rust_sources_dir}" -type f -name filcrypto.pc -exec cp -- "{}" . \;
 
+        pwd
+        ls *filcrypto*
+
         check_installed_files
 
         (>&2 echo "[install-filcrypto/main] successfully built and installed libfilcrypto from source")
@@ -247,6 +250,9 @@ get_release_flags() {
 }
 
 check_installed_files() {
+    pwd
+    ls *filcrypto*
+
     if [[ ! -f "./filcrypto.h" ]]; then
         (>&2 echo "[check_installed_files] failed to install filcrypto.h")
         exit 1

--- a/install-filcrypto
+++ b/install-filcrypto
@@ -62,7 +62,7 @@ main() {
         else
             find -L "${rust_sources_dir}/target/release" -type f -name libfilcrypto.a -exec cp -- "{}" . \;
         fi
-        find -L "${rust_sources_dir}/target/release" -type f -name filcrypto.h -exec cp -- "{}" . \;
+        find -L "${rust_sources_dir}" -type f -name filcrypto.h -exec cp -- "{}" . \;
         find -L "${rust_sources_dir}" -type f -name filcrypto.pc -exec cp -- "{}" . \;
 
         pwd

--- a/install-filcrypto
+++ b/install-filcrypto
@@ -167,7 +167,7 @@ build_from_source() {
 
     # Default to use gpu flags, unless specified to disable
     gpu_flags=",gpu"
-    if [ "${FFI_USE_GPU}" == "0" ]; then
+    if [ "${FFI_USE_GPU}" == "0" ] || [ "$(uname -s)" = "Darwin" ]; then
         gpu_flags=""
     fi
 

--- a/install-filcrypto
+++ b/install-filcrypto
@@ -57,7 +57,8 @@ main() {
 
         # copy from Rust's build directory (target) to root of filecoin-ffi
         #
-        if [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "arm64" ]; then
+        #if [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "arm64" ]; then
+        if [ "$(uname -s)" = "Darwin" ]; then
             find -L "${rust_sources_dir}/target/universal/release" -type f -name libfilcrypto.a -exec cp -- "{}" . \;
         else
             find -L "${rust_sources_dir}/target/release" -type f -name libfilcrypto.a -exec cp -- "{}" . \;
@@ -154,13 +155,12 @@ build_from_source() {
     cargo --version
 
     additional_flags=""
-    # For building on aarch64, we try to use cargo-lipo instead of cargo build
-    x86_64_uname=$(uname -a | grep x86_64)
-    if [ -n "${x86_64_uname}" ]; then
-        build="build"
-    else
+    # For building on Darwin, we try to use cargo-lipo instead of cargo build
+    if [ "$(uname -s)" = "Darwin" ]; then
         build="lipo"
         additional_flags="--targets x86_64-apple-darwin,aarch64-apple-darwin "
+    else
+        build="build"
     fi
 
     # Default to use gpu flags, unless specified to disable

--- a/install-filcrypto
+++ b/install-filcrypto
@@ -183,7 +183,7 @@ build_from_source() {
     elif [ "${FFI_USE_PAIRING}" == "1" ]; then
         additional_flags="--no-default-features --features ${use_multicore_sdr},pairing${gpu_flags}"
     else
-        additional_flags="--no-default-features ${use_multicore_sdr} --features blst${gpu_flags}"
+        additional_flags="--no-default-features --features ${use_multicore_sdr},blst${gpu_flags}"
     fi
 
     echo "Using additional build flags: ${additional_flags}"

--- a/install-filcrypto
+++ b/install-filcrypto
@@ -66,7 +66,7 @@ main() {
         find -L "${rust_sources_dir}" -type f -name filcrypto.pc -exec cp -- "{}" . \;
 
         pwd
-        ls *filcrypto*
+        ls ./*filcrypto*
 
         check_installed_files
 
@@ -251,7 +251,7 @@ get_release_flags() {
 
 check_installed_files() {
     pwd
-    ls *filcrypto*
+    ls ./*filcrypto*
 
     if [[ ! -f "./filcrypto.h" ]]; then
         (>&2 echo "[check_installed_files] failed to install filcrypto.h")

--- a/install-filcrypto
+++ b/install-filcrypto
@@ -169,7 +169,7 @@ build_from_source() {
 
     # Default to use gpu flags, unless specified to disable
     gpu_flags=",gpu"
-    if [ "${FFI_USE_GPU}" == "0" ] || [ "$(uname -s)" = "Darwin" ]; then
+    if [ "${FFI_USE_GPU}" == "0" ]; then
         gpu_flags=""
     fi
 

--- a/install-filcrypto
+++ b/install-filcrypto
@@ -177,13 +177,13 @@ build_from_source() {
 
     # Add feature specific rust flags as needed here.
     if [ "${FFI_USE_BLST_PORTABLE}" == "1" ] && [ "${FFI_USE_PAIRING}" == "1" ]; then
-        additional_flags="--no-default-features --features ${use_multicore_sdr},pairing,blst-portable${gpu_flags}"
+        additional_flags="${additional_flags} --no-default-features --features ${use_multicore_sdr},pairing,blst-portable${gpu_flags}"
     elif [ "${FFI_USE_BLST_PORTABLE}" == "1" ]; then
-        additional_flags="--no-default-features --features ${use_multicore_sdr},blst,blst-portable${gpu_flags}"
+        additional_flags="${additional_flags} --no-default-features --features ${use_multicore_sdr},blst,blst-portable${gpu_flags}"
     elif [ "${FFI_USE_PAIRING}" == "1" ]; then
-        additional_flags="--no-default-features --features ${use_multicore_sdr},pairing${gpu_flags}"
+        additional_flags="${additional_flags} --no-default-features --features ${use_multicore_sdr},pairing${gpu_flags}"
     else
-        additional_flags="--no-default-features --features ${use_multicore_sdr},blst${gpu_flags}"
+        additional_flags="${additional_flags} --no-default-features --features ${use_multicore_sdr},blst${gpu_flags}"
     fi
 
     echo "Using additional build flags: ${additional_flags}"

--- a/install-filcrypto
+++ b/install-filcrypto
@@ -57,7 +57,7 @@ main() {
 
         # copy from Rust's build directory (target) to root of filecoin-ffi
         #
-        if [ "$(uname -s)" = "Darwin" ]; then
+        if [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "x86_64" ]; then
             find -L "${rust_sources_dir}/target/universal/release" -type f -name libfilcrypto.a -exec cp -- "{}" . \;
         else
             find -L "${rust_sources_dir}/target/release" -type f -name libfilcrypto.a -exec cp -- "{}" . \;
@@ -157,8 +157,10 @@ build_from_source() {
     cargo --version
 
     additional_flags=""
-    # For building on Darwin, we try to use cargo-lipo instead of cargo build
-    if [ "$(uname -s)" = "Darwin" ]; then
+    # For building on Darwin, we try to use cargo-lipo instead of cargo build.
+    # Note that the cross compile works on x86_64 for m1, but doesn't work on m1.
+    # For m1, we will build natively if building from source.
+    if [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "x86_64" ]; then
         build="lipo"
         additional_flags="--targets x86_64-apple-darwin,aarch64-apple-darwin "
     else

--- a/install-filcrypto
+++ b/install-filcrypto
@@ -80,11 +80,11 @@ download_release_tarball() {
     local __release_tag="${__release_sha1:0:16}"
     local __release_tag_url="https://api.github.com/repos/filecoin-project/${__repo_name}/releases/tags/${__release_tag}"
 
-    # Download either the non-optimized standard or standard-blst release.
-    if [ "${FFI_USE_BLST}" == "1" ]; then
-        release_flag_name="standard-blst"
-    else
+    # Download either the non-optimized standard or standard-pairing release.
+    if [ "${FFI_USE_PAIRING}" == "1" ]; then
         release_flag_name="standard-pairing"
+    else
+        release_flag_name="standard-blst"
     fi
 
     # TODO: This function shouldn't make assumptions about how these releases'
@@ -176,12 +176,14 @@ build_from_source() {
     fi
 
     # Add feature specific rust flags as needed here.
-    if [ "${FFI_USE_BLST_PORTABLE}" == "1" ]; then
+    if [ "${FFI_USE_BLST_PORTABLE}" == "1" ] && [ "${FFI_USE_PAIRING}" == "1" ]; then
+        additional_flags="--no-default-features --features ${use_multicore_sdr},pairing,blst-portable${gpu_flags}"
+    elif [ "${FFI_USE_BLST_PORTABLE}" == "1" ]; then
         additional_flags="--no-default-features --features ${use_multicore_sdr},blst,blst-portable${gpu_flags}"
-    elif [ "${FFI_USE_BLST}" == "1" ]; then
-        additional_flags="--no-default-features --features ${use_multicore_sdr},blst${gpu_flags}"
-    else
+    elif [ "${FFI_USE_PAIRING}" == "1" ]; then
         additional_flags="--no-default-features --features ${use_multicore_sdr},pairing${gpu_flags}"
+    else
+        additional_flags="--no-default-features ${use_multicore_sdr} --features blst${gpu_flags}"
     fi
 
     echo "Using additional build flags: ${additional_flags}"

--- a/install-filcrypto
+++ b/install-filcrypto
@@ -57,7 +57,6 @@ main() {
 
         # copy from Rust's build directory (target) to root of filecoin-ffi
         #
-        #if [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "arm64" ]; then
         if [ "$(uname -s)" = "Darwin" ]; then
             find -L "${rust_sources_dir}/target/universal/release" -type f -name libfilcrypto.a -exec cp -- "{}" . \;
         else
@@ -217,7 +216,11 @@ get_release_flags() {
     fi
 
     # Maps cpu flag to rust flags (related to entries in rust/rustc-target-features-optimized.json)
-    feature_map=("adx:+adx" "sha_ni:+sha" "sha2:+sha2" "sse2:+sse2" "avx2:+avx2" "avx:+avx" "sse4_2:+sse4.2" "sse4_1:+sse4.1")
+    if [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "x86_64" ]; then
+        feature_map=("adx:+adx" "sha_ni:+sha" "sha2:+sha2" "avx2:+avx2" "sse4_2:+sse4.2" "sse4_1:+sse4.1")
+    else
+        feature_map=("adx:+adx" "sha_ni:+sha" "sha2:+sha2" "sse2:+sse2" "avx2:+avx2" "avx:+avx" "sse4_2:+sse4.2" "sse4_1:+sse4.1")
+    fi
 
     target_features=""
     # check for the presence of each required CPU feature

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -68,9 +68,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.42"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
+checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
 
 [[package]]
 name = "arrayref"
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "bellperson"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0561197d45d807faccac88af69c841730ac881fc13c3d0c6382aa84a7ce09f9d"
+checksum = "cf45c8be6eb74ede124851a228809faa882cae0685f5449613817cc4a633245b"
 dependencies = [
  "bincode",
  "bit-vec",
@@ -142,11 +142,12 @@ dependencies = [
  "rand 0.7.3",
  "rand_core 0.5.1",
  "rayon",
- "rust-gpu-tools 0.4.0",
+ "rust-gpu-tools 0.4.1",
  "rustc-hash",
  "serde",
  "sha2 0.9.5",
  "thiserror",
+ "yastl",
 ]
 
 [[package]]
@@ -172,9 +173,9 @@ checksum = "8dead7461c1127cf637931a1e50934eb6eee8bff2f74433ac7909e9afcee04a3"
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitvec"
@@ -385,9 +386,9 @@ dependencies = [
 
 [[package]]
 name = "cl3"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3973b4f2789dc2b25fbcba1a0d7e4e79ee63ed57aa1e8907fa0c08f51a5e724d"
+checksum = "e162e5fd0310c1060ab86ca788bf8660f916cbba7473b1c1cb1ecac8e663b9e2"
 dependencies = [
  "cl-sys",
  "libc",
@@ -401,7 +402,7 @@ checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
  "ansi_term",
  "atty",
- "bitflags 1.2.1",
+ "bitflags 1.3.2",
  "strsim",
  "textwrap",
  "unicode-width",
@@ -449,7 +450,7 @@ checksum = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
 dependencies = [
  "cfg-if 0.1.10",
  "crossbeam-channel 0.4.4",
- "crossbeam-deque 0.7.3",
+ "crossbeam-deque 0.7.4",
  "crossbeam-epoch 0.8.2",
  "crossbeam-queue 0.2.3",
  "crossbeam-utils 0.7.2",
@@ -463,7 +464,7 @@ checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-channel 0.5.1",
- "crossbeam-deque 0.8.0",
+ "crossbeam-deque 0.8.1",
  "crossbeam-epoch 0.9.5",
  "crossbeam-queue 0.3.2",
  "crossbeam-utils 0.8.5",
@@ -491,9 +492,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
+checksum = "c20ff29ded3204c5106278a81a38f4b482636ed4fa1e6cfbeef193291beb29ed"
 dependencies = [
  "crossbeam-epoch 0.8.2",
  "crossbeam-utils 0.7.2",
@@ -502,9 +503,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch 0.9.5",
@@ -789,7 +790,7 @@ version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "827ceba5f0c5dc932509a9c097f7f1f671b179c64bc224cffbdf6e39827c0ffc"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags 1.3.2",
  "cl-sys",
  "enum_primitive",
  "failure",
@@ -840,8 +841,9 @@ dependencies = [
 
 [[package]]
 name = "filecoin-hashers"
-version = "3.0.3"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=swap-pairing-for-blst#f81494ec6c0970590f8d2c76a638088f66e225de"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d0c68cd87bd5899ca5d305daac3133b77dcaa8ab90f6c780ec34deb62a15f66"
 dependencies = [
  "anyhow",
  "bellperson",
@@ -858,8 +860,9 @@ dependencies = [
 
 [[package]]
 name = "filecoin-proofs"
-version = "8.0.3"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=swap-pairing-for-blst#f81494ec6c0970590f8d2c76a638088f66e225de"
+version = "9.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3290452b555122b635efc6bb213e0ba33fbe475368c3dc4e9bfd6f40bef07e"
 dependencies = [
  "anyhow",
  "bellperson",
@@ -896,8 +899,9 @@ dependencies = [
 
 [[package]]
 name = "filecoin-proofs-api"
-version = "8.0.1"
-source = "git+https://github.com/filecoin-project/rust-filecoin-proofs-api?branch=swap-pairing-for-blst#ca476e23eee66258aec6c9584fc9ba195a3499fb"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b3e43c2c1921b23f0a2d50cdd77f44c6c7f7459e9a66ba0b9f31dd56596dd09"
 dependencies = [
  "anyhow",
  "bellperson",
@@ -933,9 +937,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e90cc80fad5bb391b38127896b0fa27d97e7fef74742797f4da518d67e1292f"
+dependencies = [
+ "spinning_top",
+]
+
+[[package]]
 name = "fr32"
-version = "1.0.3"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=swap-pairing-for-blst#f81494ec6c0970590f8d2c76a638088f66e225de"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d50f88cd4bf2ecb51589b7400e1217e597bbd19a4f81f47159a3a26b33330cd2"
 dependencies = [
  "anyhow",
  "bellperson",
@@ -1128,7 +1142,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
 dependencies = [
  "arrayvec",
- "bitflags 1.2.1",
+ "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "ryu",
  "static_assertions",
@@ -1136,9 +1150,18 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
+
+[[package]]
+name = "lock_api"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -1230,8 +1253,9 @@ dependencies = [
 
 [[package]]
 name = "neptune"
-version = "3.0.0"
-source = "git+https://github.com/filecoin-project/neptune#69814e9c0ec671566eb9ad7a497497425a535d7a"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e700fb2356a1c9cecd590b789a919b727f8885747587fc4659114e6a98e12583"
 dependencies = [
  "bellperson",
  "blake2s_simd",
@@ -1242,7 +1266,7 @@ dependencies = [
  "itertools 0.8.2",
  "lazy_static",
  "log",
- "rust-gpu-tools 0.4.0",
+ "rust-gpu-tools 0.4.1",
 ]
 
 [[package]]
@@ -1663,7 +1687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
 dependencies = [
  "autocfg",
- "crossbeam-deque 0.8.0",
+ "crossbeam-deque 0.8.1",
  "either",
  "rayon-core",
 ]
@@ -1675,7 +1699,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
 dependencies = [
  "crossbeam-channel 0.5.1",
- "crossbeam-deque 0.8.0",
+ "crossbeam-deque 0.8.1",
  "crossbeam-utils 0.8.5",
  "lazy_static",
  "num_cpus",
@@ -1692,11 +1716,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
- "bitflags 1.2.1",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1751,9 +1775,9 @@ dependencies = [
 
 [[package]]
 name = "rust-gpu-tools"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30c8c9bf8533e2fcd560904086abdb1214223d9522b6a887819e04b5f78e80a2"
+checksum = "4dcf264eeb8cbea81e83cd5ed838b9ee51b0879a55896c000cf2d4161d509eac"
 dependencies = [
  "dirs",
  "hex",
@@ -1823,18 +1847,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.126"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.126"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
+checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
 dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",
@@ -1843,9 +1867,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.64"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
 dependencies = [
  "itoa",
  "ryu",
@@ -1889,8 +1913,9 @@ dependencies = [
 
 [[package]]
 name = "sha2raw"
-version = "3.0.3"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=swap-pairing-for-blst#f81494ec6c0970590f8d2c76a638088f66e225de"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb6909ab9d47f7fc10071094faf29333aa9d08fb3bdcd445dddbcb4d21ed8003"
 dependencies = [
  "block-buffer 0.9.0",
  "byteorder 1.4.3",
@@ -1903,6 +1928,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spinning_top"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75adad84ee84b521fb2cca2d4fd0f1dab1d8d026bda3c5bea4ca63b5f9f9293c"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1910,8 +1944,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-proofs-core"
-version = "8.0.3"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=swap-pairing-for-blst#f81494ec6c0970590f8d2c76a638088f66e225de"
+version = "9.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beab1b4c0b9ddf29673244c4fab9988e4b22358dfcf4223a5c97f7ae7b8467b1"
 dependencies = [
  "aes",
  "anyhow",
@@ -1948,8 +1983,9 @@ dependencies = [
 
 [[package]]
 name = "storage-proofs-porep"
-version = "8.0.3"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=swap-pairing-for-blst#f81494ec6c0970590f8d2c76a638088f66e225de"
+version = "9.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb1bd60ee3d764e8e4774a101d13bc1e2e74d996321ac0b69cfed112bf875f99"
 dependencies = [
  "anyhow",
  "bellperson",
@@ -1982,12 +2018,14 @@ dependencies = [
  "sha2 0.9.5",
  "sha2raw",
  "storage-proofs-core",
+ "yastl",
 ]
 
 [[package]]
 name = "storage-proofs-post"
-version = "8.0.3"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=swap-pairing-for-blst#f81494ec6c0970590f8d2c76a638088f66e225de"
+version = "9.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a14aeaee17e853608b6d8eeee65df2b188924990907d77624e89c63222e480"
 dependencies = [
  "anyhow",
  "bellperson",
@@ -2231,6 +2269,16 @@ name = "yansi"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc79f4a1e39857fc00c3f662cbf2651c771f00e9c15fe2abc341806bd46bd71"
+
+[[package]]
+name = "yastl"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca6c5a4d66c1a9ea261811cf4773c27343de7e5033e1b75ea3f297dc7db3c1a"
+dependencies = [
+ "flume",
+ "scopeguard",
+]
 
 [[package]]
 name = "zeroize"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,21 +3,6 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61f2b7f93d2c7d2b08263acaa4a363b3e276806c68af6134c44f523bf1aacd"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "aes"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,21 +87,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
-name = "backtrace"
-version = "0.3.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7a905d892734eea339e896738c14b9afce22b5318f64b951e70bf3844419b01"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if 1.0.0",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
-]
-
-[[package]]
 name = "bellperson"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,7 +97,7 @@ dependencies = [
  "blake2s_simd",
  "blstrs",
  "byteorder 1.4.3",
- "crossbeam-channel 0.5.1",
+ "crossbeam-channel",
  "digest 0.9.0",
  "ff-cl-gen",
  "fff",
@@ -142,7 +112,7 @@ dependencies = [
  "rand 0.7.3",
  "rand_core 0.5.1",
  "rayon",
- "rust-gpu-tools 0.4.1",
+ "rust-gpu-tools",
  "rustc-hash",
  "serde",
  "sha2 0.9.5",
@@ -361,7 +331,7 @@ checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
  "libc",
  "num-integer",
- "num-traits 0.2.14",
+ "num-traits",
  "time",
  "winapi 0.3.9",
 ]
@@ -444,40 +414,16 @@ checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
 name = "crossbeam"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
-dependencies = [
- "cfg-if 0.1.10",
- "crossbeam-channel 0.4.4",
- "crossbeam-deque 0.7.4",
- "crossbeam-epoch 0.8.2",
- "crossbeam-queue 0.2.3",
- "crossbeam-utils 0.7.2",
-]
-
-[[package]]
-name = "crossbeam"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-channel 0.5.1",
- "crossbeam-deque 0.8.1",
- "crossbeam-epoch 0.9.5",
- "crossbeam-queue 0.3.2",
- "crossbeam-utils 0.8.5",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
-dependencies = [
- "crossbeam-utils 0.7.2",
- "maybe-uninit",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -487,18 +433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.5",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20ff29ded3204c5106278a81a38f4b482636ed4fa1e6cfbeef193291beb29ed"
-dependencies = [
- "crossbeam-epoch 0.8.2",
- "crossbeam-utils 0.7.2",
- "maybe-uninit",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -508,23 +443,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-epoch 0.9.5",
- "crossbeam-utils 0.8.5",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
-dependencies = [
- "autocfg",
- "cfg-if 0.1.10",
- "crossbeam-utils 0.7.2",
- "lazy_static",
- "maybe-uninit",
- "memoffset 0.5.6",
- "scopeguard",
+ "crossbeam-epoch",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -534,21 +454,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.5",
+ "crossbeam-utils",
  "lazy_static",
- "memoffset 0.6.4",
+ "memoffset",
  "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
-dependencies = [
- "cfg-if 0.1.10",
- "crossbeam-utils 0.7.2",
- "maybe-uninit",
 ]
 
 [[package]]
@@ -558,18 +467,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.5",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
-dependencies = [
- "autocfg",
- "cfg-if 0.1.10",
- "lazy_static",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -665,15 +563,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
-name = "enum_primitive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4551092f4d519593039259a9ed8daedf0da12e5109c5280338073eaeb81180"
-dependencies = [
- "num-traits 0.1.43",
-]
-
-[[package]]
 name = "errno"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -682,28 +571,6 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "winapi 0.2.8",
-]
-
-[[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.74",
- "synstructure",
 ]
 
 [[package]]
@@ -754,7 +621,7 @@ checksum = "78dcbbfd77fe2bb6535a6ab35f643bf94d4c3ad30590dcbd0574fcc638747535"
 dependencies = [
  "num-bigint 0.2.6",
  "num-integer",
- "num-traits 0.2.14",
+ "num-traits",
  "proc-macro2 1.0.28",
  "quote 1.0.9",
  "syn 1.0.74",
@@ -768,36 +635,6 @@ checksum = "b92ec22ace9da5ca0ad6ab61fa6cab1eb46faad7aaaaf9bcf24394c22b7e605a"
 dependencies = [
  "drop_struct_macro_derive",
  "libc",
-]
-
-[[package]]
-name = "fil-ocl"
-version = "0.19.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cb95c3c684138f2522dbedb070c27e6223999b775120936ea7f90b38a823d07"
-dependencies = [
- "failure",
- "fil-ocl-core",
- "futures",
- "nodrop",
- "num-traits 0.2.14",
- "qutex",
-]
-
-[[package]]
-name = "fil-ocl-core"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "827ceba5f0c5dc932509a9c097f7f1f671b179c64bc224cffbdf6e39827c0ffc"
-dependencies = [
- "bitflags 1.3.2",
- "cl-sys",
- "enum_primitive",
- "failure",
- "num-complex",
- "num-traits 0.2.14",
- "ocl-core-vector",
- "rustc_version",
 ]
 
 [[package]]
@@ -833,7 +670,7 @@ dependencies = [
  "rand 0.7.3",
  "rand_chacha 0.2.2",
  "rayon",
- "rust-gpu-tools 0.3.0",
+ "rust-gpu-tools",
  "serde_json",
  "storage-proofs-porep",
  "tempfile",
@@ -976,12 +813,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
-name = "futures"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
-
-[[package]]
 name = "generic-array"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1021,12 +852,6 @@ dependencies = [
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
 
 [[package]]
 name = "glob"
@@ -1183,12 +1008,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
-
-[[package]]
 name = "memchr"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1202,15 +1021,6 @@ checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 dependencies = [
  "libc",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -1242,16 +1052,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "miniz_oxide"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
-dependencies = [
- "adler",
- "autocfg",
-]
-
-[[package]]
 name = "neptune"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1266,14 +1066,8 @@ dependencies = [
  "itertools 0.8.2",
  "lazy_static",
  "log",
- "rust-gpu-tools 0.4.1",
+ "rust-gpu-tools",
 ]
-
-[[package]]
-name = "nodrop"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "nom"
@@ -1297,7 +1091,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-rational",
- "num-traits 0.2.14",
+ "num-traits",
 ]
 
 [[package]]
@@ -1307,7 +1101,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1"
 dependencies = [
  "num-integer",
- "num-traits 0.2.14",
+ "num-traits",
  "rand 0.4.6",
  "rustc-serialize",
 ]
@@ -1320,7 +1114,7 @@ checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits 0.2.14",
+ "num-traits",
 ]
 
 [[package]]
@@ -1329,7 +1123,7 @@ version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b288631d7878aaf59442cffd36910ea604ecd7745c36054328595114001c9656"
 dependencies = [
- "num-traits 0.2.14",
+ "num-traits",
  "rustc-serialize",
 ]
 
@@ -1340,7 +1134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
- "num-traits 0.2.14",
+ "num-traits",
 ]
 
 [[package]]
@@ -1351,7 +1145,7 @@ checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits 0.2.14",
+ "num-traits",
 ]
 
 [[package]]
@@ -1362,17 +1156,8 @@ checksum = "ee314c74bd753fc86b4780aa9475da469155f3848473a261d2d18e35245a784e"
 dependencies = [
  "num-bigint 0.1.44",
  "num-integer",
- "num-traits 0.2.14",
+ "num-traits",
  "rustc-serialize",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
-dependencies = [
- "num-traits 0.2.14",
 ]
 
 [[package]]
@@ -1392,24 +1177,6 @@ checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
  "libc",
-]
-
-[[package]]
-name = "object"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55827317fb4c08822499848a14237d2874d6f139828893017237e7ab93eb386"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "ocl-core-vector"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4072920739958adeec5abedec51af70febc58f7fff0601aaa0827c1f3c8fefd"
-dependencies = [
- "num",
 ]
 
 [[package]]
@@ -1547,16 +1314,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "qutex"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084325f9fb9f2c23e4c225be1a4799583badd1666c3c6bbc67bacc6147f20ba1"
-dependencies = [
- "crossbeam 0.7.3",
- "futures",
-]
-
-[[package]]
 name = "radium"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1687,7 +1444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
 dependencies = [
  "autocfg",
- "crossbeam-deque 0.8.1",
+ "crossbeam-deque",
  "either",
  "rayon-core",
 ]
@@ -1698,9 +1455,9 @@ version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
 dependencies = [
- "crossbeam-channel 0.5.1",
- "crossbeam-deque 0.8.1",
- "crossbeam-utils 0.8.5",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
  "lazy_static",
  "num_cpus",
 ]
@@ -1761,20 +1518,6 @@ dependencies = [
 
 [[package]]
 name = "rust-gpu-tools"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a221f75523a16675b1b3b78aa70cc361c4fffde33255a3d4414419a5f1347d"
-dependencies = [
- "dirs",
- "fil-ocl",
- "lazy_static",
- "log",
- "sha2 0.8.2",
- "thiserror",
-]
-
-[[package]]
-name = "rust-gpu-tools"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcf264eeb8cbea81e83cd5ed838b9ee51b0879a55896c000cf2d4161d509eac"
@@ -1789,12 +1532,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dead70b0b5e03e9c814bcb6b01e03e68f7c57a80aa48c72ec92152ab3e818d49"
-
-[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1805,15 +1542,6 @@ name = "rustc-serialize"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
-
-[[package]]
-name = "rustc_version"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
-dependencies = [
- "semver",
-]
 
 [[package]]
 name = "ryu"
@@ -1992,7 +1720,7 @@ dependencies = [
  "bincode",
  "byte-slice-cast",
  "byteorder 1.4.3",
- "crossbeam 0.8.1",
+ "crossbeam",
  "digest 0.9.0",
  "fdlimit",
  "fff",
@@ -2008,7 +1736,7 @@ dependencies = [
  "merkletree",
  "neptune",
  "num-bigint 0.2.6",
- "num-traits 0.2.14",
+ "num-traits",
  "num_cpus",
  "pretty_assertions",
  "rand 0.7.3",
@@ -2032,7 +1760,7 @@ dependencies = [
  "blake2b_simd",
  "blake2s_simd",
  "byteorder 1.4.3",
- "crossbeam 0.8.1",
+ "crossbeam",
  "fff",
  "filecoin-hashers",
  "fr32",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "bellperson"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb7179a6277802b4d28110758e614af736c19e0e3ab0c78f7a2db7956989b6e"
+checksum = "0561197d45d807faccac88af69c841730ac881fc13c3d0c6382aa84a7ce09f9d"
 dependencies = [
  "bincode",
  "bit-vec",
@@ -142,7 +142,7 @@ dependencies = [
  "rand 0.7.3",
  "rand_core 0.5.1",
  "rayon",
- "rust-gpu-tools",
+ "rust-gpu-tools 0.4.0",
  "rustc-hash",
  "serde",
  "sha2 0.9.5",
@@ -380,6 +380,16 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8573fa3ff8acd6c49e8e113296c54277e82376b96c6ca6307848632cce38e44"
 dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cl3"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3973b4f2789dc2b25fbcba1a0d7e4e79ee63ed57aa1e8907fa0c08f51a5e724d"
+dependencies = [
+ "cl-sys",
  "libc",
 ]
 
@@ -822,7 +832,7 @@ dependencies = [
  "rand 0.7.3",
  "rand_chacha 0.2.2",
  "rayon",
- "rust-gpu-tools",
+ "rust-gpu-tools 0.3.0",
  "serde_json",
  "storage-proofs-porep",
  "tempfile",
@@ -831,7 +841,7 @@ dependencies = [
 [[package]]
 name = "filecoin-hashers"
 version = "3.0.3"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=swap-pairing-for-blst#bbb8bfba1bdbefc25dca6bdc7097a5d0ae4124f4"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=swap-pairing-for-blst#f81494ec6c0970590f8d2c76a638088f66e225de"
 dependencies = [
  "anyhow",
  "bellperson",
@@ -849,7 +859,7 @@ dependencies = [
 [[package]]
 name = "filecoin-proofs"
 version = "8.0.3"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=swap-pairing-for-blst#bbb8bfba1bdbefc25dca6bdc7097a5d0ae4124f4"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=swap-pairing-for-blst#f81494ec6c0970590f8d2c76a638088f66e225de"
 dependencies = [
  "anyhow",
  "bellperson",
@@ -887,7 +897,7 @@ dependencies = [
 [[package]]
 name = "filecoin-proofs-api"
 version = "8.0.1"
-source = "git+https://github.com/filecoin-project/rust-filecoin-proofs-api?branch=swap-pairing-for-blst#718630f1afe7ac728d7bc4d324ecd9986c30f43d"
+source = "git+https://github.com/filecoin-project/rust-filecoin-proofs-api?branch=swap-pairing-for-blst#ca476e23eee66258aec6c9584fc9ba195a3499fb"
 dependencies = [
  "anyhow",
  "bellperson",
@@ -925,7 +935,7 @@ dependencies = [
 [[package]]
 name = "fr32"
 version = "1.0.3"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=swap-pairing-for-blst#bbb8bfba1bdbefc25dca6bdc7097a5d0ae4124f4"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=swap-pairing-for-blst#f81494ec6c0970590f8d2c76a638088f66e225de"
 dependencies = [
  "anyhow",
  "bellperson",
@@ -1221,7 +1231,7 @@ dependencies = [
 [[package]]
 name = "neptune"
 version = "3.0.0"
-source = "git+https://github.com/filecoin-project/neptune?branch=updated-bellperson#2b41d2ea18926d16d95895f7f85b34e1395638c3"
+source = "git+https://github.com/filecoin-project/neptune#69814e9c0ec671566eb9ad7a497497425a535d7a"
 dependencies = [
  "bellperson",
  "blake2s_simd",
@@ -1232,7 +1242,7 @@ dependencies = [
  "itertools 0.8.2",
  "lazy_static",
  "log",
- "rust-gpu-tools",
+ "rust-gpu-tools 0.4.0",
 ]
 
 [[package]]
@@ -1395,6 +1405,16 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "opencl3"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2362074823a6505fc03fe1729c2fd4bdf9668c70e0ecaf8de7d1799cd54b465"
+dependencies = [
+ "cl3",
+ "libc",
+]
 
 [[package]]
 name = "output_vt100"
@@ -1730,6 +1750,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-gpu-tools"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30c8c9bf8533e2fcd560904086abdb1214223d9522b6a887819e04b5f78e80a2"
+dependencies = [
+ "dirs",
+ "hex",
+ "lazy_static",
+ "log",
+ "opencl3",
+ "sha2 0.8.2",
+ "thiserror",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1855,7 +1890,7 @@ dependencies = [
 [[package]]
 name = "sha2raw"
 version = "3.0.3"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=swap-pairing-for-blst#bbb8bfba1bdbefc25dca6bdc7097a5d0ae4124f4"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=swap-pairing-for-blst#f81494ec6c0970590f8d2c76a638088f66e225de"
 dependencies = [
  "block-buffer 0.9.0",
  "byteorder 1.4.3",
@@ -1876,7 +1911,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "storage-proofs-core"
 version = "8.0.3"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=swap-pairing-for-blst#bbb8bfba1bdbefc25dca6bdc7097a5d0ae4124f4"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=swap-pairing-for-blst#f81494ec6c0970590f8d2c76a638088f66e225de"
 dependencies = [
  "aes",
  "anyhow",
@@ -1914,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "storage-proofs-porep"
 version = "8.0.3"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=swap-pairing-for-blst#bbb8bfba1bdbefc25dca6bdc7097a5d0ae4124f4"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=swap-pairing-for-blst#f81494ec6c0970590f8d2c76a638088f66e225de"
 dependencies = [
  "anyhow",
  "bellperson",
@@ -1952,7 +1987,7 @@ dependencies = [
 [[package]]
 name = "storage-proofs-post"
 version = "8.0.3"
-source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=swap-pairing-for-blst#bbb8bfba1bdbefc25dca6bdc7097a5d0ae4124f4"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=swap-pairing-for-blst#f81494ec6c0970590f8d2c76a638088f66e225de"
 dependencies = [
  "anyhow",
  "bellperson",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -357,8 +357,7 @@ dependencies = [
 [[package]]
 name = "cl3"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e162e5fd0310c1060ab86ca788bf8660f916cbba7473b1c1cb1ecac8e663b9e2"
+source = "git+https://github.com/vmx/cl3?branch=filecoin-ffi-v9-tmp-fix#52d6117759a894600e526e8ea2d1f72f550bc24f"
 dependencies = [
  "cl-sys",
  "libc",
@@ -1200,8 +1199,7 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 [[package]]
 name = "opencl3"
 version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2362074823a6505fc03fe1729c2fd4bdf9668c70e0ecaf8de7d1799cd54b465"
+source = "git+https://github.com/vmx/opencl3?branch=filecoin-ffi-v9-tmp-fix#80f4520a0274b1dbf5a6623972e0c893a136d3a3"
 dependencies = [
  "cl3",
  "libc",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "bellperson"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edb7b07cab660137847825b90d1c88e82907689ee1e935eb2101579bc649e0a"
+checksum = "abb7179a6277802b4d28110758e614af736c19e0e3ab0c78f7a2db7956989b6e"
 dependencies = [
  "bincode",
  "bit-vec",
@@ -831,8 +831,7 @@ dependencies = [
 [[package]]
 name = "filecoin-hashers"
 version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9e1f14e1259a7aa09d8c389639343e61d6659715cd01f13b190c68e8397475"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=swap-pairing-for-blst#bbb8bfba1bdbefc25dca6bdc7097a5d0ae4124f4"
 dependencies = [
  "anyhow",
  "bellperson",
@@ -850,8 +849,7 @@ dependencies = [
 [[package]]
 name = "filecoin-proofs"
 version = "8.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cbe35e8932d2791041c299bcbbc2decfb1ea4d192e3c58ada866f0e7303049"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=swap-pairing-for-blst#bbb8bfba1bdbefc25dca6bdc7097a5d0ae4124f4"
 dependencies = [
  "anyhow",
  "bellperson",
@@ -889,8 +887,7 @@ dependencies = [
 [[package]]
 name = "filecoin-proofs-api"
 version = "8.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81509cfc2486a67d850c3583576a49f251dc4e51fdfd6fac8bc1751341e64813"
+source = "git+https://github.com/filecoin-project/rust-filecoin-proofs-api?branch=swap-pairing-for-blst#718630f1afe7ac728d7bc4d324ecd9986c30f43d"
 dependencies = [
  "anyhow",
  "bellperson",
@@ -928,8 +925,7 @@ dependencies = [
 [[package]]
 name = "fr32"
 version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abf1d4bb155e2f4222bd5a7e4a585d14d9512a7bb00139bc1d010119bb68da3"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=swap-pairing-for-blst#bbb8bfba1bdbefc25dca6bdc7097a5d0ae4124f4"
 dependencies = [
  "anyhow",
  "bellperson",
@@ -1225,8 +1221,7 @@ dependencies = [
 [[package]]
 name = "neptune"
 version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec660e9f6f2ff666996be8d34fa70142f05bf25b4268d0ab9f325d80378bf4e5"
+source = "git+https://github.com/filecoin-project/neptune?branch=updated-bellperson#2b41d2ea18926d16d95895f7f85b34e1395638c3"
 dependencies = [
  "bellperson",
  "blake2s_simd",
@@ -1860,8 +1855,7 @@ dependencies = [
 [[package]]
 name = "sha2raw"
 version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02ff2c87fa4fd886f740292b4df3bc934bb36af2ba4587bd442b7e4c584f459f"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=swap-pairing-for-blst#bbb8bfba1bdbefc25dca6bdc7097a5d0ae4124f4"
 dependencies = [
  "block-buffer 0.9.0",
  "byteorder 1.4.3",
@@ -1882,8 +1876,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "storage-proofs-core"
 version = "8.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8fcc9130403ca28a722fcc4d449f19ade14cc84fe3ab067d5ef723e393c018b"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=swap-pairing-for-blst#bbb8bfba1bdbefc25dca6bdc7097a5d0ae4124f4"
 dependencies = [
  "aes",
  "anyhow",
@@ -1921,8 +1914,7 @@ dependencies = [
 [[package]]
 name = "storage-proofs-porep"
 version = "8.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c876cfa8ec4408e8829ed7ad374164820d1df953098f92e73a36ff54002f5ae"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=swap-pairing-for-blst#bbb8bfba1bdbefc25dca6bdc7097a5d0ae4124f4"
 dependencies = [
  "anyhow",
  "bellperson",
@@ -1960,8 +1952,7 @@ dependencies = [
 [[package]]
 name = "storage-proofs-post"
 version = "8.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec3c440730b1dc76c7921746bf7d40696ce63374b430d3c186b6d92b9349f58"
+source = "git+https://github.com/filecoin-project/rust-fil-proofs?branch=swap-pairing-for-blst#bbb8bfba1bdbefc25dca6bdc7097a5d0ae4124f4"
 dependencies = [
  "anyhow",
  "bellperson",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -32,7 +32,7 @@ rand = "0.7"
 rand_chacha = "0.2.1"
 rayon = "1.2.1"
 anyhow = "1.0.23"
-bellperson = { version = "0.15", default-features = false }
+bellperson = { version = "0.16", default-features = false }
 serde_json = "1.0.46"
 rust-gpu-tools = "0.3.0"
 storage-proofs-porep = { version = "~8.0.1", default-features = false }
@@ -63,4 +63,4 @@ storage-proofs-core = { git = "https://github.com/filecoin-project/rust-fil-proo
 storage-proofs-porep = { git = "https://github.com/filecoin-project/rust-fil-proofs", branch = "swap-pairing-for-blst", default-features = false }
 filecoin-hashers = { git = "https://github.com/filecoin-project/rust-fil-proofs", branch = "swap-pairing-for-blst", default-features = false }
 fr32 = { git = "https://github.com/filecoin-project/rust-fil-proofs", branch = "swap-pairing-for-blst", default-features = false }
-neptune = { git = "https://github.com/filecoin-project/neptune", branch = "updated-bellperson", default-features = false }
+neptune = { git = "https://github.com/filecoin-project/neptune", default-features = false }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -32,14 +32,16 @@ rand = "0.7"
 rand_chacha = "0.2.1"
 rayon = "1.2.1"
 anyhow = "1.0.23"
-bellperson = { version = "0.14.1", default-features = false }
+bellperson = { version = "0.15", default-features = false }
 serde_json = "1.0.46"
 rust-gpu-tools = "0.3.0"
 storage-proofs-porep = { version = "~8.0.1", default-features = false }
 
 [dependencies.filecoin-proofs-api]
 package = "filecoin-proofs-api"
-version = "8.0.1"
+#version = "8.0.1"
+git = "https://github.com/filecoin-project/rust-filecoin-proofs-api"
+branch = "swap-pairing-for-blst"
 default-features = false
 
 [build-dependencies]
@@ -49,9 +51,16 @@ cbindgen = "= 0.14.0"
 tempfile = "3.0.8"
 
 [features]
-default = ["pairing", "gpu", "multicore-sdr" ]
+default = ["blst", "gpu", "multicore-sdr" ]
 pairing = ["filecoin-proofs-api/pairing", "bellperson/pairing", "storage-proofs-porep/pairing"]
 blst = ["filecoin-proofs-api/blst", "bellperson/blst", "storage-proofs-porep/blst"]
 blst-portable = ["bls-signatures/blst-portable", "blstrs/portable"]
 gpu = ["filecoin-proofs-api/gpu", "bellperson/gpu", "storage-proofs-porep/gpu"]
 multicore-sdr = ["storage-proofs-porep/multicore-sdr"]
+
+[patch.crates-io]
+storage-proofs-core = { git = "https://github.com/filecoin-project/rust-fil-proofs", branch = "swap-pairing-for-blst", default-features = false }
+storage-proofs-porep = { git = "https://github.com/filecoin-project/rust-fil-proofs", branch = "swap-pairing-for-blst", default-features = false }
+filecoin-hashers = { git = "https://github.com/filecoin-project/rust-fil-proofs", branch = "swap-pairing-for-blst", default-features = false }
+fr32 = { git = "https://github.com/filecoin-project/rust-fil-proofs", branch = "swap-pairing-for-blst", default-features = false }
+neptune = { git = "https://github.com/filecoin-project/neptune", branch = "updated-bellperson", default-features = false }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -55,3 +55,6 @@ blst = ["filecoin-proofs-api/blst", "bellperson/blst", "storage-proofs-porep/bls
 blst-portable = ["bls-signatures/blst-portable", "blstrs/portable"]
 gpu = ["filecoin-proofs-api/gpu", "bellperson/gpu", "storage-proofs-porep/gpu"]
 multicore-sdr = ["storage-proofs-porep/multicore-sdr"]
+
+[patch.crates-io]
+opencl3 = { git = "https://github.com/vmx/opencl3", branch = "filecoin-ffi-v9-tmp-fix" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -35,13 +35,11 @@ anyhow = "1.0.23"
 bellperson = { version = "0.16", default-features = false }
 serde_json = "1.0.46"
 rust-gpu-tools = "0.3.0"
-storage-proofs-porep = { version = "~8.0.1", default-features = false }
+storage-proofs-porep = { version = "~9.0.1", default-features = false }
 
 [dependencies.filecoin-proofs-api]
 package = "filecoin-proofs-api"
-#version = "8.0.1"
-git = "https://github.com/filecoin-project/rust-filecoin-proofs-api"
-branch = "swap-pairing-for-blst"
+version = "9.0"
 default-features = false
 
 [build-dependencies]
@@ -57,10 +55,3 @@ blst = ["filecoin-proofs-api/blst", "bellperson/blst", "storage-proofs-porep/bls
 blst-portable = ["bls-signatures/blst-portable", "blstrs/portable"]
 gpu = ["filecoin-proofs-api/gpu", "bellperson/gpu", "storage-proofs-porep/gpu"]
 multicore-sdr = ["storage-proofs-porep/multicore-sdr"]
-
-[patch.crates-io]
-storage-proofs-core = { git = "https://github.com/filecoin-project/rust-fil-proofs", branch = "swap-pairing-for-blst", default-features = false }
-storage-proofs-porep = { git = "https://github.com/filecoin-project/rust-fil-proofs", branch = "swap-pairing-for-blst", default-features = false }
-filecoin-hashers = { git = "https://github.com/filecoin-project/rust-fil-proofs", branch = "swap-pairing-for-blst", default-features = false }
-fr32 = { git = "https://github.com/filecoin-project/rust-fil-proofs", branch = "swap-pairing-for-blst", default-features = false }
-neptune = { git = "https://github.com/filecoin-project/neptune", default-features = false }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -34,7 +34,7 @@ rayon = "1.2.1"
 anyhow = "1.0.23"
 bellperson = { version = "0.16", default-features = false }
 serde_json = "1.0.46"
-rust-gpu-tools = "0.3.0"
+rust-gpu-tools = "0.4"
 storage-proofs-porep = { version = "~9.0.1", default-features = false }
 
 [dependencies.filecoin-proofs-api]

--- a/rust/scripts/build-release.sh
+++ b/rust/scripts/build-release.sh
@@ -59,6 +59,17 @@ main() {
         echo "Eliminated non-universal binary libraries"
         find . -type f -name "lib$1.a"
     fi
+
+    # copy from Rust's build directory (target) to root of filecoin-ffi
+    #
+    if [ "$(uname -s)" = "Darwin" ]; then
+        find -L "${rust_sources_dir}/target/universal/release" -type f -name libfilcrypto.a -exec cp -- "{}" . \;
+    else
+        find -L "${rust_sources_dir}/target/release" -type f -name libfilcrypto.a -exec cp -- "{}" . \;
+    fi
+    find -L "${rust_sources_dir}/target/release" -type f -name filcrypto.h -exec cp -- "{}" . \;
+    find -L "${rust_sources_dir}" -type f -name filcrypto.pc -exec cp -- "{}" . \;
+
     # generate pkg-config
     #
     sed -e "s;@VERSION@;$(git rev-parse HEAD);" \

--- a/rust/scripts/build-release.sh
+++ b/rust/scripts/build-release.sh
@@ -65,16 +65,6 @@ main() {
     sed -e "s;@VERSION@;$(git rev-parse HEAD);" \
         -e "s;@PRIVATE_LIBS@;${__linker_flags};" "$1.pc.template" > "$1.pc"
 
-    # copy from Rust's build directory (target) to root of filecoin-ffi
-    #
-    if [ "$(uname -s)" = "Darwin" ]; then
-        find -L . -type f -name libfilcrypto.a -exec cp -- "{}" . \;
-    else
-        find -L . -type f -name libfilcrypto.a -exec cp -- "{}" . \;
-    fi
-    find -L . -type f -name filcrypto.h -exec cp -- "{}" . \;
-    find -L . -type f -name filcrypto.pc -exec cp -- "{}" . \;
-
     # ensure header file was built
     #
     find -L . -type f -name "$1.h" | read

--- a/rust/scripts/build-release.sh
+++ b/rust/scripts/build-release.sh
@@ -46,7 +46,7 @@ main() {
         | cut -d ':' -f 3)
 
     echo "Linker Flags: ${__linker_flags}"
-    if [ $(uname -s) = "Darwin" ]; then
+    if [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "x86_64" ]; then
         # With lipo enabled, this replacement may not be necessary,
         # but leaving it in doesn't hurt as it does nothing if not
         # needed

--- a/rust/scripts/build-release.sh
+++ b/rust/scripts/build-release.sh
@@ -60,20 +60,20 @@ main() {
         find . -type f -name "lib$1.a"
     fi
 
-    # copy from Rust's build directory (target) to root of filecoin-ffi
-    #
-    if [ "$(uname -s)" = "Darwin" ]; then
-        find -L "${rust_sources_dir}/target/universal/release" -type f -name libfilcrypto.a -exec cp -- "{}" . \;
-    else
-        find -L "${rust_sources_dir}/target/release" -type f -name libfilcrypto.a -exec cp -- "{}" . \;
-    fi
-    find -L "${rust_sources_dir}/target/release" -type f -name filcrypto.h -exec cp -- "{}" . \;
-    find -L "${rust_sources_dir}" -type f -name filcrypto.pc -exec cp -- "{}" . \;
-
     # generate pkg-config
     #
     sed -e "s;@VERSION@;$(git rev-parse HEAD);" \
         -e "s;@PRIVATE_LIBS@;${__linker_flags};" "$1.pc.template" > "$1.pc"
+
+    # copy from Rust's build directory (target) to root of filecoin-ffi
+    #
+    if [ "$(uname -s)" = "Darwin" ]; then
+        find -L . -type f -name libfilcrypto.a -exec cp -- "{}" . \;
+    else
+        find -L . -type f -name libfilcrypto.a -exec cp -- "{}" . \;
+    fi
+    find -L . -type f -name filcrypto.h -exec cp -- "{}" . \;
+    find -L . -type f -name filcrypto.pc -exec cp -- "{}" . \;
 
     # ensure header file was built
     #

--- a/srs-inner-product.json
+++ b/srs-inner-product.json
@@ -1,0 +1,7 @@
+{
+  "v28-fil-inner-product-v1.srs": {
+    "cid": "Qmdq44DjcQnFfU3PJcdX7J49GCqcUYszr1TxMbHtAkvQ3g",
+    "digest": "ae20310138f5ba81451d723f858e3797",
+    "sector_size": 0
+  }
+}


### PR DESCRIPTION
This PR is based on https://github.com/filecoin-project/filecoin-ffi/pull/192. It adds a custom version of `opencl3` and `cl3` which should fix linker issues on MacOS. The issue there is that it only supports OpenCL 1.2, and by default `opencl3` includes features from newer OpenCL versions. I've also opened an upstream issue: https://github.com/kenba/opencl3/issues/30.