### PR TITLE
chore: update fvm & actors

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1373,11 +1373,11 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_account"
-version = "6.0.6"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97f0d14a76097a838a784ace1d59241a1ee20adaceede46b5797033fc6048e1e"
+checksum = "8a24de92a239b73cc754153fc72d5e2eafc894091b9a2ba7aaa5ae7b762a2c89"
 dependencies = [
- "fil_actors_runtime 6.0.6",
+ "fil_actors_runtime 6.1.0",
  "fvm_shared",
  "num-derive",
  "num-traits",
@@ -1386,11 +1386,11 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_account"
-version = "7.0.7"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f3ae4a5bff7502fa1de56afcaaf10526c9be4d20b33baf5ee1199883560d03"
+checksum = "e2e126a9b5eb81b4eda1b57f1fa355276c710bb51dba1b0be156be061e9bd514"
 dependencies = [
- "fil_actors_runtime 7.0.7",
+ "fil_actors_runtime 7.1.0",
  "fvm_shared",
  "num-derive",
  "num-traits",
@@ -1399,9 +1399,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_bundler"
-version = "1.0.3"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83f813b22186e747f1c713d97113394790718009a861b7620d037a4c4110c3fb"
+checksum = "acdb9c600e969dec295da976f2f649babefe6f216cb6db9a26ecc35b2cd5a2c1"
 dependencies = [
  "anyhow",
  "async-std",
@@ -1417,11 +1417,11 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_cron"
-version = "6.0.6"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01f2cb6bf526d4d635031bbd52af5386094c31f5b283e21b9a9eceb422ad78be"
+checksum = "35185449dd7307b7407e3a493d2e45021542ef0ddecc9374b81c734102a80371"
 dependencies = [
- "fil_actors_runtime 6.0.6",
+ "fil_actors_runtime 6.1.0",
  "fvm_shared",
  "log",
  "num-derive",
@@ -1431,11 +1431,11 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_cron"
-version = "7.0.7"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9ca1905ee44c4e2173038af444cf19890026d81e7a6ebc1c99631d7d5c5900d"
+checksum = "cd5cd5ca2ff85a19a2ea761c7416e61d3b0b3a9ccab8f004968008495c7e69aa"
 dependencies = [
- "fil_actors_runtime 7.0.7",
+ "fil_actors_runtime 7.1.0",
  "fvm_shared",
  "log",
  "num-derive",
@@ -1445,13 +1445,13 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_init"
-version = "6.0.6"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fa44b996d831719c83b3480899265ecdcdb90594e459bb45a6e041b8160926d"
+checksum = "5cfe1e8801faa75fbd986bd4c3a3e61152eb18fc1b6a982e24fca02412ca4506"
 dependencies = [
  "anyhow",
  "cid",
- "fil_actors_runtime 6.0.6",
+ "fil_actors_runtime 6.1.0",
  "fvm_ipld_hamt",
  "fvm_shared",
  "log",
@@ -1462,13 +1462,13 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_init"
-version = "7.0.7"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ccd75de479ad0d76255d52e606a9509a286b6533bb7fc10c39c21c074801a4e"
+checksum = "421de19e63c58591243977f9ade8257e4d201f67cfcec27135b4cb2613655347"
 dependencies = [
  "anyhow",
  "cid",
- "fil_actors_runtime 7.0.7",
+ "fil_actors_runtime 7.1.0",
  "fvm_ipld_hamt",
  "fvm_shared",
  "log",
@@ -1479,14 +1479,14 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_market"
-version = "6.0.6"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbcd8169e23142f4374597d743a342011c6932e649fe2ee588c2cb53387509e9"
+checksum = "9f09d51871aba20d8339faff9bc53e4c79b6fc985cf2bf78d77a757e73823e8d"
 dependencies = [
  "ahash",
  "anyhow",
  "cid",
- "fil_actors_runtime 6.0.6",
+ "fil_actors_runtime 6.1.0",
  "fvm_ipld_bitfield",
  "fvm_shared",
  "log",
@@ -1497,14 +1497,14 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_market"
-version = "7.0.7"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b07f51c41ea0f838ab924645dd4e6ceb52ba740ba6ed076717c624dca69ff083"
+checksum = "2c941b513ca27b7cca60eb24fcf0662d851c8e23e3e9fe0cb8202ac9ccd516d5"
 dependencies = [
  "ahash",
  "anyhow",
  "cid",
- "fil_actors_runtime 7.0.7",
+ "fil_actors_runtime 7.1.0",
  "fvm_ipld_bitfield",
  "fvm_ipld_hamt",
  "fvm_shared",
@@ -1516,14 +1516,14 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_miner"
-version = "6.0.6"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce865e9efb16b865444f8121a8b990e2f9d31b4e37b029a57a19ad4073d883e8"
+checksum = "6bdb2a44ff8398188704a5a62d06addcad1be6da3c8dad7dd23d1f4e478931a9"
 dependencies = [
  "anyhow",
  "byteorder 1.4.3",
  "cid",
- "fil_actors_runtime 6.0.6",
+ "fil_actors_runtime 6.1.0",
  "fvm_ipld_amt",
  "fvm_ipld_bitfield",
  "fvm_ipld_hamt",
@@ -1538,14 +1538,14 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_miner"
-version = "7.0.7"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a6b0d350aacde7950e53cd6dc71b29db73dfbfcf816015937201a6f84596fa4"
+checksum = "203fb60940839bbf0e77e2a4be393a9d4a0e3b76fa658acf3d52ce67ea4dc6aa"
 dependencies = [
  "anyhow",
  "byteorder 1.4.3",
  "cid",
- "fil_actors_runtime 7.0.7",
+ "fil_actors_runtime 7.1.0",
  "fvm_ipld_amt",
  "fvm_ipld_bitfield",
  "fvm_ipld_hamt",
@@ -1560,13 +1560,13 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_multisig"
-version = "6.0.6"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a579967a250a065f8be52803299a39b91ec50a0d0dd7ebd70e1faab496368df"
+checksum = "0c70e508c07fc0d7ba2686ffef6429d709d41e5a1ae91382f58ef3a1862f43c8"
 dependencies = [
  "anyhow",
  "cid",
- "fil_actors_runtime 6.0.6",
+ "fil_actors_runtime 6.1.0",
  "fvm_ipld_hamt",
  "fvm_shared",
  "indexmap",
@@ -1578,13 +1578,13 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_multisig"
-version = "7.0.7"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1156e4983e535a7a820d805a7b98b8cd46c883f83fd3c13c7765dd2ca9658214"
+checksum = "dc4061211f5bd7bd99ecad4a39c0d6bf11cae4548f90a12505ea438b85acf215"
 dependencies = [
  "anyhow",
  "cid",
- "fil_actors_runtime 7.0.7",
+ "fil_actors_runtime 7.1.0",
  "fvm_ipld_hamt",
  "fvm_shared",
  "indexmap",
@@ -1596,13 +1596,13 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_paych"
-version = "6.0.6"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b594bbb69da2fa0bf098d16205045a8026b3e2bb2fb2ae2bbdb719ae9a6c08"
+checksum = "6715551705639bf9f8f640e89b8f347178ae82449e28a2570a5c0750b9b89710"
 dependencies = [
  "anyhow",
  "cid",
- "fil_actors_runtime 6.0.6",
+ "fil_actors_runtime 6.1.0",
  "fvm_shared",
  "num-derive",
  "num-traits",
@@ -1611,13 +1611,13 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_paych"
-version = "7.0.7"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81f7c51ed7b495a9a00f60cce226d3c75cce37e0858446dc95d43c68c4c42ef"
+checksum = "2588d321d1d604b12331c1585c2f89bd473b78f6276cd68a37f7cca88541b98f"
 dependencies = [
  "anyhow",
  "cid",
- "fil_actors_runtime 7.0.7",
+ "fil_actors_runtime 7.1.0",
  "fvm_shared",
  "num-derive",
  "num-traits",
@@ -1626,13 +1626,13 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_power"
-version = "6.0.6"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7f1ef69fb86e5eb779d0fa421d801bf93c54e9af0d81499b70a0854dc70499"
+checksum = "d937e0a724afbe957a66883372dcc9a68eb5d031df7ec761f07be793194704b6"
 dependencies = [
  "anyhow",
  "cid",
- "fil_actors_runtime 6.0.6",
+ "fil_actors_runtime 6.1.0",
  "fvm_ipld_hamt",
  "fvm_shared",
  "indexmap",
@@ -1646,13 +1646,13 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_power"
-version = "7.0.7"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b0325169497153c336eb51f622477c2101dfdfda3756d6f354626936c4516f"
+checksum = "416e4442a1b0bc4750ba5a41178e138560bc8e57712661125af81371ec120c03"
 dependencies = [
  "anyhow",
  "cid",
- "fil_actors_runtime 7.0.7",
+ "fil_actors_runtime 7.1.0",
  "fvm_ipld_hamt",
  "fvm_shared",
  "indexmap",
@@ -1666,11 +1666,11 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_reward"
-version = "6.0.6"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ceb221fb7399900d21cf85435901c21ebb7ec2f70c99327a2def2e6e0a1359c"
+checksum = "16b335ea867ad146bdc3542d8c6450e3cd09f02715fd72dca9762e8af8db52d4"
 dependencies = [
- "fil_actors_runtime 6.0.6",
+ "fil_actors_runtime 6.1.0",
  "fvm_shared",
  "lazy_static",
  "log",
@@ -1681,11 +1681,11 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_reward"
-version = "7.0.7"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73d29df286b97ceee0d13df9c063b03c66fba8f8c0e88b766ac10c1b0caf5175"
+checksum = "9fa31c98586e3a0be1a602e67fc94bd9c01888e8c1c630acc4fefb2e62ba3e3c"
 dependencies = [
- "fil_actors_runtime 7.0.7",
+ "fil_actors_runtime 7.1.0",
  "fvm_shared",
  "lazy_static",
  "log",
@@ -1696,11 +1696,11 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_system"
-version = "6.0.6"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938284f5b4769c5592bb89449be362a79c2f7cd710cb6867e3eb38612cfeb8fb"
+checksum = "ca15548b4c156fe24e940bba687163ba24d9ee0ec638c0c440389accee38c18c"
 dependencies = [
- "fil_actors_runtime 6.0.6",
+ "fil_actors_runtime 6.1.0",
  "fvm_shared",
  "num-derive",
  "num-traits",
@@ -1709,11 +1709,11 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_system"
-version = "7.0.7"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a39278c0ea027170393144edc29d14ba2d63cbd506211baf3f44423a14d3abd"
+checksum = "a23f15d73aff829ae181c7c285fe51e3fff817bb0e4de73938bd1be028d855d3"
 dependencies = [
- "fil_actors_runtime 7.0.7",
+ "fil_actors_runtime 7.1.0",
  "fvm_shared",
  "num-derive",
  "num-traits",
@@ -1722,13 +1722,13 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_verifreg"
-version = "6.0.6"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecb7f1993c3f44ed5f314a03349172ca6a2ecad9ec9ca82c67873cd517a2a7a8"
+checksum = "68473798aacc7695917a1143c1a8b53a192eda6e0861a30c4ca8e035e24a488c"
 dependencies = [
  "anyhow",
  "cid",
- "fil_actors_runtime 6.0.6",
+ "fil_actors_runtime 6.1.0",
  "fvm_shared",
  "lazy_static",
  "num-derive",
@@ -1738,13 +1738,13 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_verifreg"
-version = "7.0.7"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1714b6157993c007f2356cb0b2da4c6f9fb9d44a802464151ff2bde427d58839"
+checksum = "3220c98003260fdeca9766313df42d4a781e22e5e1b1b455ad6e0316baed94d7"
 dependencies = [
  "anyhow",
  "cid",
- "fil_actors_runtime 7.0.7",
+ "fil_actors_runtime 7.1.0",
  "fvm_ipld_hamt",
  "fvm_shared",
  "lazy_static",
@@ -1755,9 +1755,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actors_runtime"
-version = "6.0.6"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58d1ab161513ef701f57c387d534b7d95fae39ff1eb06822cba2a4e3cef5c519"
+checksum = "3f4e6adf9b0854aaadce33a09ab155eb8f89fb07f6e7400935dfe0c651e15450"
 dependencies = [
  "anyhow",
  "base64",
@@ -1781,9 +1781,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actors_runtime"
-version = "7.0.7"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4683999cd0f556a90cf1b356e3bb9cec1f7b9af6ff912df0ff60ad2d17bf2c6"
+checksum = "75255db97d40384153be52a2360212c855376476780b41f1709452cd3b8b0c77"
 dependencies = [
  "anyhow",
  "base64",
@@ -1807,45 +1807,45 @@ dependencies = [
 
 [[package]]
 name = "fil_builtin_actors_bundle"
-version = "6.0.6"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7a78281fbd87f91f288565643054eb6b7d8d1eebfad7888125b9d57f688a1a"
+checksum = "8f7c97ab28a52fc23d107357c5a622713318df7787d0b9f5fb5ea737a583c93a"
 dependencies = [
  "cid",
- "fil_actor_account 6.0.6",
+ "fil_actor_account 6.1.0",
  "fil_actor_bundler",
- "fil_actor_cron 6.0.6",
- "fil_actor_init 6.0.6",
- "fil_actor_market 6.0.6",
- "fil_actor_miner 6.0.6",
- "fil_actor_multisig 6.0.6",
- "fil_actor_paych 6.0.6",
- "fil_actor_power 6.0.6",
- "fil_actor_reward 6.0.6",
- "fil_actor_system 6.0.6",
- "fil_actor_verifreg 6.0.6",
+ "fil_actor_cron 6.1.0",
+ "fil_actor_init 6.1.0",
+ "fil_actor_market 6.1.0",
+ "fil_actor_miner 6.1.0",
+ "fil_actor_multisig 6.1.0",
+ "fil_actor_paych 6.1.0",
+ "fil_actor_power 6.1.0",
+ "fil_actor_reward 6.1.0",
+ "fil_actor_system 6.1.0",
+ "fil_actor_verifreg 6.1.0",
 ]
 
 [[package]]
 name = "fil_builtin_actors_bundle"
-version = "7.0.7"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349ff2b01c578777d45b3435db0b614c1920388a295462c0a8a666b64871f351"
+checksum = "7942ce03f298265db03193e2d09da60a9099214cce0b13eb182219db43a3d1ed"
 dependencies = [
  "cid",
- "fil_actor_account 7.0.7",
+ "fil_actor_account 7.1.0",
  "fil_actor_bundler",
- "fil_actor_cron 7.0.7",
- "fil_actor_init 7.0.7",
- "fil_actor_market 7.0.7",
- "fil_actor_miner 7.0.7",
- "fil_actor_multisig 7.0.7",
- "fil_actor_paych 7.0.7",
- "fil_actor_power 7.0.7",
- "fil_actor_reward 7.0.7",
- "fil_actor_system 7.0.7",
- "fil_actor_verifreg 7.0.7",
- "fil_actors_runtime 7.0.7",
+ "fil_actor_cron 7.1.0",
+ "fil_actor_init 7.1.0",
+ "fil_actor_market 7.1.0",
+ "fil_actor_miner 7.1.0",
+ "fil_actor_multisig 7.1.0",
+ "fil_actor_paych 7.1.0",
+ "fil_actor_power 7.1.0",
+ "fil_actor_reward 7.1.0",
+ "fil_actor_system 7.1.0",
+ "fil_actor_verifreg 7.1.0",
+ "fil_actors_runtime 7.1.0",
 ]
 
 [[package]]
@@ -1873,8 +1873,8 @@ dependencies = [
  "drop_struct_macro_derive",
  "fff",
  "ffi-toolkit",
- "fil_builtin_actors_bundle 6.0.6",
- "fil_builtin_actors_bundle 7.0.7",
+ "fil_builtin_actors_bundle 6.1.0",
+ "fil_builtin_actors_bundle 7.1.0",
  "fil_logger",
  "filecoin-proofs-api",
  "filepath",
@@ -2173,9 +2173,9 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf85081bb8f5d9856acd98f7e74e9a9b92f979686529d30368687487507e8a73"
+checksum = "75f7a3f72541c679e8cdee9c6cd44ea37115d152cee51f0890cfeaa20b9ff1d0"
 dependencies = [
  "ahash",
  "anyhow",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -39,14 +39,14 @@ memmap = "0.7"
 rust-gpu-tools = { version = "0.5", default-features = false }
 storage-proofs-porep = { version = "~11.0", default-features = false }
 fr32 = { version = "~4.0", default-features = false }
-fvm = { version = "0.2.1", default-features = false }
+fvm = { version = "0.3.0", default-features = false }
 fvm_ipld_car = { version = "0.2.0" }
-fvm_shared = { version = "0.2.1" }
-actors-v6 = { package = "fil_builtin_actors_bundle", version = "6.0.6" }
-actors-v7 = { package = "fil_builtin_actors_bundle", version = "7.0.7" }
+fvm_shared = { version = "0.2.2" }
+actors-v6 = { package = "fil_builtin_actors_bundle", version = "6.1.0" }
+actors-v7 = { package = "fil_builtin_actors_bundle", version = "7.1.0" }
 num-traits = "0.2.14"
 num-bigint = "0.4"
-cid = { version = "0.8.2", features = ["serde-codec"] }
+cid = { version = "0.8.3", features = ["serde-codec"] }
 lazy_static = "1.4.0"
 once_cell = "1.9.0"
 serde = "1.0.117"

--- a/rust/src/fvm/machine.rs
+++ b/rust/src/fvm/machine.rs
@@ -109,7 +109,7 @@ pub unsafe extern "C" fn fil_create_fvm_machine(
             base_circ_supply,
             network_version,
             state_root,
-            builtin_actors,
+            Some(builtin_actors),
             blockstore,
             externs,
         );


### PR DESCRIPTION
This switches to the new bundle method. And makes everything work again.