### PR TITLE
fix: use released crates

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -356,8 +356,9 @@ dependencies = [
 
 [[package]]
 name = "cl3"
-version = "0.4.1"
-source = "git+https://github.com/vmx/cl3?branch=filecoin-ffi-v9-tmp-fix#52d6117759a894600e526e8ea2d1f72f550bc24f"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68fdb522345cabcdd77098487d15632dd39e79ec50ccdc81073bf534b55b3da7"
 dependencies = [
  "cl-sys",
  "libc",
@@ -1198,8 +1199,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "opencl3"
-version = "0.2.4"
-source = "git+https://github.com/vmx/opencl3?branch=filecoin-ffi-v9-tmp-fix#80f4520a0274b1dbf5a6623972e0c893a136d3a3"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8862f86c2b3f757038243318edb55a47b1be7d46376fe6bdd9aedd1b0074902"
 dependencies = [
  "cl3",
  "libc",
@@ -1516,9 +1518,9 @@ dependencies = [
 
 [[package]]
 name = "rust-gpu-tools"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcf264eeb8cbea81e83cd5ed838b9ee51b0879a55896c000cf2d4161d509eac"
+checksum = "a300963e624abc34bf16490160380b83a2ee0fda7edf0cf5252f8328ad99c375"
 dependencies = [
  "dirs",
  "hex",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -55,6 +55,3 @@ blst = ["filecoin-proofs-api/blst", "bellperson/blst", "storage-proofs-porep/bls
 blst-portable = ["bls-signatures/blst-portable", "blstrs/portable"]
 gpu = ["filecoin-proofs-api/gpu", "bellperson/gpu", "storage-proofs-porep/gpu"]
 multicore-sdr = ["storage-proofs-porep/multicore-sdr"]
-
-[patch.crates-io]
-opencl3 = { git = "https://github.com/vmx/opencl3", branch = "filecoin-ffi-v9-tmp-fix" }


### PR DESCRIPTION
There is no longer the need to use Git based dependencies, the fixes
that were needed for proper compilation on MacOS were released.

This is the proper fix for the MacOS linker issue. I've only updated the minimum of what's needed in the Cargo.lock. I'd like to get this one merged, even if it's too late for the current release, to make sure it's definitely in the next one.