### PR TITLE
fix: specify cargo build directory explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 DEPS:=filcrypto.h filcrypto.pc libfilcrypto.a
 
+export CARGO_TARGET_DIR=target
+
 all: $(DEPS)
 .PHONY: all
 


### PR DESCRIPTION
Some users may change the default value of [build.target-dir](https://doc.rust-lang.org/cargo/reference/config.html#buildtarget-dir), which will cause this project failed to build.