### PR TITLE
Fix "Remove tmp prefix from tar path"

### DIFF
--- a/rust/scripts/package-release.sh
+++ b/rust/scripts/package-release.sh
@@ -24,13 +24,14 @@ main() {
 
     # copy assets into temporary directory
     #
-    find -L . -type f -name filcrypto.h -exec cp -- "{}" $__tmp_dir/ \;
-    find -L . -type f -name libfilcrypto.a -exec cp -- "{}" $__tmp_dir/ \;
-    find -L . -type f -name filcrypto.pc -exec cp -- "{}" $__tmp_dir/ \;
+    mkdir $__tmp_dir/filcrypto
+    find -L . -type f -name filcrypto.h -exec cp -- "{}" $__tmp_dir/filcrypto \;
+    find -L . -type f -name libfilcrypto.a -exec cp -- "{}" $__tmp_dir/filcrypto \;
+    find -L . -type f -name filcrypto.pc -exec cp -- "{}" $__tmp_dir/filcrypto \;
 
     # create gzipped tarball from contents of temporary directory
     #
-    tar -czf $__tarball_output_path $__tmp_dir/*
+    tar -czf $__tarball_output_path -C $__tmp_dir filcrypto
 
     (>&2 echo "[package-release/main] release file created: $__tarball_output_path")
 }


### PR DESCRIPTION
Fixes #158 and reverts #176.

I introduced bug by using unnecessary wildcard.  
Fixed by removing it.
```diff
-    tar -czf $__tarball_output_path -C $__tmp_dir filcrypto/*
+    tar -czf $__tarball_output_path -C $__tmp_dir filcrypto
```
  
However code before #158 also had unnecessary wildcard.
```diff
-    tar -czf $__tarball_output_path $__tmp_dir/*
+    tar -czf $__tarball_output_path $__tmp_dir
```

---

There are two options for tar file structure:
1. One line change to just remove tmp prefix (sufficient)
```diff
-    tar -czf $__tarball_output_path $__tmp_dir/*
+    tar -czf $__tarball_output_path -C $__tmp_dir .
```

2. Remove tmp prefix and put files in a directory.
This is just for conveniece - it's annoying when archive is unpacked in wrong directory, and it creates lots of files there, and it's not easy to write all the filenames for `rm` or `mv` - tar file can have single root directory.
```diff
+    mkdir $__tmp_dir/filcrypto
-    find -L . -type f -name filcrypto.h -exec cp -- "{}" $__tmp_dir/ \;
+    find -L . -type f -name filcrypto.h -exec cp -- "{}" $__tmp_dir/filcrypto \;
-    find -L . -type f -name libfilcrypto.a -exec cp -- "{}" $__tmp_dir/ \;
+    find -L . -type f -name libfilcrypto.a -exec cp -- "{}" $__tmp_dir/filcrypto \;
-    find -L . -type f -name filcrypto.pc -exec cp -- "{}" $__tmp_dir/ \;
+    find -L . -type f -name filcrypto.pc -exec cp -- "{}" $__tmp_dir/filcrypto \;

-    tar -czf $__tarball_output_path $__tmp_dir/*
+    tar -czf $__tarball_output_path -C $__tmp_dir filcrypto
```

Please comment, and I will revert second option, and reduce PR to first option one-line

---

CI complains about `GITHUB_TOKEN`, which is not related to this PR
- [ci/circleci: publish_linux_staticlib](https://app.circleci.com/pipelines/github/filecoin-project/filecoin-ffi/1601/workflows/3ef60e18-3c1c-4d43-b20a-e45770d39335/jobs/9456?invite=true#step-112-758)
- [ci/circleci: publish_darwin_staticlib](https://app.circleci.com/pipelines/github/filecoin-project/filecoin-ffi/1601/workflows/3ef60e18-3c1c-4d43-b20a-e45770d39335/jobs/9457?invite=true#step-116-443)