### PR TITLE
fix identity

### DIFF
--- a/rust/src/fvm/blockstore/fake.rs
+++ b/rust/src/fvm/blockstore/fake.rs
@@ -6,6 +6,7 @@ use cid::{
     Cid,
 };
 use fvm_shared::blockstore::Blockstore;
+use fvm_shared::IDENTITY_HASH;
 
 use super::OverlayBlockstore;
 
@@ -41,10 +42,12 @@ where
     }
 
     fn put_keyed(&self, k: &Cid, block: &[u8]) -> Result<()> {
-        if Code::try_from(k.hash().code())
-            .ok()
-            .map(|code| &code.digest(block) == k.hash())
-            .unwrap_or_default()
+        let code = k.hash().code();
+        if code != IDENTITY_HASH
+            && Code::try_from(code)
+                .ok()
+                .map(|code| &code.digest(block) == k.hash())
+                .unwrap_or_default()
         {
             self.base.put_keyed(k, block)
         } else {


### PR DESCRIPTION
Fix regression from #249 ([fake.rs](https://github.com/filecoin-project/filecoin-ffi/pull/249/files#diff-c1ecb968cfe1f28e114eeb3b28aa1c484370f91199fc741482508b94b838ad31L38-R47)).

`fil_builtin_actors_bundle` car files use arbitrary string keys (identity hash) instead of hashes, but [`rust-multihash`](https://github.com/multiformats/rust-multihash/blob/master/src/hasher_impl.rs#L223) identity hasher can't "hash" such big values (actor wasm code).

without that fix rust panics when calling fvm functions