### PR TITLE
fix: completely remove the multihash identity feature

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -54,7 +54,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.5",
+ "getrandom 0.2.6",
  "once_cell",
  "version_check",
 ]
@@ -235,7 +235,7 @@ checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.17",
- "syn 1.0.89",
+ "syn 1.0.90",
 ]
 
 [[package]]
@@ -598,7 +598,7 @@ dependencies = [
  "quote 1.0.17",
  "serde",
  "serde_json",
- "syn 1.0.89",
+ "syn 1.0.90",
  "tempfile",
  "toml",
 ]
@@ -718,7 +718,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.36",
  "quote 1.0.17",
- "syn 1.0.89",
+ "syn 1.0.90",
 ]
 
 [[package]]
@@ -996,7 +996,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c"
 dependencies = [
  "quote 1.0.17",
- "syn 1.0.89",
+ "syn 1.0.90",
 ]
 
 [[package]]
@@ -1038,7 +1038,7 @@ dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.17",
  "strsim 0.10.0",
- "syn 1.0.89",
+ "syn 1.0.90",
 ]
 
 [[package]]
@@ -1049,7 +1049,7 @@ checksum = "29b5acf0dea37a7f66f7b25d2c5e93fd46f8f6968b1a5d7a3e02e97768afc95a"
 dependencies = [
  "darling_core",
  "quote 1.0.17",
- "syn 1.0.89",
+ "syn 1.0.90",
 ]
 
 [[package]]
@@ -1075,7 +1075,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5bbed42daaa95e780b60a50546aa345b8413a1e46f9a40a12907d3598f038db"
 dependencies = [
  "data-encoding",
- "syn 1.0.89",
+ "syn 1.0.90",
 ]
 
 [[package]]
@@ -1086,7 +1086,7 @@ checksum = "0c5905670fd9c320154f3a4a01c9e609733cd7b753f3c58777ab7d5ce26686b3"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.17",
- "syn 1.0.89",
+ "syn 1.0.90",
 ]
 
 [[package]]
@@ -1107,7 +1107,7 @@ dependencies = [
  "darling",
  "proc-macro2 1.0.36",
  "quote 1.0.17",
- "syn 1.0.89",
+ "syn 1.0.90",
 ]
 
 [[package]]
@@ -1117,7 +1117,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58a94ace95092c5acb1e97a7e846b310cfbd499652f72297da7493f618a98d73"
 dependencies = [
  "derive_builder_core",
- "syn 1.0.89",
+ "syn 1.0.90",
 ]
 
 [[package]]
@@ -1130,7 +1130,7 @@ dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.17",
  "rustc_version",
- "syn 1.0.89",
+ "syn 1.0.90",
 ]
 
 [[package]]
@@ -1286,7 +1286,7 @@ checksum = "af4a304bcd894a5d41f8b379d01e09bff28fd8df257216a33699658ea37bccb8"
 dependencies = [
  "execute-command-tokens",
  "quote 1.0.17",
- "syn 1.0.89",
+ "syn 1.0.90",
 ]
 
 [[package]]
@@ -1373,11 +1373,11 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_account"
-version = "6.0.4"
+version = "6.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e983dcf1aae114c84873c1d9b572b18bde0cb483cb56ccde0e1d7919d1e31cb0"
+checksum = "97f0d14a76097a838a784ace1d59241a1ee20adaceede46b5797033fc6048e1e"
 dependencies = [
- "fil_actors_runtime 6.0.4",
+ "fil_actors_runtime 6.0.6",
  "fvm_shared",
  "num-derive",
  "num-traits",
@@ -1399,9 +1399,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_bundler"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9bec58de1b0b77daaafe8de7dd341182a0163e2ad0e36056013822fab4288a4"
+checksum = "83f813b22186e747f1c713d97113394790718009a861b7620d037a4c4110c3fb"
 dependencies = [
  "anyhow",
  "async-std",
@@ -1410,18 +1410,18 @@ dependencies = [
  "futures",
  "fvm_ipld_car",
  "fvm_shared",
- "multihash",
+ "serde",
  "serde_ipld_dagcbor",
  "serde_json",
 ]
 
 [[package]]
 name = "fil_actor_cron"
-version = "6.0.4"
+version = "6.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc82ee4e3f2f032c07064a9475cbda2cb6f31bdd7c48a243616d99ec22e1ae17"
+checksum = "01f2cb6bf526d4d635031bbd52af5386094c31f5b283e21b9a9eceb422ad78be"
 dependencies = [
- "fil_actors_runtime 6.0.4",
+ "fil_actors_runtime 6.0.6",
  "fvm_shared",
  "log",
  "num-derive",
@@ -1445,13 +1445,13 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_init"
-version = "6.0.4"
+version = "6.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d15a2146d74c2bd79295c6fd6a78aa1d98cbfe5b8a5a18d31a3e61126c41359"
+checksum = "2fa44b996d831719c83b3480899265ecdcdb90594e459bb45a6e041b8160926d"
 dependencies = [
  "anyhow",
  "cid",
- "fil_actors_runtime 6.0.4",
+ "fil_actors_runtime 6.0.6",
  "fvm_ipld_hamt",
  "fvm_shared",
  "log",
@@ -1479,14 +1479,14 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_market"
-version = "6.0.4"
+version = "6.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d11960f2ddadb19b890b94e96de3a3b6546ef2cddd97293a1e47c49ccc1fcab5"
+checksum = "fbcd8169e23142f4374597d743a342011c6932e649fe2ee588c2cb53387509e9"
 dependencies = [
  "ahash",
  "anyhow",
  "cid",
- "fil_actors_runtime 6.0.4",
+ "fil_actors_runtime 6.0.6",
  "fvm_ipld_bitfield",
  "fvm_shared",
  "log",
@@ -1516,14 +1516,14 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_miner"
-version = "6.0.4"
+version = "6.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f9fd532f0b3230ba2202e37094810d8c53afe32b6fc864b5c7a5103649ee00"
+checksum = "ce865e9efb16b865444f8121a8b990e2f9d31b4e37b029a57a19ad4073d883e8"
 dependencies = [
  "anyhow",
  "byteorder 1.4.3",
  "cid",
- "fil_actors_runtime 6.0.4",
+ "fil_actors_runtime 6.0.6",
  "fvm_ipld_amt",
  "fvm_ipld_bitfield",
  "fvm_ipld_hamt",
@@ -1560,13 +1560,13 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_multisig"
-version = "6.0.4"
+version = "6.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0200572126551a1f2d8bbd57976b3c9dd71e6886464f7f94770ad60474e0b1f8"
+checksum = "5a579967a250a065f8be52803299a39b91ec50a0d0dd7ebd70e1faab496368df"
 dependencies = [
  "anyhow",
  "cid",
- "fil_actors_runtime 6.0.4",
+ "fil_actors_runtime 6.0.6",
  "fvm_ipld_hamt",
  "fvm_shared",
  "indexmap",
@@ -1596,13 +1596,13 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_paych"
-version = "6.0.4"
+version = "6.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebbd5d695ccb85a7b48aa76606d473910d9ac1467a84657c4edaa7d4d280589e"
+checksum = "81b594bbb69da2fa0bf098d16205045a8026b3e2bb2fb2ae2bbdb719ae9a6c08"
 dependencies = [
  "anyhow",
  "cid",
- "fil_actors_runtime 6.0.4",
+ "fil_actors_runtime 6.0.6",
  "fvm_shared",
  "num-derive",
  "num-traits",
@@ -1626,13 +1626,13 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_power"
-version = "6.0.4"
+version = "6.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36a6a94336789f1defc1705c7463f818ff8a062a2eaed7773be6a514f867a915"
+checksum = "0e7f1ef69fb86e5eb779d0fa421d801bf93c54e9af0d81499b70a0854dc70499"
 dependencies = [
  "anyhow",
  "cid",
- "fil_actors_runtime 6.0.4",
+ "fil_actors_runtime 6.0.6",
  "fvm_ipld_hamt",
  "fvm_shared",
  "indexmap",
@@ -1666,11 +1666,11 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_reward"
-version = "6.0.4"
+version = "6.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f53d71ddec450efd2c260e1381123c8639e7a7fab41b924bdb2ebb167339c361"
+checksum = "5ceb221fb7399900d21cf85435901c21ebb7ec2f70c99327a2def2e6e0a1359c"
 dependencies = [
- "fil_actors_runtime 6.0.4",
+ "fil_actors_runtime 6.0.6",
  "fvm_shared",
  "lazy_static",
  "log",
@@ -1696,11 +1696,11 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_system"
-version = "6.0.4"
+version = "6.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3d6e3fa9121c1500af5f4791ae2ac3ed38f989efb1ec2818ed81e43ab5e6a3"
+checksum = "938284f5b4769c5592bb89449be362a79c2f7cd710cb6867e3eb38612cfeb8fb"
 dependencies = [
- "fil_actors_runtime 6.0.4",
+ "fil_actors_runtime 6.0.6",
  "fvm_shared",
  "num-derive",
  "num-traits",
@@ -1722,13 +1722,13 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_verifreg"
-version = "6.0.4"
+version = "6.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dd58b50165d53634575e5ea61868ce32db236b1ff88f8c82f0ec9199ad12b4d"
+checksum = "ecb7f1993c3f44ed5f314a03349172ca6a2ecad9ec9ca82c67873cd517a2a7a8"
 dependencies = [
  "anyhow",
  "cid",
- "fil_actors_runtime 6.0.4",
+ "fil_actors_runtime 6.0.6",
  "fvm_shared",
  "lazy_static",
  "num-derive",
@@ -1755,9 +1755,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actors_runtime"
-version = "6.0.4"
+version = "6.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f8a5fb86bd13e134d38b264d6378b9c134ebdcfb0e7d20e411409f9c457715"
+checksum = "58d1ab161513ef701f57c387d534b7d95fae39ff1eb06822cba2a4e3cef5c519"
 dependencies = [
  "anyhow",
  "base64",
@@ -1767,12 +1767,11 @@ dependencies = [
  "fvm_ipld_hamt",
  "fvm_sdk",
  "fvm_shared",
- "getrandom 0.2.5",
+ "getrandom 0.2.6",
  "indexmap",
  "integer-encoding",
  "lazy_static",
  "log",
- "multihash",
  "num-derive",
  "num-traits",
  "serde",
@@ -1794,7 +1793,7 @@ dependencies = [
  "fvm_ipld_hamt",
  "fvm_sdk",
  "fvm_shared",
- "getrandom 0.2.5",
+ "getrandom 0.2.6",
  "indexmap",
  "integer-encoding",
  "lazy_static",
@@ -1808,23 +1807,23 @@ dependencies = [
 
 [[package]]
 name = "fil_builtin_actors_bundle"
-version = "6.0.5"
+version = "6.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "474d65a48e74770f0ee62829b00c11243c3484bbfba2a551326cf7f12afa084b"
+checksum = "1e7a78281fbd87f91f288565643054eb6b7d8d1eebfad7888125b9d57f688a1a"
 dependencies = [
  "cid",
- "fil_actor_account 6.0.4",
+ "fil_actor_account 6.0.6",
  "fil_actor_bundler",
- "fil_actor_cron 6.0.4",
- "fil_actor_init 6.0.4",
- "fil_actor_market 6.0.4",
- "fil_actor_miner 6.0.4",
- "fil_actor_multisig 6.0.4",
- "fil_actor_paych 6.0.4",
- "fil_actor_power 6.0.4",
- "fil_actor_reward 6.0.4",
- "fil_actor_system 6.0.4",
- "fil_actor_verifreg 6.0.4",
+ "fil_actor_cron 6.0.6",
+ "fil_actor_init 6.0.6",
+ "fil_actor_market 6.0.6",
+ "fil_actor_miner 6.0.6",
+ "fil_actor_multisig 6.0.6",
+ "fil_actor_paych 6.0.6",
+ "fil_actor_power 6.0.6",
+ "fil_actor_reward 6.0.6",
+ "fil_actor_system 6.0.6",
+ "fil_actor_verifreg 6.0.6",
 ]
 
 [[package]]
@@ -1874,7 +1873,7 @@ dependencies = [
  "drop_struct_macro_derive",
  "fff",
  "ffi-toolkit",
- "fil_builtin_actors_bundle 6.0.5",
+ "fil_builtin_actors_bundle 6.0.6",
  "fil_builtin_actors_bundle 7.0.7",
  "fil_logger",
  "filecoin-proofs-api",
@@ -2139,7 +2138,7 @@ checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.17",
- "syn 1.0.89",
+ "syn 1.0.90",
 ]
 
 [[package]]
@@ -2345,9 +2344,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
+checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -2819,7 +2818,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.36",
  "quote 1.0.17",
- "syn 1.0.89",
+ "syn 1.0.90",
  "synstructure",
 ]
 
@@ -2923,7 +2922,7 @@ checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.17",
- "syn 1.0.89",
+ "syn 1.0.90",
 ]
 
 [[package]]
@@ -3052,9 +3051,9 @@ checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "paste"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
+checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
 
 [[package]]
 name = "pest"
@@ -3145,7 +3144,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.36",
  "quote 1.0.17",
- "syn 1.0.89",
+ "syn 1.0.90",
  "version_check",
 ]
 
@@ -3304,7 +3303,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom 0.2.5",
+ "getrandom 0.2.6",
 ]
 
 [[package]]
@@ -3374,7 +3373,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7776223e2696f1aa4c6b0170e83212f47296a00424305117d013dfe86fb0fe55"
 dependencies = [
- "getrandom 0.2.5",
+ "getrandom 0.2.6",
  "redox_syscall",
  "thiserror",
 ]
@@ -3464,7 +3463,7 @@ checksum = "43ce8670a1a1d0fc2514a3b846dacdb65646f9bd494b6674cfacbb4ce430bd7e"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.17",
- "syn 1.0.89",
+ "syn 1.0.90",
 ]
 
 [[package]]
@@ -3491,7 +3490,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.6",
+ "semver 1.0.7",
 ]
 
 [[package]]
@@ -3531,9 +3530,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
+checksum = "d65bd28f48be7196d222d95b9243287f48d27aca604e08497513019ff0502cc4"
 
 [[package]]
 name = "semver-parser"
@@ -3579,7 +3578,7 @@ checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.17",
- "syn 1.0.89",
+ "syn 1.0.90",
 ]
 
 [[package]]
@@ -3612,7 +3611,7 @@ checksum = "98d0516900518c29efa217c298fa1f4e6c6ffc85ae29fd7f4ee48f176e1a9ed5"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.17",
- "syn 1.0.89",
+ "syn 1.0.90",
 ]
 
 [[package]]
@@ -3633,7 +3632,7 @@ checksum = "4076151d1a2b688e25aaf236997933c66e18b870d0369f8b248b8ab2be630d7e"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.17",
- "syn 1.0.89",
+ "syn 1.0.90",
 ]
 
 [[package]]
@@ -3938,9 +3937,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.89"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea297be220d52398dcc07ce15a209fce436d361735ac1db700cab3b6cdfb9f54"
+checksum = "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.17",
@@ -3955,7 +3954,7 @@ checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.17",
- "syn 1.0.89",
+ "syn 1.0.90",
  "unicode-xid 0.2.2",
 ]
 
@@ -4036,7 +4035,7 @@ checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.17",
- "syn 1.0.89",
+ "syn 1.0.90",
 ]
 
 [[package]]
@@ -4170,7 +4169,7 @@ dependencies = [
  "log",
  "proc-macro2 1.0.36",
  "quote 1.0.17",
- "syn 1.0.89",
+ "syn 1.0.90",
  "wasm-bindgen-shared",
 ]
 
@@ -4204,7 +4203,7 @@ checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.17",
- "syn 1.0.89",
+ "syn 1.0.90",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4456,6 +4455,6 @@ checksum = "4eb56561c1f8f5441784ea91f52ae8b44268d920f2a59121968fec9297fa7157"
 dependencies = [
  "proc-macro2 1.0.36",
  "quote 1.0.17",
- "syn 1.0.89",
+ "syn 1.0.90",
  "synstructure",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,7 +10,8 @@ authors = [
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/filecoin-project/filecoin-ffi"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
+resolver = "2"
 publish = false
 
 [lib]
@@ -41,7 +42,7 @@ fr32 = { version = "~4.0", default-features = false }
 fvm = { version = "0.2.1", default-features = false }
 fvm_ipld_car = { version = "0.2.0" }
 fvm_shared = { version = "0.2.1" }
-actors-v6 = { package = "fil_builtin_actors_bundle", version = "6.0.5" }
+actors-v6 = { package = "fil_builtin_actors_bundle", version = "6.0.6" }
 actors-v7 = { package = "fil_builtin_actors_bundle", version = "7.0.7" }
 num-traits = "0.2.14"
 num-bigint = "0.4"


### PR DESCRIPTION
And switch to rust edition 2021, with the version-2 feature resolver. This fixes the panic in the FVM constructor.

See https://github.com/filecoin-project/filecoin-ffi/pull/251.