### PR TITLE
WIP demo nicer FFI types

### DIFF
--- a/rust/src/util/types.rs
+++ b/rust/src/util/types.rs
@@ -1,25 +1,115 @@
-use std::ptr;
+use std::{ops::Deref, ptr};
 
 use drop_struct_macro_derive::DropStructMacro;
 // `CodeAndMessage` is the trait implemented by `code_and_message_impl
 use ffi_toolkit::{code_and_message_impl, free_c_str, CodeAndMessage, FCPResponseStatus};
 
 #[repr(C)]
-#[derive(DropStructMacro)]
+pub struct fil_Array<T: Sized> {
+    ptr: *mut T,
+    len: usize,
+}
+
+impl<T> Default for fil_Array<T> {
+    fn default() -> Self {
+        Self {
+            ptr: ptr::null_mut(),
+            len: 0,
+        }
+    }
+}
+
+pub type fil_Bytes = fil_Array<u8>;
+
+impl<T> From<Vec<T>> for fil_Array<T> {
+    fn from(buf: Vec<T>) -> Self {
+        if buf.is_empty() {
+            return Default::default();
+        }
+        buf.into_boxed_slice().into()
+    }
+}
+
+impl<T> From<Box<[T]>> for fil_Array<T> {
+    fn from(buf: Box<[T]>) -> Self {
+        if buf.is_empty() {
+            return Default::default();
+        }
+        let len = buf.len();
+        let ptr = buf.as_mut_ptr();
+        Box::leak(buf);
+
+        Self { ptr, len }
+    }
+}
+
+impl<T> Drop for fil_Array<T> {
+    fn drop(&mut self) {
+        unsafe {
+            if !self.ptr.is_null() && self.len != 0 {
+                let _ = Vec::from_raw_parts(self.ptr, self.len, self.len);
+            }
+        }
+    }
+}
+
+impl<T> Deref for fil_Array<T> {
+    type Target = [T];
+    fn deref(&self) -> &[T] {
+        unsafe {
+            if self.ptr.is_null() {
+                std::slice::from_raw_parts(ptr::NonNull::dangling().as_ptr(), 0)
+            } else {
+                std::slice::from_raw_parts(self.ptr, self.len)
+            }
+        }
+    }
+}
+
+impl From<&str> for fil_Bytes {
+    fn from(s: &str) -> Self {
+        if s.is_empty() {
+            return Default::default();
+        }
+        Box::<str>::from(s).into()
+    }
+}
+
+impl From<String> for fil_Bytes {
+    fn from(s: String) -> Self {
+        if s.is_empty() {
+            return Default::default();
+        }
+        s.into_boxed_str().into()
+    }
+}
+
+impl From<Box<str>> for fil_Bytes {
+    fn from(s: Box<str>) -> Self {
+        if s.is_empty() {
+            return Default::default();
+        }
+        let len = s.len();
+        let ptr = s.as_mut_ptr();
+        Box::leak(s);
+
+        Self { ptr, len }
+    }
+}
+
+#[repr(C)]
 pub struct fil_GpuDeviceResponse {
     pub status_code: FCPResponseStatus,
-    pub error_msg: *const libc::c_char,
-    pub devices_len: libc::size_t,
-    pub devices_ptr: *const *const libc::c_char,
+    pub error_msg: fil_Bytes,
+    pub devices: fil_Array<fil_Bytes>,
 }
 
 impl Default for fil_GpuDeviceResponse {
     fn default() -> Self {
         Self {
-            error_msg: ptr::null(),
+            error_msg: Default::default(),
             status_code: FCPResponseStatus::FCPNoError,
-            devices_len: 0,
-            devices_ptr: ptr::null(),
+            devices: Default::default(),
         }
     }
 }


### PR DESCRIPTION
This is a demonstration of nicer FFI types.

1. No more drop macro.
2. No more raw pointers in return types.
3. No more C strings.

Future improvements:

1. Add a Default implementation to FCPResponseStatus so we can derive defaults for all responses.
2. Add a generic response type.