### PR TITLE
feat: catch panics in the cgo externs

### DIFF
--- a/cgo/blockstore.go
+++ b/cgo/blockstore.go
@@ -24,7 +24,14 @@ func toCid(k C.buf_t, kLen C.int32_t) cid.Cid {
 }
 
 //export cgo_blockstore_get
-func cgo_blockstore_get(handle C.uint64_t, k C.buf_t, kLen C.int32_t, block **C.uint8_t, size *C.int32_t) C.int32_t {
+func cgo_blockstore_get(handle C.uint64_t, k C.buf_t, kLen C.int32_t, block **C.uint8_t, size *C.int32_t) (res C.int32_t) {
+	defer func() {
+		if rerr := recover(); rerr != nil {
+			logPanic(rerr)
+			res = ErrPanic
+		}
+	}()
+
 	c := toCid(k, kLen)
 	externs, ctx := Lookup(uint64(handle))
 	if externs == nil {
@@ -48,7 +55,14 @@ func cgo_blockstore_get(handle C.uint64_t, k C.buf_t, kLen C.int32_t, block **C.
 }
 
 //export cgo_blockstore_put
-func cgo_blockstore_put(handle C.uint64_t, k C.buf_t, kLen C.int32_t, block C.buf_t, blockLen C.int32_t) C.int32_t {
+func cgo_blockstore_put(handle C.uint64_t, k C.buf_t, kLen C.int32_t, block C.buf_t, blockLen C.int32_t) (res C.int32_t) {
+	defer func() {
+		if rerr := recover(); rerr != nil {
+			logPanic(rerr)
+			res = ErrPanic
+		}
+	}()
+
 	c := toCid(k, kLen)
 	externs, ctx := Lookup(uint64(handle))
 	if externs == nil {
@@ -62,7 +76,13 @@ func cgo_blockstore_put(handle C.uint64_t, k C.buf_t, kLen C.int32_t, block C.bu
 }
 
 //export cgo_blockstore_put_many
-func cgo_blockstore_put_many(handle C.uint64_t, lengths *C.int32_t, lengthsLen C.int32_t, blockBuf C.buf_t) C.int32_t {
+func cgo_blockstore_put_many(handle C.uint64_t, lengths *C.int32_t, lengthsLen C.int32_t, blockBuf C.buf_t) (res C.int32_t) {
+	defer func() {
+		if rerr := recover(); rerr != nil {
+			logPanic(rerr)
+			res = ErrPanic
+		}
+	}()
 	externs, ctx := Lookup(uint64(handle))
 	if externs == nil {
 		return ErrInvalidHandle
@@ -108,7 +128,14 @@ func cgo_blockstore_put_many(handle C.uint64_t, lengths *C.int32_t, lengthsLen C
 }
 
 //export cgo_blockstore_has
-func cgo_blockstore_has(handle C.uint64_t, k C.buf_t, kLen C.int32_t) C.int32_t {
+func cgo_blockstore_has(handle C.uint64_t, k C.buf_t, kLen C.int32_t) (res C.int32_t) {
+	defer func() {
+		if rerr := recover(); rerr != nil {
+			logPanic(rerr)
+			res = ErrPanic
+		}
+	}()
+
 	c := toCid(k, kLen)
 	externs, ctx := Lookup(uint64(handle))
 	if externs == nil {

--- a/cgo/errors.go
+++ b/cgo/errors.go
@@ -5,10 +5,21 @@ package cgo
 // #cgo pkg-config: ${SRCDIR}/../filcrypto.pc
 // #include "../filcrypto.h"
 import "C"
+import (
+	"fmt"
+	"os"
+	"runtime/debug"
+)
 
 const (
 	ErrInvalidHandle   = C.ERR_INVALID_HANDLE
 	ErrNotFound        = C.ERR_NOT_FOUND
 	ErrIO              = C.ERR_IO
 	ErrInvalidArgument = C.ERR_INVALID_ARGUMENT
+	ErrPanic           = C.ERR_PANIC
 )
+
+func logPanic(err interface{}) {
+	fmt.Fprintf(os.Stderr, "panic in cgo externs: %s\n", err)
+	debug.PrintStack()
+}

--- a/generated/const.go
+++ b/generated/const.go
@@ -13,10 +13,10 @@ package generated
 */
 import "C"
 
-// FCPResponseStatus as declared in filecoin-ffi/filcrypto.h:51
+// FCPResponseStatus as declared in filecoin-ffi/filcrypto.h:56
 type FCPResponseStatus int32
 
-// FCPResponseStatus enumeration from filecoin-ffi/filcrypto.h:51
+// FCPResponseStatus enumeration from filecoin-ffi/filcrypto.h:56
 const (
 	FCPResponseStatusFCPNoError           FCPResponseStatus = C.FCPResponseStatus_FCPNoError
 	FCPResponseStatusFCPUnclassifiedError FCPResponseStatus = C.FCPResponseStatus_FCPUnclassifiedError
@@ -24,26 +24,26 @@ const (
 	FCPResponseStatusFCPReceiverError     FCPResponseStatus = C.FCPResponseStatus_FCPReceiverError
 )
 
-// FilFvmRegisteredVersion as declared in filecoin-ffi/filcrypto.h:55
+// FilFvmRegisteredVersion as declared in filecoin-ffi/filcrypto.h:60
 type FilFvmRegisteredVersion int32
 
-// FilFvmRegisteredVersion enumeration from filecoin-ffi/filcrypto.h:55
+// FilFvmRegisteredVersion enumeration from filecoin-ffi/filcrypto.h:60
 const (
 	FilFvmRegisteredVersionV1 FilFvmRegisteredVersion = C.fil_FvmRegisteredVersion_V1
 )
 
-// FilRegisteredAggregationProof as declared in filecoin-ffi/filcrypto.h:59
+// FilRegisteredAggregationProof as declared in filecoin-ffi/filcrypto.h:64
 type FilRegisteredAggregationProof int32
 
-// FilRegisteredAggregationProof enumeration from filecoin-ffi/filcrypto.h:59
+// FilRegisteredAggregationProof enumeration from filecoin-ffi/filcrypto.h:64
 const (
 	FilRegisteredAggregationProofSnarkPackV1 FilRegisteredAggregationProof = C.fil_RegisteredAggregationProof_SnarkPackV1
 )
 
-// FilRegisteredPoStProof as declared in filecoin-ffi/filcrypto.h:72
+// FilRegisteredPoStProof as declared in filecoin-ffi/filcrypto.h:77
 type FilRegisteredPoStProof int32
 
-// FilRegisteredPoStProof enumeration from filecoin-ffi/filcrypto.h:72
+// FilRegisteredPoStProof enumeration from filecoin-ffi/filcrypto.h:77
 const (
 	FilRegisteredPoStProofStackedDrgWinning2KiBV1   FilRegisteredPoStProof = C.fil_RegisteredPoStProof_StackedDrgWinning2KiBV1
 	FilRegisteredPoStProofStackedDrgWinning8MiBV1   FilRegisteredPoStProof = C.fil_RegisteredPoStProof_StackedDrgWinning8MiBV1
@@ -57,10 +57,10 @@ const (
 	FilRegisteredPoStProofStackedDrgWindow64GiBV1   FilRegisteredPoStProof = C.fil_RegisteredPoStProof_StackedDrgWindow64GiBV1
 )
 
-// FilRegisteredSealProof as declared in filecoin-ffi/filcrypto.h:85
+// FilRegisteredSealProof as declared in filecoin-ffi/filcrypto.h:90
 type FilRegisteredSealProof int32
 
-// FilRegisteredSealProof enumeration from filecoin-ffi/filcrypto.h:85
+// FilRegisteredSealProof enumeration from filecoin-ffi/filcrypto.h:90
 const (
 	FilRegisteredSealProofStackedDrg2KiBV1    FilRegisteredSealProof = C.fil_RegisteredSealProof_StackedDrg2KiBV1
 	FilRegisteredSealProofStackedDrg8MiBV1    FilRegisteredSealProof = C.fil_RegisteredSealProof_StackedDrg8MiBV1
@@ -74,10 +74,10 @@ const (
 	FilRegisteredSealProofStackedDrg64GiBV11  FilRegisteredSealProof = C.fil_RegisteredSealProof_StackedDrg64GiBV1_1
 )
 
-// FilRegisteredUpdateProof as declared in filecoin-ffi/filcrypto.h:93
+// FilRegisteredUpdateProof as declared in filecoin-ffi/filcrypto.h:98
 type FilRegisteredUpdateProof int32
 
-// FilRegisteredUpdateProof enumeration from filecoin-ffi/filcrypto.h:93
+// FilRegisteredUpdateProof enumeration from filecoin-ffi/filcrypto.h:98
 const (
 	FilRegisteredUpdateProofStackedDrg2KiBV1   FilRegisteredUpdateProof = C.fil_RegisteredUpdateProof_StackedDrg2KiBV1
 	FilRegisteredUpdateProofStackedDrg8MiBV1   FilRegisteredUpdateProof = C.fil_RegisteredUpdateProof_StackedDrg8MiBV1

--- a/generated/generated.go
+++ b/generated/generated.go
@@ -17,7 +17,7 @@ import (
 	"unsafe"
 )
 
-// FilHash function as declared in filecoin-ffi/filcrypto.h:480
+// FilHash function as declared in filecoin-ffi/filcrypto.h:485
 func FilHash(messagePtr []byte, messageLen uint) *FilHashResponse {
 	cmessagePtr, cmessagePtrAllocMap := copyPUint8TBytes((*sliceHeader)(unsafe.Pointer(&messagePtr)))
 	cmessageLen, cmessageLenAllocMap := (C.size_t)(messageLen), cgoAllocsUnknown
@@ -28,7 +28,7 @@ func FilHash(messagePtr []byte, messageLen uint) *FilHashResponse {
 	return __v
 }
 
-// FilAggregate function as declared in filecoin-ffi/filcrypto.h:492
+// FilAggregate function as declared in filecoin-ffi/filcrypto.h:497
 func FilAggregate(flattenedSignaturesPtr []byte, flattenedSignaturesLen uint) *FilAggregateResponse {
 	cflattenedSignaturesPtr, cflattenedSignaturesPtrAllocMap := copyPUint8TBytes((*sliceHeader)(unsafe.Pointer(&flattenedSignaturesPtr)))
 	cflattenedSignaturesLen, cflattenedSignaturesLenAllocMap := (C.size_t)(flattenedSignaturesLen), cgoAllocsUnknown
@@ -39,7 +39,7 @@ func FilAggregate(flattenedSignaturesPtr []byte, flattenedSignaturesLen uint) *F
 	return __v
 }
 
-// FilVerify function as declared in filecoin-ffi/filcrypto.h:506
+// FilVerify function as declared in filecoin-ffi/filcrypto.h:511
 func FilVerify(signaturePtr []byte, flattenedDigestsPtr []byte, flattenedDigestsLen uint, flattenedPublicKeysPtr []byte, flattenedPublicKeysLen uint) int32 {
 	csignaturePtr, csignaturePtrAllocMap := copyPUint8TBytes((*sliceHeader)(unsafe.Pointer(&signaturePtr)))
 	cflattenedDigestsPtr, cflattenedDigestsPtrAllocMap := copyPUint8TBytes((*sliceHeader)(unsafe.Pointer(&flattenedDigestsPtr)))
@@ -56,7 +56,7 @@ func FilVerify(signaturePtr []byte, flattenedDigestsPtr []byte, flattenedDigests
 	return __v
 }
 
-// FilHashVerify function as declared in filecoin-ffi/filcrypto.h:524
+// FilHashVerify function as declared in filecoin-ffi/filcrypto.h:529
 func FilHashVerify(signaturePtr []byte, flattenedMessagesPtr []byte, flattenedMessagesLen uint, messageSizesPtr []uint, messageSizesLen uint, flattenedPublicKeysPtr []byte, flattenedPublicKeysLen uint) int32 {
 	csignaturePtr, csignaturePtrAllocMap := copyPUint8TBytes((*sliceHeader)(unsafe.Pointer(&signaturePtr)))
 	cflattenedMessagesPtr, cflattenedMessagesPtrAllocMap := copyPUint8TBytes((*sliceHeader)(unsafe.Pointer(&flattenedMessagesPtr)))
@@ -77,14 +77,14 @@ func FilHashVerify(signaturePtr []byte, flattenedMessagesPtr []byte, flattenedMe
 	return __v
 }
 
-// FilPrivateKeyGenerate function as declared in filecoin-ffi/filcrypto.h:535
+// FilPrivateKeyGenerate function as declared in filecoin-ffi/filcrypto.h:540
 func FilPrivateKeyGenerate() *FilPrivateKeyGenerateResponse {
 	__ret := C.fil_private_key_generate()
 	__v := NewFilPrivateKeyGenerateResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
 
-// FilPrivateKeyGenerateWithSeed function as declared in filecoin-ffi/filcrypto.h:548
+// FilPrivateKeyGenerateWithSeed function as declared in filecoin-ffi/filcrypto.h:553
 func FilPrivateKeyGenerateWithSeed(rawSeed Fil32ByteArray) *FilPrivateKeyGenerateResponse {
 	crawSeed, crawSeedAllocMap := rawSeed.PassValue()
 	__ret := C.fil_private_key_generate_with_seed(crawSeed)
@@ -93,7 +93,7 @@ func FilPrivateKeyGenerateWithSeed(rawSeed Fil32ByteArray) *FilPrivateKeyGenerat
 	return __v
 }
 
-// FilPrivateKeySign function as declared in filecoin-ffi/filcrypto.h:561
+// FilPrivateKeySign function as declared in filecoin-ffi/filcrypto.h:566
 func FilPrivateKeySign(rawPrivateKeyPtr []byte, messagePtr []byte, messageLen uint) *FilPrivateKeySignResponse {
 	crawPrivateKeyPtr, crawPrivateKeyPtrAllocMap := copyPUint8TBytes((*sliceHeader)(unsafe.Pointer(&rawPrivateKeyPtr)))
 	cmessagePtr, cmessagePtrAllocMap := copyPUint8TBytes((*sliceHeader)(unsafe.Pointer(&messagePtr)))
@@ -106,7 +106,7 @@ func FilPrivateKeySign(rawPrivateKeyPtr []byte, messagePtr []byte, messageLen ui
 	return __v
 }
 
-// FilPrivateKeyPublicKey function as declared in filecoin-ffi/filcrypto.h:574
+// FilPrivateKeyPublicKey function as declared in filecoin-ffi/filcrypto.h:579
 func FilPrivateKeyPublicKey(rawPrivateKeyPtr []byte) *FilPrivateKeyPublicKeyResponse {
 	crawPrivateKeyPtr, crawPrivateKeyPtrAllocMap := copyPUint8TBytes((*sliceHeader)(unsafe.Pointer(&rawPrivateKeyPtr)))
 	__ret := C.fil_private_key_public_key(crawPrivateKeyPtr)
@@ -115,63 +115,63 @@ func FilPrivateKeyPublicKey(rawPrivateKeyPtr []byte) *FilPrivateKeyPublicKeyResp
 	return __v
 }
 
-// FilCreateZeroSignature function as declared in filecoin-ffi/filcrypto.h:581
+// FilCreateZeroSignature function as declared in filecoin-ffi/filcrypto.h:586
 func FilCreateZeroSignature() *FilZeroSignatureResponse {
 	__ret := C.fil_create_zero_signature()
 	__v := NewFilZeroSignatureResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
 
-// FilDropSignature function as declared in filecoin-ffi/filcrypto.h:586
+// FilDropSignature function as declared in filecoin-ffi/filcrypto.h:591
 func FilDropSignature(sig []byte) {
 	csig, csigAllocMap := copyPUint8TBytes((*sliceHeader)(unsafe.Pointer(&sig)))
 	C.fil_drop_signature(csig)
 	runtime.KeepAlive(csigAllocMap)
 }
 
-// FilDestroyHashResponse function as declared in filecoin-ffi/filcrypto.h:588
+// FilDestroyHashResponse function as declared in filecoin-ffi/filcrypto.h:593
 func FilDestroyHashResponse(ptr *FilHashResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_hash_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroyAggregateResponse function as declared in filecoin-ffi/filcrypto.h:590
+// FilDestroyAggregateResponse function as declared in filecoin-ffi/filcrypto.h:595
 func FilDestroyAggregateResponse(ptr *FilAggregateResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_aggregate_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroyPrivateKeyGenerateResponse function as declared in filecoin-ffi/filcrypto.h:592
+// FilDestroyPrivateKeyGenerateResponse function as declared in filecoin-ffi/filcrypto.h:597
 func FilDestroyPrivateKeyGenerateResponse(ptr *FilPrivateKeyGenerateResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_private_key_generate_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroyPrivateKeySignResponse function as declared in filecoin-ffi/filcrypto.h:594
+// FilDestroyPrivateKeySignResponse function as declared in filecoin-ffi/filcrypto.h:599
 func FilDestroyPrivateKeySignResponse(ptr *FilPrivateKeySignResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_private_key_sign_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroyPrivateKeyPublicKeyResponse function as declared in filecoin-ffi/filcrypto.h:596
+// FilDestroyPrivateKeyPublicKeyResponse function as declared in filecoin-ffi/filcrypto.h:601
 func FilDestroyPrivateKeyPublicKeyResponse(ptr *FilPrivateKeyPublicKeyResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_private_key_public_key_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroyZeroSignatureResponse function as declared in filecoin-ffi/filcrypto.h:598
+// FilDestroyZeroSignatureResponse function as declared in filecoin-ffi/filcrypto.h:603
 func FilDestroyZeroSignatureResponse(ptr *FilZeroSignatureResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_zero_signature_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilCreateFvmMachine function as declared in filecoin-ffi/filcrypto.h:606
+// FilCreateFvmMachine function as declared in filecoin-ffi/filcrypto.h:611
 func FilCreateFvmMachine(fvmVersion FilFvmRegisteredVersion, chainEpoch uint64, baseFeeHi uint64, baseFeeLo uint64, baseCircSupplyHi uint64, baseCircSupplyLo uint64, networkVersion uint64, stateRootPtr []byte, stateRootLen uint, manifestCidPtr []byte, manifestCidLen uint, blockstoreId uint64, externsId uint64) *FilCreateFvmMachineResponse {
 	cfvmVersion, cfvmVersionAllocMap := (C.enum_fil_FvmRegisteredVersion)(fvmVersion), cgoAllocsUnknown
 	cchainEpoch, cchainEpochAllocMap := (C.uint64_t)(chainEpoch), cgoAllocsUnknown
@@ -204,14 +204,14 @@ func FilCreateFvmMachine(fvmVersion FilFvmRegisteredVersion, chainEpoch uint64, 
 	return __v
 }
 
-// FilDropFvmMachine function as declared in filecoin-ffi/filcrypto.h:620
+// FilDropFvmMachine function as declared in filecoin-ffi/filcrypto.h:625
 func FilDropFvmMachine(executor unsafe.Pointer) {
 	cexecutor, cexecutorAllocMap := executor, cgoAllocsUnknown
 	C.fil_drop_fvm_machine(cexecutor)
 	runtime.KeepAlive(cexecutorAllocMap)
 }
 
-// FilFvmMachineExecuteMessage function as declared in filecoin-ffi/filcrypto.h:622
+// FilFvmMachineExecuteMessage function as declared in filecoin-ffi/filcrypto.h:627
 func FilFvmMachineExecuteMessage(executor unsafe.Pointer, messagePtr []byte, messageLen uint, chainLen uint64, applyKind uint64) *FilFvmMachineExecuteResponse {
 	cexecutor, cexecutorAllocMap := executor, cgoAllocsUnknown
 	cmessagePtr, cmessagePtrAllocMap := copyPUint8TBytes((*sliceHeader)(unsafe.Pointer(&messagePtr)))
@@ -228,7 +228,7 @@ func FilFvmMachineExecuteMessage(executor unsafe.Pointer, messagePtr []byte, mes
 	return __v
 }
 
-// FilFvmMachineFlush function as declared in filecoin-ffi/filcrypto.h:628
+// FilFvmMachineFlush function as declared in filecoin-ffi/filcrypto.h:633
 func FilFvmMachineFlush(executor unsafe.Pointer) *FilFvmMachineFlushResponse {
 	cexecutor, cexecutorAllocMap := executor, cgoAllocsUnknown
 	__ret := C.fil_fvm_machine_flush(cexecutor)
@@ -237,28 +237,28 @@ func FilFvmMachineFlush(executor unsafe.Pointer) *FilFvmMachineFlushResponse {
 	return __v
 }
 
-// FilDestroyCreateFvmMachineResponse function as declared in filecoin-ffi/filcrypto.h:630
+// FilDestroyCreateFvmMachineResponse function as declared in filecoin-ffi/filcrypto.h:635
 func FilDestroyCreateFvmMachineResponse(ptr *FilCreateFvmMachineResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_create_fvm_machine_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroyFvmMachineExecuteResponse function as declared in filecoin-ffi/filcrypto.h:632
+// FilDestroyFvmMachineExecuteResponse function as declared in filecoin-ffi/filcrypto.h:637
 func FilDestroyFvmMachineExecuteResponse(ptr *FilFvmMachineExecuteResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_fvm_machine_execute_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroyFvmMachineFlushResponse function as declared in filecoin-ffi/filcrypto.h:634
+// FilDestroyFvmMachineFlushResponse function as declared in filecoin-ffi/filcrypto.h:639
 func FilDestroyFvmMachineFlushResponse(ptr *FilFvmMachineFlushResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_fvm_machine_flush_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilWriteWithAlignment function as declared in filecoin-ffi/filcrypto.h:640
+// FilWriteWithAlignment function as declared in filecoin-ffi/filcrypto.h:645
 func FilWriteWithAlignment(registeredProof FilRegisteredSealProof, srcFd int32, srcSize uint64, dstFd int32, existingPieceSizesPtr []uint64, existingPieceSizesLen uint) *FilWriteWithAlignmentResponse {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	csrcFd, csrcFdAllocMap := (C.int)(srcFd), cgoAllocsUnknown
@@ -277,7 +277,7 @@ func FilWriteWithAlignment(registeredProof FilRegisteredSealProof, srcFd int32, 
 	return __v
 }
 
-// FilWriteWithoutAlignment function as declared in filecoin-ffi/filcrypto.h:651
+// FilWriteWithoutAlignment function as declared in filecoin-ffi/filcrypto.h:656
 func FilWriteWithoutAlignment(registeredProof FilRegisteredSealProof, srcFd int32, srcSize uint64, dstFd int32) *FilWriteWithoutAlignmentResponse {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	csrcFd, csrcFdAllocMap := (C.int)(srcFd), cgoAllocsUnknown
@@ -292,7 +292,7 @@ func FilWriteWithoutAlignment(registeredProof FilRegisteredSealProof, srcFd int3
 	return __v
 }
 
-// FilFauxrep function as declared in filecoin-ffi/filcrypto.h:656
+// FilFauxrep function as declared in filecoin-ffi/filcrypto.h:661
 func FilFauxrep(registeredProof FilRegisteredSealProof, cacheDirPath string, sealedSectorPath string) *FilFauxRepResponse {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	cacheDirPath = safeString(cacheDirPath)
@@ -309,7 +309,7 @@ func FilFauxrep(registeredProof FilRegisteredSealProof, cacheDirPath string, sea
 	return __v
 }
 
-// FilFauxrep2 function as declared in filecoin-ffi/filcrypto.h:660
+// FilFauxrep2 function as declared in filecoin-ffi/filcrypto.h:665
 func FilFauxrep2(registeredProof FilRegisteredSealProof, cacheDirPath string, existingPAuxPath string) *FilFauxRepResponse {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	cacheDirPath = safeString(cacheDirPath)
@@ -326,7 +326,7 @@ func FilFauxrep2(registeredProof FilRegisteredSealProof, cacheDirPath string, ex
 	return __v
 }
 
-// FilSealPreCommitPhase1 function as declared in filecoin-ffi/filcrypto.h:668
+// FilSealPreCommitPhase1 function as declared in filecoin-ffi/filcrypto.h:673
 func FilSealPreCommitPhase1(registeredProof FilRegisteredSealProof, cacheDirPath string, stagedSectorPath string, sealedSectorPath string, sectorId uint64, proverId Fil32ByteArray, ticket Fil32ByteArray, piecesPtr []FilPublicPieceInfo, piecesLen uint) *FilSealPreCommitPhase1Response {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	cacheDirPath = safeString(cacheDirPath)
@@ -358,7 +358,7 @@ func FilSealPreCommitPhase1(registeredProof FilRegisteredSealProof, cacheDirPath
 	return __v
 }
 
-// FilSealPreCommitPhase2 function as declared in filecoin-ffi/filcrypto.h:682
+// FilSealPreCommitPhase2 function as declared in filecoin-ffi/filcrypto.h:687
 func FilSealPreCommitPhase2(sealPreCommitPhase1OutputPtr []byte, sealPreCommitPhase1OutputLen uint, cacheDirPath string, sealedSectorPath string) *FilSealPreCommitPhase2Response {
 	csealPreCommitPhase1OutputPtr, csealPreCommitPhase1OutputPtrAllocMap := copyPUint8TBytes((*sliceHeader)(unsafe.Pointer(&sealPreCommitPhase1OutputPtr)))
 	csealPreCommitPhase1OutputLen, csealPreCommitPhase1OutputLenAllocMap := (C.size_t)(sealPreCommitPhase1OutputLen), cgoAllocsUnknown
@@ -377,7 +377,7 @@ func FilSealPreCommitPhase2(sealPreCommitPhase1OutputPtr []byte, sealPreCommitPh
 	return __v
 }
 
-// FilSealCommitPhase1 function as declared in filecoin-ffi/filcrypto.h:691
+// FilSealCommitPhase1 function as declared in filecoin-ffi/filcrypto.h:696
 func FilSealCommitPhase1(registeredProof FilRegisteredSealProof, commR Fil32ByteArray, commD Fil32ByteArray, cacheDirPath string, replicaPath string, sectorId uint64, proverId Fil32ByteArray, ticket Fil32ByteArray, seed Fil32ByteArray, piecesPtr []FilPublicPieceInfo, piecesLen uint) *FilSealCommitPhase1Response {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	ccommR, ccommRAllocMap := commR.PassValue()
@@ -411,7 +411,7 @@ func FilSealCommitPhase1(registeredProof FilRegisteredSealProof, commR Fil32Byte
 	return __v
 }
 
-// FilSealCommitPhase2 function as declared in filecoin-ffi/filcrypto.h:703
+// FilSealCommitPhase2 function as declared in filecoin-ffi/filcrypto.h:708
 func FilSealCommitPhase2(sealCommitPhase1OutputPtr []byte, sealCommitPhase1OutputLen uint, sectorId uint64, proverId Fil32ByteArray) *FilSealCommitPhase2Response {
 	csealCommitPhase1OutputPtr, csealCommitPhase1OutputPtrAllocMap := copyPUint8TBytes((*sliceHeader)(unsafe.Pointer(&sealCommitPhase1OutputPtr)))
 	csealCommitPhase1OutputLen, csealCommitPhase1OutputLenAllocMap := (C.size_t)(sealCommitPhase1OutputLen), cgoAllocsUnknown
@@ -426,7 +426,7 @@ func FilSealCommitPhase2(sealCommitPhase1OutputPtr []byte, sealCommitPhase1Outpu
 	return __v
 }
 
-// FilAggregateSealProofs function as declared in filecoin-ffi/filcrypto.h:708
+// FilAggregateSealProofs function as declared in filecoin-ffi/filcrypto.h:713
 func FilAggregateSealProofs(registeredProof FilRegisteredSealProof, registeredAggregation FilRegisteredAggregationProof, commRsPtr []Fil32ByteArray, commRsLen uint, seedsPtr []Fil32ByteArray, seedsLen uint, sealCommitResponsesPtr []FilSealCommitPhase2Response, sealCommitResponsesLen uint) *FilAggregateProof {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	cregisteredAggregation, cregisteredAggregationAllocMap := (C.enum_fil_RegisteredAggregationProof)(registeredAggregation), cgoAllocsUnknown
@@ -452,7 +452,7 @@ func FilAggregateSealProofs(registeredProof FilRegisteredSealProof, registeredAg
 	return __v
 }
 
-// FilVerifyAggregateSealProof function as declared in filecoin-ffi/filcrypto.h:721
+// FilVerifyAggregateSealProof function as declared in filecoin-ffi/filcrypto.h:726
 func FilVerifyAggregateSealProof(registeredProof FilRegisteredSealProof, registeredAggregation FilRegisteredAggregationProof, proverId Fil32ByteArray, proofPtr []byte, proofLen uint, commitInputsPtr []FilAggregationInputs, commitInputsLen uint) *FilVerifyAggregateSealProofResponse {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	cregisteredAggregation, cregisteredAggregationAllocMap := (C.enum_fil_RegisteredAggregationProof)(registeredAggregation), cgoAllocsUnknown
@@ -474,7 +474,7 @@ func FilVerifyAggregateSealProof(registeredProof FilRegisteredSealProof, registe
 	return __v
 }
 
-// FilUnsealRange function as declared in filecoin-ffi/filcrypto.h:732
+// FilUnsealRange function as declared in filecoin-ffi/filcrypto.h:737
 func FilUnsealRange(registeredProof FilRegisteredSealProof, cacheDirPath string, sealedSectorFdRaw int32, unsealOutputFdRaw int32, sectorId uint64, proverId Fil32ByteArray, ticket Fil32ByteArray, commD Fil32ByteArray, unpaddedByteIndex uint64, unpaddedBytesAmount uint64) *FilUnsealRangeResponse {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	cacheDirPath = safeString(cacheDirPath)
@@ -503,7 +503,7 @@ func FilUnsealRange(registeredProof FilRegisteredSealProof, cacheDirPath string,
 	return __v
 }
 
-// FilVerifySeal function as declared in filecoin-ffi/filcrypto.h:747
+// FilVerifySeal function as declared in filecoin-ffi/filcrypto.h:752
 func FilVerifySeal(registeredProof FilRegisteredSealProof, commR Fil32ByteArray, commD Fil32ByteArray, proverId Fil32ByteArray, ticket Fil32ByteArray, seed Fil32ByteArray, sectorId uint64, proofPtr []byte, proofLen uint) *FilVerifySealResponse {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	ccommR, ccommRAllocMap := commR.PassValue()
@@ -528,7 +528,7 @@ func FilVerifySeal(registeredProof FilRegisteredSealProof, commR Fil32ByteArray,
 	return __v
 }
 
-// FilGenerateWinningPostSectorChallenge function as declared in filecoin-ffi/filcrypto.h:761
+// FilGenerateWinningPostSectorChallenge function as declared in filecoin-ffi/filcrypto.h:766
 func FilGenerateWinningPostSectorChallenge(registeredProof FilRegisteredPoStProof, randomness Fil32ByteArray, sectorSetLen uint64, proverId Fil32ByteArray) *FilGenerateWinningPoStSectorChallenge {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredPoStProof)(registeredProof), cgoAllocsUnknown
 	crandomness, crandomnessAllocMap := randomness.PassValue()
@@ -543,7 +543,7 @@ func FilGenerateWinningPostSectorChallenge(registeredProof FilRegisteredPoStProo
 	return __v
 }
 
-// FilGenerateFallbackSectorChallenges function as declared in filecoin-ffi/filcrypto.h:770
+// FilGenerateFallbackSectorChallenges function as declared in filecoin-ffi/filcrypto.h:775
 func FilGenerateFallbackSectorChallenges(registeredProof FilRegisteredPoStProof, randomness Fil32ByteArray, sectorIdsPtr []uint64, sectorIdsLen uint, proverId Fil32ByteArray) *FilGenerateFallbackSectorChallengesResponse {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredPoStProof)(registeredProof), cgoAllocsUnknown
 	crandomness, crandomnessAllocMap := randomness.PassValue()
@@ -560,7 +560,7 @@ func FilGenerateFallbackSectorChallenges(registeredProof FilRegisteredPoStProof,
 	return __v
 }
 
-// FilGenerateSingleVanillaProof function as declared in filecoin-ffi/filcrypto.h:780
+// FilGenerateSingleVanillaProof function as declared in filecoin-ffi/filcrypto.h:785
 func FilGenerateSingleVanillaProof(replica FilPrivateReplicaInfo, challengesPtr []uint64, challengesLen uint) *FilGenerateSingleVanillaProofResponse {
 	creplica, creplicaAllocMap := replica.PassValue()
 	cchallengesPtr, cchallengesPtrAllocMap := copyPUint64TBytes((*sliceHeader)(unsafe.Pointer(&challengesPtr)))
@@ -573,7 +573,7 @@ func FilGenerateSingleVanillaProof(replica FilPrivateReplicaInfo, challengesPtr 
 	return __v
 }
 
-// FilGenerateWinningPostWithVanilla function as declared in filecoin-ffi/filcrypto.h:788
+// FilGenerateWinningPostWithVanilla function as declared in filecoin-ffi/filcrypto.h:793
 func FilGenerateWinningPostWithVanilla(registeredProof FilRegisteredPoStProof, randomness Fil32ByteArray, proverId Fil32ByteArray, vanillaProofsPtr []FilVanillaProof, vanillaProofsLen uint) *FilGenerateWinningPoStResponse {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredPoStProof)(registeredProof), cgoAllocsUnknown
 	crandomness, crandomnessAllocMap := randomness.PassValue()
@@ -591,7 +591,7 @@ func FilGenerateWinningPostWithVanilla(registeredProof FilRegisteredPoStProof, r
 	return __v
 }
 
-// FilGenerateWinningPost function as declared in filecoin-ffi/filcrypto.h:798
+// FilGenerateWinningPost function as declared in filecoin-ffi/filcrypto.h:803
 func FilGenerateWinningPost(randomness Fil32ByteArray, replicasPtr []FilPrivateReplicaInfo, replicasLen uint, proverId Fil32ByteArray) *FilGenerateWinningPoStResponse {
 	crandomness, crandomnessAllocMap := randomness.PassValue()
 	creplicasPtr, creplicasPtrAllocMap := unpackArgSFilPrivateReplicaInfo(replicasPtr)
@@ -607,7 +607,7 @@ func FilGenerateWinningPost(randomness Fil32ByteArray, replicasPtr []FilPrivateR
 	return __v
 }
 
-// FilVerifyWinningPost function as declared in filecoin-ffi/filcrypto.h:806
+// FilVerifyWinningPost function as declared in filecoin-ffi/filcrypto.h:811
 func FilVerifyWinningPost(randomness Fil32ByteArray, replicasPtr []FilPublicReplicaInfo, replicasLen uint, proofsPtr []FilPoStProof, proofsLen uint, proverId Fil32ByteArray) *FilVerifyWinningPoStResponse {
 	crandomness, crandomnessAllocMap := randomness.PassValue()
 	creplicasPtr, creplicasPtrAllocMap := unpackArgSFilPublicReplicaInfo(replicasPtr)
@@ -628,7 +628,7 @@ func FilVerifyWinningPost(randomness Fil32ByteArray, replicasPtr []FilPublicRepl
 	return __v
 }
 
-// FilGenerateWindowPostWithVanilla function as declared in filecoin-ffi/filcrypto.h:817
+// FilGenerateWindowPostWithVanilla function as declared in filecoin-ffi/filcrypto.h:822
 func FilGenerateWindowPostWithVanilla(registeredProof FilRegisteredPoStProof, randomness Fil32ByteArray, proverId Fil32ByteArray, vanillaProofsPtr []FilVanillaProof, vanillaProofsLen uint) *FilGenerateWindowPoStResponse {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredPoStProof)(registeredProof), cgoAllocsUnknown
 	crandomness, crandomnessAllocMap := randomness.PassValue()
@@ -646,7 +646,7 @@ func FilGenerateWindowPostWithVanilla(registeredProof FilRegisteredPoStProof, ra
 	return __v
 }
 
-// FilGenerateWindowPost function as declared in filecoin-ffi/filcrypto.h:827
+// FilGenerateWindowPost function as declared in filecoin-ffi/filcrypto.h:832
 func FilGenerateWindowPost(randomness Fil32ByteArray, replicasPtr []FilPrivateReplicaInfo, replicasLen uint, proverId Fil32ByteArray) *FilGenerateWindowPoStResponse {
 	crandomness, crandomnessAllocMap := randomness.PassValue()
 	creplicasPtr, creplicasPtrAllocMap := unpackArgSFilPrivateReplicaInfo(replicasPtr)
@@ -662,7 +662,7 @@ func FilGenerateWindowPost(randomness Fil32ByteArray, replicasPtr []FilPrivateRe
 	return __v
 }
 
-// FilVerifyWindowPost function as declared in filecoin-ffi/filcrypto.h:835
+// FilVerifyWindowPost function as declared in filecoin-ffi/filcrypto.h:840
 func FilVerifyWindowPost(randomness Fil32ByteArray, replicasPtr []FilPublicReplicaInfo, replicasLen uint, proofsPtr []FilPoStProof, proofsLen uint, proverId Fil32ByteArray) *FilVerifyWindowPoStResponse {
 	crandomness, crandomnessAllocMap := randomness.PassValue()
 	creplicasPtr, creplicasPtrAllocMap := unpackArgSFilPublicReplicaInfo(replicasPtr)
@@ -683,7 +683,7 @@ func FilVerifyWindowPost(randomness Fil32ByteArray, replicasPtr []FilPublicRepli
 	return __v
 }
 
-// FilMergeWindowPostPartitionProofs function as declared in filecoin-ffi/filcrypto.h:846
+// FilMergeWindowPostPartitionProofs function as declared in filecoin-ffi/filcrypto.h:851
 func FilMergeWindowPostPartitionProofs(registeredProof FilRegisteredPoStProof, partitionProofsPtr []FilPartitionSnarkProof, partitionProofsLen uint) *FilMergeWindowPoStPartitionProofsResponse {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredPoStProof)(registeredProof), cgoAllocsUnknown
 	cpartitionProofsPtr, cpartitionProofsPtrAllocMap := unpackArgSFilPartitionSnarkProof(partitionProofsPtr)
@@ -697,7 +697,7 @@ func FilMergeWindowPostPartitionProofs(registeredProof FilRegisteredPoStProof, p
 	return __v
 }
 
-// FilGetNumPartitionForFallbackPost function as declared in filecoin-ffi/filcrypto.h:854
+// FilGetNumPartitionForFallbackPost function as declared in filecoin-ffi/filcrypto.h:859
 func FilGetNumPartitionForFallbackPost(registeredProof FilRegisteredPoStProof, numSectors uint) *FilGetNumPartitionForFallbackPoStResponse {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredPoStProof)(registeredProof), cgoAllocsUnknown
 	cnumSectors, cnumSectorsAllocMap := (C.size_t)(numSectors), cgoAllocsUnknown
@@ -708,7 +708,7 @@ func FilGetNumPartitionForFallbackPost(registeredProof FilRegisteredPoStProof, n
 	return __v
 }
 
-// FilGenerateSingleWindowPostWithVanilla function as declared in filecoin-ffi/filcrypto.h:861
+// FilGenerateSingleWindowPostWithVanilla function as declared in filecoin-ffi/filcrypto.h:866
 func FilGenerateSingleWindowPostWithVanilla(registeredProof FilRegisteredPoStProof, randomness Fil32ByteArray, proverId Fil32ByteArray, vanillaProofsPtr []FilVanillaProof, vanillaProofsLen uint, partitionIndex uint) *FilGenerateSingleWindowPoStWithVanillaResponse {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredPoStProof)(registeredProof), cgoAllocsUnknown
 	crandomness, crandomnessAllocMap := randomness.PassValue()
@@ -728,7 +728,7 @@ func FilGenerateSingleWindowPostWithVanilla(registeredProof FilRegisteredPoStPro
 	return __v
 }
 
-// FilEmptySectorUpdateEncodeInto function as declared in filecoin-ffi/filcrypto.h:872
+// FilEmptySectorUpdateEncodeInto function as declared in filecoin-ffi/filcrypto.h:877
 func FilEmptySectorUpdateEncodeInto(registeredProof FilRegisteredUpdateProof, newReplicaPath string, newCacheDirPath string, sectorKeyPath string, sectorKeyCacheDirPath string, stagedDataPath string, piecesPtr []FilPublicPieceInfo, piecesLen uint) *FilEmptySectorUpdateEncodeIntoResponse {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredUpdateProof)(registeredProof), cgoAllocsUnknown
 	newReplicaPath = safeString(newReplicaPath)
@@ -762,7 +762,7 @@ func FilEmptySectorUpdateEncodeInto(registeredProof FilRegisteredUpdateProof, ne
 	return __v
 }
 
-// FilEmptySectorUpdateDecodeFrom function as declared in filecoin-ffi/filcrypto.h:885
+// FilEmptySectorUpdateDecodeFrom function as declared in filecoin-ffi/filcrypto.h:890
 func FilEmptySectorUpdateDecodeFrom(registeredProof FilRegisteredUpdateProof, outDataPath string, replicaPath string, sectorKeyPath string, sectorKeyCacheDirPath string, commDNew Fil32ByteArray) *FilEmptySectorUpdateDecodeFromResponse {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredUpdateProof)(registeredProof), cgoAllocsUnknown
 	outDataPath = safeString(outDataPath)
@@ -789,7 +789,7 @@ func FilEmptySectorUpdateDecodeFrom(registeredProof FilRegisteredUpdateProof, ou
 	return __v
 }
 
-// FilEmptySectorUpdateRemoveEncodedData function as declared in filecoin-ffi/filcrypto.h:896
+// FilEmptySectorUpdateRemoveEncodedData function as declared in filecoin-ffi/filcrypto.h:901
 func FilEmptySectorUpdateRemoveEncodedData(registeredProof FilRegisteredUpdateProof, sectorKeyPath string, sectorKeyCacheDirPath string, replicaPath string, replicaCachePath string, dataPath string, commDNew Fil32ByteArray) *FilEmptySectorUpdateRemoveEncodedDataResponse {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredUpdateProof)(registeredProof), cgoAllocsUnknown
 	sectorKeyPath = safeString(sectorKeyPath)
@@ -820,7 +820,7 @@ func FilEmptySectorUpdateRemoveEncodedData(registeredProof FilRegisteredUpdatePr
 	return __v
 }
 
-// FilGenerateEmptySectorUpdatePartitionProofs function as declared in filecoin-ffi/filcrypto.h:908
+// FilGenerateEmptySectorUpdatePartitionProofs function as declared in filecoin-ffi/filcrypto.h:913
 func FilGenerateEmptySectorUpdatePartitionProofs(registeredProof FilRegisteredUpdateProof, commROld Fil32ByteArray, commRNew Fil32ByteArray, commDNew Fil32ByteArray, sectorKeyPath string, sectorKeyCacheDirPath string, replicaPath string, replicaCachePath string) *FilPartitionProofResponse {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredUpdateProof)(registeredProof), cgoAllocsUnknown
 	ccommROld, ccommROldAllocMap := commROld.PassValue()
@@ -851,7 +851,7 @@ func FilGenerateEmptySectorUpdatePartitionProofs(registeredProof FilRegisteredUp
 	return __v
 }
 
-// FilVerifyEmptySectorUpdatePartitionProofs function as declared in filecoin-ffi/filcrypto.h:921
+// FilVerifyEmptySectorUpdatePartitionProofs function as declared in filecoin-ffi/filcrypto.h:926
 func FilVerifyEmptySectorUpdatePartitionProofs(registeredProof FilRegisteredUpdateProof, proofsLen uint, proofsPtr []FilPartitionProof, commROld Fil32ByteArray, commRNew Fil32ByteArray, commDNew Fil32ByteArray) *FilVerifyPartitionProofResponse {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredUpdateProof)(registeredProof), cgoAllocsUnknown
 	cproofsLen, cproofsLenAllocMap := (C.size_t)(proofsLen), cgoAllocsUnknown
@@ -871,7 +871,7 @@ func FilVerifyEmptySectorUpdatePartitionProofs(registeredProof FilRegisteredUpda
 	return __v
 }
 
-// FilGenerateEmptySectorUpdateProofWithVanilla function as declared in filecoin-ffi/filcrypto.h:932
+// FilGenerateEmptySectorUpdateProofWithVanilla function as declared in filecoin-ffi/filcrypto.h:937
 func FilGenerateEmptySectorUpdateProofWithVanilla(registeredProof FilRegisteredUpdateProof, vanillaProofsPtr []FilPartitionProof, vanillaProofsLen uint, commROld Fil32ByteArray, commRNew Fil32ByteArray, commDNew Fil32ByteArray) *FilEmptySectorUpdateProofResponse {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredUpdateProof)(registeredProof), cgoAllocsUnknown
 	cvanillaProofsPtr, cvanillaProofsPtrAllocMap := unpackArgSFilPartitionProof(vanillaProofsPtr)
@@ -891,7 +891,7 @@ func FilGenerateEmptySectorUpdateProofWithVanilla(registeredProof FilRegisteredU
 	return __v
 }
 
-// FilGenerateEmptySectorUpdateProof function as declared in filecoin-ffi/filcrypto.h:943
+// FilGenerateEmptySectorUpdateProof function as declared in filecoin-ffi/filcrypto.h:948
 func FilGenerateEmptySectorUpdateProof(registeredProof FilRegisteredUpdateProof, commROld Fil32ByteArray, commRNew Fil32ByteArray, commDNew Fil32ByteArray, sectorKeyPath string, sectorKeyCacheDirPath string, replicaPath string, replicaCachePath string) *FilEmptySectorUpdateProofResponse {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredUpdateProof)(registeredProof), cgoAllocsUnknown
 	ccommROld, ccommROldAllocMap := commROld.PassValue()
@@ -922,7 +922,7 @@ func FilGenerateEmptySectorUpdateProof(registeredProof FilRegisteredUpdateProof,
 	return __v
 }
 
-// FilVerifyEmptySectorUpdateProof function as declared in filecoin-ffi/filcrypto.h:956
+// FilVerifyEmptySectorUpdateProof function as declared in filecoin-ffi/filcrypto.h:961
 func FilVerifyEmptySectorUpdateProof(registeredProof FilRegisteredUpdateProof, proofPtr []byte, proofLen uint, commROld Fil32ByteArray, commRNew Fil32ByteArray, commDNew Fil32ByteArray) *FilVerifyEmptySectorUpdateProofResponse {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredUpdateProof)(registeredProof), cgoAllocsUnknown
 	cproofPtr, cproofPtrAllocMap := copyPUint8TBytes((*sliceHeader)(unsafe.Pointer(&proofPtr)))
@@ -941,7 +941,7 @@ func FilVerifyEmptySectorUpdateProof(registeredProof FilRegisteredUpdateProof, p
 	return __v
 }
 
-// FilGeneratePieceCommitment function as declared in filecoin-ffi/filcrypto.h:967
+// FilGeneratePieceCommitment function as declared in filecoin-ffi/filcrypto.h:972
 func FilGeneratePieceCommitment(registeredProof FilRegisteredSealProof, pieceFdRaw int32, unpaddedPieceSize uint64) *FilGeneratePieceCommitmentResponse {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	cpieceFdRaw, cpieceFdRawAllocMap := (C.int)(pieceFdRaw), cgoAllocsUnknown
@@ -954,7 +954,7 @@ func FilGeneratePieceCommitment(registeredProof FilRegisteredSealProof, pieceFdR
 	return __v
 }
 
-// FilGenerateDataCommitment function as declared in filecoin-ffi/filcrypto.h:974
+// FilGenerateDataCommitment function as declared in filecoin-ffi/filcrypto.h:979
 func FilGenerateDataCommitment(registeredProof FilRegisteredSealProof, piecesPtr []FilPublicPieceInfo, piecesLen uint) *FilGenerateDataCommitmentResponse {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	cpiecesPtr, cpiecesPtrAllocMap := unpackArgSFilPublicPieceInfo(piecesPtr)
@@ -968,7 +968,7 @@ func FilGenerateDataCommitment(registeredProof FilRegisteredSealProof, piecesPtr
 	return __v
 }
 
-// FilClearCache function as declared in filecoin-ffi/filcrypto.h:978
+// FilClearCache function as declared in filecoin-ffi/filcrypto.h:983
 func FilClearCache(sectorSize uint64, cacheDirPath string) *FilClearCacheResponse {
 	csectorSize, csectorSizeAllocMap := (C.uint64_t)(sectorSize), cgoAllocsUnknown
 	cacheDirPath = safeString(cacheDirPath)
@@ -981,84 +981,84 @@ func FilClearCache(sectorSize uint64, cacheDirPath string) *FilClearCacheRespons
 	return __v
 }
 
-// FilDestroyWriteWithAlignmentResponse function as declared in filecoin-ffi/filcrypto.h:980
+// FilDestroyWriteWithAlignmentResponse function as declared in filecoin-ffi/filcrypto.h:985
 func FilDestroyWriteWithAlignmentResponse(ptr *FilWriteWithAlignmentResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_write_with_alignment_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroyWriteWithoutAlignmentResponse function as declared in filecoin-ffi/filcrypto.h:982
+// FilDestroyWriteWithoutAlignmentResponse function as declared in filecoin-ffi/filcrypto.h:987
 func FilDestroyWriteWithoutAlignmentResponse(ptr *FilWriteWithoutAlignmentResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_write_without_alignment_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroyFauxrepResponse function as declared in filecoin-ffi/filcrypto.h:984
+// FilDestroyFauxrepResponse function as declared in filecoin-ffi/filcrypto.h:989
 func FilDestroyFauxrepResponse(ptr *FilFauxRepResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_fauxrep_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroySealPreCommitPhase1Response function as declared in filecoin-ffi/filcrypto.h:986
+// FilDestroySealPreCommitPhase1Response function as declared in filecoin-ffi/filcrypto.h:991
 func FilDestroySealPreCommitPhase1Response(ptr *FilSealPreCommitPhase1Response) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_seal_pre_commit_phase1_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroySealPreCommitPhase2Response function as declared in filecoin-ffi/filcrypto.h:988
+// FilDestroySealPreCommitPhase2Response function as declared in filecoin-ffi/filcrypto.h:993
 func FilDestroySealPreCommitPhase2Response(ptr *FilSealPreCommitPhase2Response) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_seal_pre_commit_phase2_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroySealCommitPhase1Response function as declared in filecoin-ffi/filcrypto.h:990
+// FilDestroySealCommitPhase1Response function as declared in filecoin-ffi/filcrypto.h:995
 func FilDestroySealCommitPhase1Response(ptr *FilSealCommitPhase1Response) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_seal_commit_phase1_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroySealCommitPhase2Response function as declared in filecoin-ffi/filcrypto.h:992
+// FilDestroySealCommitPhase2Response function as declared in filecoin-ffi/filcrypto.h:997
 func FilDestroySealCommitPhase2Response(ptr *FilSealCommitPhase2Response) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_seal_commit_phase2_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroyUnsealRangeResponse function as declared in filecoin-ffi/filcrypto.h:994
+// FilDestroyUnsealRangeResponse function as declared in filecoin-ffi/filcrypto.h:999
 func FilDestroyUnsealRangeResponse(ptr *FilUnsealRangeResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_unseal_range_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroyGeneratePieceCommitmentResponse function as declared in filecoin-ffi/filcrypto.h:996
+// FilDestroyGeneratePieceCommitmentResponse function as declared in filecoin-ffi/filcrypto.h:1001
 func FilDestroyGeneratePieceCommitmentResponse(ptr *FilGeneratePieceCommitmentResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_generate_piece_commitment_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroyGenerateDataCommitmentResponse function as declared in filecoin-ffi/filcrypto.h:998
+// FilDestroyGenerateDataCommitmentResponse function as declared in filecoin-ffi/filcrypto.h:1003
 func FilDestroyGenerateDataCommitmentResponse(ptr *FilGenerateDataCommitmentResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_generate_data_commitment_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroyStringResponse function as declared in filecoin-ffi/filcrypto.h:1000
+// FilDestroyStringResponse function as declared in filecoin-ffi/filcrypto.h:1005
 func FilDestroyStringResponse(ptr *FilStringResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_string_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilGetMaxUserBytesPerStagedSector function as declared in filecoin-ffi/filcrypto.h:1006
+// FilGetMaxUserBytesPerStagedSector function as declared in filecoin-ffi/filcrypto.h:1011
 func FilGetMaxUserBytesPerStagedSector(registeredProof FilRegisteredSealProof) uint64 {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_max_user_bytes_per_staged_sector(cregisteredProof)
@@ -1067,7 +1067,7 @@ func FilGetMaxUserBytesPerStagedSector(registeredProof FilRegisteredSealProof) u
 	return __v
 }
 
-// FilGetSealParamsCid function as declared in filecoin-ffi/filcrypto.h:1012
+// FilGetSealParamsCid function as declared in filecoin-ffi/filcrypto.h:1017
 func FilGetSealParamsCid(registeredProof FilRegisteredSealProof) *FilStringResponse {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_seal_params_cid(cregisteredProof)
@@ -1076,7 +1076,7 @@ func FilGetSealParamsCid(registeredProof FilRegisteredSealProof) *FilStringRespo
 	return __v
 }
 
-// FilGetSealVerifyingKeyCid function as declared in filecoin-ffi/filcrypto.h:1018
+// FilGetSealVerifyingKeyCid function as declared in filecoin-ffi/filcrypto.h:1023
 func FilGetSealVerifyingKeyCid(registeredProof FilRegisteredSealProof) *FilStringResponse {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_seal_verifying_key_cid(cregisteredProof)
@@ -1085,7 +1085,7 @@ func FilGetSealVerifyingKeyCid(registeredProof FilRegisteredSealProof) *FilStrin
 	return __v
 }
 
-// FilGetSealParamsPath function as declared in filecoin-ffi/filcrypto.h:1025
+// FilGetSealParamsPath function as declared in filecoin-ffi/filcrypto.h:1030
 func FilGetSealParamsPath(registeredProof FilRegisteredSealProof) *FilStringResponse {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_seal_params_path(cregisteredProof)
@@ -1094,7 +1094,7 @@ func FilGetSealParamsPath(registeredProof FilRegisteredSealProof) *FilStringResp
 	return __v
 }
 
-// FilGetSealVerifyingKeyPath function as declared in filecoin-ffi/filcrypto.h:1032
+// FilGetSealVerifyingKeyPath function as declared in filecoin-ffi/filcrypto.h:1037
 func FilGetSealVerifyingKeyPath(registeredProof FilRegisteredSealProof) *FilStringResponse {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_seal_verifying_key_path(cregisteredProof)
@@ -1103,7 +1103,7 @@ func FilGetSealVerifyingKeyPath(registeredProof FilRegisteredSealProof) *FilStri
 	return __v
 }
 
-// FilGetSealCircuitIdentifier function as declared in filecoin-ffi/filcrypto.h:1038
+// FilGetSealCircuitIdentifier function as declared in filecoin-ffi/filcrypto.h:1043
 func FilGetSealCircuitIdentifier(registeredProof FilRegisteredSealProof) *FilStringResponse {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_seal_circuit_identifier(cregisteredProof)
@@ -1112,7 +1112,7 @@ func FilGetSealCircuitIdentifier(registeredProof FilRegisteredSealProof) *FilStr
 	return __v
 }
 
-// FilGetSealVersion function as declared in filecoin-ffi/filcrypto.h:1044
+// FilGetSealVersion function as declared in filecoin-ffi/filcrypto.h:1049
 func FilGetSealVersion(registeredProof FilRegisteredSealProof) *FilStringResponse {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredSealProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_seal_version(cregisteredProof)
@@ -1121,7 +1121,7 @@ func FilGetSealVersion(registeredProof FilRegisteredSealProof) *FilStringRespons
 	return __v
 }
 
-// FilGetPostParamsCid function as declared in filecoin-ffi/filcrypto.h:1050
+// FilGetPostParamsCid function as declared in filecoin-ffi/filcrypto.h:1055
 func FilGetPostParamsCid(registeredProof FilRegisteredPoStProof) *FilStringResponse {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredPoStProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_post_params_cid(cregisteredProof)
@@ -1130,7 +1130,7 @@ func FilGetPostParamsCid(registeredProof FilRegisteredPoStProof) *FilStringRespo
 	return __v
 }
 
-// FilGetPostVerifyingKeyCid function as declared in filecoin-ffi/filcrypto.h:1056
+// FilGetPostVerifyingKeyCid function as declared in filecoin-ffi/filcrypto.h:1061
 func FilGetPostVerifyingKeyCid(registeredProof FilRegisteredPoStProof) *FilStringResponse {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredPoStProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_post_verifying_key_cid(cregisteredProof)
@@ -1139,7 +1139,7 @@ func FilGetPostVerifyingKeyCid(registeredProof FilRegisteredPoStProof) *FilStrin
 	return __v
 }
 
-// FilGetPostParamsPath function as declared in filecoin-ffi/filcrypto.h:1063
+// FilGetPostParamsPath function as declared in filecoin-ffi/filcrypto.h:1068
 func FilGetPostParamsPath(registeredProof FilRegisteredPoStProof) *FilStringResponse {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredPoStProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_post_params_path(cregisteredProof)
@@ -1148,7 +1148,7 @@ func FilGetPostParamsPath(registeredProof FilRegisteredPoStProof) *FilStringResp
 	return __v
 }
 
-// FilGetPostVerifyingKeyPath function as declared in filecoin-ffi/filcrypto.h:1070
+// FilGetPostVerifyingKeyPath function as declared in filecoin-ffi/filcrypto.h:1075
 func FilGetPostVerifyingKeyPath(registeredProof FilRegisteredPoStProof) *FilStringResponse {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredPoStProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_post_verifying_key_path(cregisteredProof)
@@ -1157,7 +1157,7 @@ func FilGetPostVerifyingKeyPath(registeredProof FilRegisteredPoStProof) *FilStri
 	return __v
 }
 
-// FilGetPostCircuitIdentifier function as declared in filecoin-ffi/filcrypto.h:1076
+// FilGetPostCircuitIdentifier function as declared in filecoin-ffi/filcrypto.h:1081
 func FilGetPostCircuitIdentifier(registeredProof FilRegisteredPoStProof) *FilStringResponse {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredPoStProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_post_circuit_identifier(cregisteredProof)
@@ -1166,7 +1166,7 @@ func FilGetPostCircuitIdentifier(registeredProof FilRegisteredPoStProof) *FilStr
 	return __v
 }
 
-// FilGetPostVersion function as declared in filecoin-ffi/filcrypto.h:1082
+// FilGetPostVersion function as declared in filecoin-ffi/filcrypto.h:1087
 func FilGetPostVersion(registeredProof FilRegisteredPoStProof) *FilStringResponse {
 	cregisteredProof, cregisteredProofAllocMap := (C.enum_fil_RegisteredPoStProof)(registeredProof), cgoAllocsUnknown
 	__ret := C.fil_get_post_version(cregisteredProof)
@@ -1175,168 +1175,168 @@ func FilGetPostVersion(registeredProof FilRegisteredPoStProof) *FilStringRespons
 	return __v
 }
 
-// FilDestroyVerifySealResponse function as declared in filecoin-ffi/filcrypto.h:1088
+// FilDestroyVerifySealResponse function as declared in filecoin-ffi/filcrypto.h:1093
 func FilDestroyVerifySealResponse(ptr *FilVerifySealResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_verify_seal_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroyVerifyAggregateSealResponse function as declared in filecoin-ffi/filcrypto.h:1094
+// FilDestroyVerifyAggregateSealResponse function as declared in filecoin-ffi/filcrypto.h:1099
 func FilDestroyVerifyAggregateSealResponse(ptr *FilVerifyAggregateSealProofResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_verify_aggregate_seal_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroyFinalizeTicketResponse function as declared in filecoin-ffi/filcrypto.h:1096
+// FilDestroyFinalizeTicketResponse function as declared in filecoin-ffi/filcrypto.h:1101
 func FilDestroyFinalizeTicketResponse(ptr *FilFinalizeTicketResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_finalize_ticket_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroyVerifyWinningPostResponse function as declared in filecoin-ffi/filcrypto.h:1102
+// FilDestroyVerifyWinningPostResponse function as declared in filecoin-ffi/filcrypto.h:1107
 func FilDestroyVerifyWinningPostResponse(ptr *FilVerifyWinningPoStResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_verify_winning_post_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroyVerifyWindowPostResponse function as declared in filecoin-ffi/filcrypto.h:1104
+// FilDestroyVerifyWindowPostResponse function as declared in filecoin-ffi/filcrypto.h:1109
 func FilDestroyVerifyWindowPostResponse(ptr *FilVerifyWindowPoStResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_verify_window_post_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroyGenerateFallbackSectorChallengesResponse function as declared in filecoin-ffi/filcrypto.h:1106
+// FilDestroyGenerateFallbackSectorChallengesResponse function as declared in filecoin-ffi/filcrypto.h:1111
 func FilDestroyGenerateFallbackSectorChallengesResponse(ptr *FilGenerateFallbackSectorChallengesResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_generate_fallback_sector_challenges_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroyGenerateSingleVanillaProofResponse function as declared in filecoin-ffi/filcrypto.h:1108
+// FilDestroyGenerateSingleVanillaProofResponse function as declared in filecoin-ffi/filcrypto.h:1113
 func FilDestroyGenerateSingleVanillaProofResponse(ptr *FilGenerateSingleVanillaProofResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_generate_single_vanilla_proof_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroyGenerateSingleWindowPostWithVanillaResponse function as declared in filecoin-ffi/filcrypto.h:1110
+// FilDestroyGenerateSingleWindowPostWithVanillaResponse function as declared in filecoin-ffi/filcrypto.h:1115
 func FilDestroyGenerateSingleWindowPostWithVanillaResponse(ptr *FilGenerateSingleWindowPoStWithVanillaResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_generate_single_window_post_with_vanilla_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroyGetNumPartitionForFallbackPostResponse function as declared in filecoin-ffi/filcrypto.h:1112
+// FilDestroyGetNumPartitionForFallbackPostResponse function as declared in filecoin-ffi/filcrypto.h:1117
 func FilDestroyGetNumPartitionForFallbackPostResponse(ptr *FilGetNumPartitionForFallbackPoStResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_get_num_partition_for_fallback_post_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroyMergeWindowPostPartitionProofsResponse function as declared in filecoin-ffi/filcrypto.h:1114
+// FilDestroyMergeWindowPostPartitionProofsResponse function as declared in filecoin-ffi/filcrypto.h:1119
 func FilDestroyMergeWindowPostPartitionProofsResponse(ptr *FilMergeWindowPoStPartitionProofsResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_merge_window_post_partition_proofs_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroyGenerateWinningPostResponse function as declared in filecoin-ffi/filcrypto.h:1116
+// FilDestroyGenerateWinningPostResponse function as declared in filecoin-ffi/filcrypto.h:1121
 func FilDestroyGenerateWinningPostResponse(ptr *FilGenerateWinningPoStResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_generate_winning_post_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroyGenerateWindowPostResponse function as declared in filecoin-ffi/filcrypto.h:1118
+// FilDestroyGenerateWindowPostResponse function as declared in filecoin-ffi/filcrypto.h:1123
 func FilDestroyGenerateWindowPostResponse(ptr *FilGenerateWindowPoStResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_generate_window_post_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroyGenerateWinningPostSectorChallenge function as declared in filecoin-ffi/filcrypto.h:1120
+// FilDestroyGenerateWinningPostSectorChallenge function as declared in filecoin-ffi/filcrypto.h:1125
 func FilDestroyGenerateWinningPostSectorChallenge(ptr *FilGenerateWinningPoStSectorChallenge) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_generate_winning_post_sector_challenge(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroyClearCacheResponse function as declared in filecoin-ffi/filcrypto.h:1122
+// FilDestroyClearCacheResponse function as declared in filecoin-ffi/filcrypto.h:1127
 func FilDestroyClearCacheResponse(ptr *FilClearCacheResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_clear_cache_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroyAggregateProof function as declared in filecoin-ffi/filcrypto.h:1128
+// FilDestroyAggregateProof function as declared in filecoin-ffi/filcrypto.h:1133
 func FilDestroyAggregateProof(ptr *FilAggregateProof) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_aggregate_proof(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroyEmptySectorUpdateGenerateProofResponse function as declared in filecoin-ffi/filcrypto.h:1134
+// FilDestroyEmptySectorUpdateGenerateProofResponse function as declared in filecoin-ffi/filcrypto.h:1139
 func FilDestroyEmptySectorUpdateGenerateProofResponse(ptr *FilEmptySectorUpdateProofResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_empty_sector_update_generate_proof_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroyEmptySectorUpdateVerifyProofResponse function as declared in filecoin-ffi/filcrypto.h:1140
+// FilDestroyEmptySectorUpdateVerifyProofResponse function as declared in filecoin-ffi/filcrypto.h:1145
 func FilDestroyEmptySectorUpdateVerifyProofResponse(ptr *FilVerifyEmptySectorUpdateProofResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_empty_sector_update_verify_proof_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroyGenerateEmptySectorUpdatePartitionProofResponse function as declared in filecoin-ffi/filcrypto.h:1146
+// FilDestroyGenerateEmptySectorUpdatePartitionProofResponse function as declared in filecoin-ffi/filcrypto.h:1151
 func FilDestroyGenerateEmptySectorUpdatePartitionProofResponse(ptr *FilPartitionProofResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_generate_empty_sector_update_partition_proof_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroyVerifyEmptySectorUpdatePartitionProofResponse function as declared in filecoin-ffi/filcrypto.h:1152
+// FilDestroyVerifyEmptySectorUpdatePartitionProofResponse function as declared in filecoin-ffi/filcrypto.h:1157
 func FilDestroyVerifyEmptySectorUpdatePartitionProofResponse(ptr *FilVerifyPartitionProofResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_verify_empty_sector_update_partition_proof_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroyEmptySectorUpdateEncodeIntoResponse function as declared in filecoin-ffi/filcrypto.h:1158
+// FilDestroyEmptySectorUpdateEncodeIntoResponse function as declared in filecoin-ffi/filcrypto.h:1163
 func FilDestroyEmptySectorUpdateEncodeIntoResponse(ptr *FilEmptySectorUpdateEncodeIntoResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_empty_sector_update_encode_into_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroyEmptySectorUpdateDecodeFromResponse function as declared in filecoin-ffi/filcrypto.h:1164
+// FilDestroyEmptySectorUpdateDecodeFromResponse function as declared in filecoin-ffi/filcrypto.h:1169
 func FilDestroyEmptySectorUpdateDecodeFromResponse(ptr *FilEmptySectorUpdateDecodeFromResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_empty_sector_update_decode_from_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroyEmptySectorUpdateRemoveEncodedDataResponse function as declared in filecoin-ffi/filcrypto.h:1170
+// FilDestroyEmptySectorUpdateRemoveEncodedDataResponse function as declared in filecoin-ffi/filcrypto.h:1175
 func FilDestroyEmptySectorUpdateRemoveEncodedDataResponse(ptr *FilEmptySectorUpdateRemoveEncodedDataResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_empty_sector_update_remove_encoded_data_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilGetGpuDevices function as declared in filecoin-ffi/filcrypto.h:1175
+// FilGetGpuDevices function as declared in filecoin-ffi/filcrypto.h:1180
 func FilGetGpuDevices() *FilGpuDeviceResponse {
 	__ret := C.fil_get_gpu_devices()
 	__v := NewFilGpuDeviceResponseRef(unsafe.Pointer(__ret))
 	return __v
 }
 
-// FilInitLogFd function as declared in filecoin-ffi/filcrypto.h:1186
+// FilInitLogFd function as declared in filecoin-ffi/filcrypto.h:1191
 func FilInitLogFd(logFd int32) *FilInitLogFdResponse {
 	clogFd, clogFdAllocMap := (C.int)(logFd), cgoAllocsUnknown
 	__ret := C.fil_init_log_fd(clogFd)
@@ -1345,14 +1345,14 @@ func FilInitLogFd(logFd int32) *FilInitLogFdResponse {
 	return __v
 }
 
-// FilDestroyGpuDeviceResponse function as declared in filecoin-ffi/filcrypto.h:1188
+// FilDestroyGpuDeviceResponse function as declared in filecoin-ffi/filcrypto.h:1193
 func FilDestroyGpuDeviceResponse(ptr *FilGpuDeviceResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_gpu_device_response(cptr)
 	runtime.KeepAlive(cptrAllocMap)
 }
 
-// FilDestroyInitLogFdResponse function as declared in filecoin-ffi/filcrypto.h:1190
+// FilDestroyInitLogFdResponse function as declared in filecoin-ffi/filcrypto.h:1195
 func FilDestroyInitLogFdResponse(ptr *FilInitLogFdResponse) {
 	cptr, cptrAllocMap := ptr.PassRef()
 	C.fil_destroy_init_log_fd_response(cptr)

--- a/generated/types.go
+++ b/generated/types.go
@@ -14,84 +14,84 @@ package generated
 import "C"
 import "unsafe"
 
-// FilBLSDigest as declared in filecoin-ffi/filcrypto.h:97
+// FilBLSDigest as declared in filecoin-ffi/filcrypto.h:102
 type FilBLSDigest struct {
 	Inner          [96]byte
 	ref215fc78c    *C.fil_BLSDigest
 	allocs215fc78c interface{}
 }
 
-// FilHashResponse as declared in filecoin-ffi/filcrypto.h:104
+// FilHashResponse as declared in filecoin-ffi/filcrypto.h:109
 type FilHashResponse struct {
 	Digest         FilBLSDigest
 	refc52a22ef    *C.fil_HashResponse
 	allocsc52a22ef interface{}
 }
 
-// FilBLSSignature as declared in filecoin-ffi/filcrypto.h:108
+// FilBLSSignature as declared in filecoin-ffi/filcrypto.h:113
 type FilBLSSignature struct {
 	Inner          [96]byte
 	refa2ac09ba    *C.fil_BLSSignature
 	allocsa2ac09ba interface{}
 }
 
-// FilAggregateResponse as declared in filecoin-ffi/filcrypto.h:115
+// FilAggregateResponse as declared in filecoin-ffi/filcrypto.h:120
 type FilAggregateResponse struct {
 	Signature      FilBLSSignature
 	refb3efa36d    *C.fil_AggregateResponse
 	allocsb3efa36d interface{}
 }
 
-// FilBLSPrivateKey as declared in filecoin-ffi/filcrypto.h:119
+// FilBLSPrivateKey as declared in filecoin-ffi/filcrypto.h:124
 type FilBLSPrivateKey struct {
 	Inner          [32]byte
 	ref2f77fe3a    *C.fil_BLSPrivateKey
 	allocs2f77fe3a interface{}
 }
 
-// FilPrivateKeyGenerateResponse as declared in filecoin-ffi/filcrypto.h:126
+// FilPrivateKeyGenerateResponse as declared in filecoin-ffi/filcrypto.h:131
 type FilPrivateKeyGenerateResponse struct {
 	PrivateKey    FilBLSPrivateKey
 	ref2dba09f    *C.fil_PrivateKeyGenerateResponse
 	allocs2dba09f interface{}
 }
 
-// Fil32ByteArray as declared in filecoin-ffi/filcrypto.h:130
+// Fil32ByteArray as declared in filecoin-ffi/filcrypto.h:135
 type Fil32ByteArray struct {
 	Inner          [32]byte
 	ref373ec61a    *C.fil_32ByteArray
 	allocs373ec61a interface{}
 }
 
-// FilPrivateKeySignResponse as declared in filecoin-ffi/filcrypto.h:137
+// FilPrivateKeySignResponse as declared in filecoin-ffi/filcrypto.h:142
 type FilPrivateKeySignResponse struct {
 	Signature      FilBLSSignature
 	refcdf97b28    *C.fil_PrivateKeySignResponse
 	allocscdf97b28 interface{}
 }
 
-// FilBLSPublicKey as declared in filecoin-ffi/filcrypto.h:141
+// FilBLSPublicKey as declared in filecoin-ffi/filcrypto.h:146
 type FilBLSPublicKey struct {
 	Inner          [48]byte
 	ref6d0cab13    *C.fil_BLSPublicKey
 	allocs6d0cab13 interface{}
 }
 
-// FilPrivateKeyPublicKeyResponse as declared in filecoin-ffi/filcrypto.h:148
+// FilPrivateKeyPublicKeyResponse as declared in filecoin-ffi/filcrypto.h:153
 type FilPrivateKeyPublicKeyResponse struct {
 	PublicKey      FilBLSPublicKey
 	refee14e59d    *C.fil_PrivateKeyPublicKeyResponse
 	allocsee14e59d interface{}
 }
 
-// FilZeroSignatureResponse as declared in filecoin-ffi/filcrypto.h:155
+// FilZeroSignatureResponse as declared in filecoin-ffi/filcrypto.h:160
 type FilZeroSignatureResponse struct {
 	Signature      FilBLSSignature
 	ref835a0405    *C.fil_ZeroSignatureResponse
 	allocs835a0405 interface{}
 }
 
-// FilCreateFvmMachineResponse as declared in filecoin-ffi/filcrypto.h:161
+// FilCreateFvmMachineResponse as declared in filecoin-ffi/filcrypto.h:166
 type FilCreateFvmMachineResponse struct {
 	ErrorMsg       string
 	StatusCode     FCPResponseStatus
@@ -100,7 +100,7 @@ type FilCreateFvmMachineResponse struct {
 	allocs40465416 interface{}
 }
 
-// FilFvmMachineExecuteResponse as declared in filecoin-ffi/filcrypto.h:174
+// FilFvmMachineExecuteResponse as declared in filecoin-ffi/filcrypto.h:179
 type FilFvmMachineExecuteResponse struct {
 	ErrorMsg       string
 	StatusCode     FCPResponseStatus
@@ -116,7 +116,7 @@ type FilFvmMachineExecuteResponse struct {
 	allocs88f63595 interface{}
 }
 
-// FilFvmMachineFlushResponse as declared in filecoin-ffi/filcrypto.h:181
+// FilFvmMachineFlushResponse as declared in filecoin-ffi/filcrypto.h:186
 type FilFvmMachineFlushResponse struct {
 	ErrorMsg       string
 	StatusCode     FCPResponseStatus
@@ -126,7 +126,7 @@ type FilFvmMachineFlushResponse struct {
 	allocs9eb3b4f4 interface{}
 }
 
-// FilWriteWithAlignmentResponse as declared in filecoin-ffi/filcrypto.h:189
+// FilWriteWithAlignmentResponse as declared in filecoin-ffi/filcrypto.h:194
 type FilWriteWithAlignmentResponse struct {
 	CommP                 [32]byte
 	ErrorMsg              string
@@ -137,7 +137,7 @@ type FilWriteWithAlignmentResponse struct {
 	allocsa330e79         interface{}
 }
 
-// FilWriteWithoutAlignmentResponse as declared in filecoin-ffi/filcrypto.h:196
+// FilWriteWithoutAlignmentResponse as declared in filecoin-ffi/filcrypto.h:201
 type FilWriteWithoutAlignmentResponse struct {
 	CommP              [32]byte
 	ErrorMsg           string
@@ -147,7 +147,7 @@ type FilWriteWithoutAlignmentResponse struct {
 	allocsc8e1ed8      interface{}
 }
 
-// FilFauxRepResponse as declared in filecoin-ffi/filcrypto.h:202
+// FilFauxRepResponse as declared in filecoin-ffi/filcrypto.h:207
 type FilFauxRepResponse struct {
 	ErrorMsg       string
 	StatusCode     FCPResponseStatus
@@ -156,7 +156,7 @@ type FilFauxRepResponse struct {
 	allocsaa003f71 interface{}
 }
 
-// FilSealPreCommitPhase1Response as declared in filecoin-ffi/filcrypto.h:209
+// FilSealPreCommitPhase1Response as declared in filecoin-ffi/filcrypto.h:214
 type FilSealPreCommitPhase1Response struct {
 	ErrorMsg                     string
 	StatusCode                   FCPResponseStatus
@@ -166,7 +166,7 @@ type FilSealPreCommitPhase1Response struct {
 	allocs132bbfd8               interface{}
 }
 
-// FilPublicPieceInfo as declared in filecoin-ffi/filcrypto.h:214
+// FilPublicPieceInfo as declared in filecoin-ffi/filcrypto.h:219
 type FilPublicPieceInfo struct {
 	NumBytes       uint64
 	CommP          [32]byte
@@ -174,7 +174,7 @@ type FilPublicPieceInfo struct {
 	allocsd00025ac interface{}
 }
 
-// FilSealPreCommitPhase2Response as declared in filecoin-ffi/filcrypto.h:222
+// FilSealPreCommitPhase2Response as declared in filecoin-ffi/filcrypto.h:227
 type FilSealPreCommitPhase2Response struct {
 	ErrorMsg        string
 	StatusCode      FCPResponseStatus
@@ -185,7 +185,7 @@ type FilSealPreCommitPhase2Response struct {
 	allocs2aa6831d  interface{}
 }
 
-// FilSealCommitPhase1Response as declared in filecoin-ffi/filcrypto.h:229
+// FilSealCommitPhase1Response as declared in filecoin-ffi/filcrypto.h:234
 type FilSealCommitPhase1Response struct {
 	StatusCode                FCPResponseStatus
 	ErrorMsg                  string
@@ -195,7 +195,7 @@ type FilSealCommitPhase1Response struct {
 	allocs61ed8561            interface{}
 }
 
-// FilAggregationInputs as declared in filecoin-ffi/filcrypto.h:237
+// FilAggregationInputs as declared in filecoin-ffi/filcrypto.h:242
 type FilAggregationInputs struct {
 	CommR          Fil32ByteArray
 	CommD          Fil32ByteArray
@@ -206,7 +206,7 @@ type FilAggregationInputs struct {
 	allocs90b967c9 interface{}
 }
 
-// FilSealCommitPhase2Response as declared in filecoin-ffi/filcrypto.h:246
+// FilSealCommitPhase2Response as declared in filecoin-ffi/filcrypto.h:251
 type FilSealCommitPhase2Response struct {
 	StatusCode      FCPResponseStatus
 	ErrorMsg        string
@@ -218,7 +218,7 @@ type FilSealCommitPhase2Response struct {
 	allocs5860b9a4  interface{}
 }
 
-// FilAggregateProof as declared in filecoin-ffi/filcrypto.h:253
+// FilAggregateProof as declared in filecoin-ffi/filcrypto.h:258
 type FilAggregateProof struct {
 	StatusCode     FCPResponseStatus
 	ErrorMsg       string
@@ -228,7 +228,7 @@ type FilAggregateProof struct {
 	allocs22b6c4f6 interface{}
 }
 
-// FilVerifyAggregateSealProofResponse as declared in filecoin-ffi/filcrypto.h:259
+// FilVerifyAggregateSealProofResponse as declared in filecoin-ffi/filcrypto.h:264
 type FilVerifyAggregateSealProofResponse struct {
 	StatusCode    FCPResponseStatus
 	ErrorMsg      string
@@ -237,7 +237,7 @@ type FilVerifyAggregateSealProofResponse struct {
 	allocs66180e0 interface{}
 }
 
-// FilUnsealRangeResponse as declared in filecoin-ffi/filcrypto.h:264
+// FilUnsealRangeResponse as declared in filecoin-ffi/filcrypto.h:269
 type FilUnsealRangeResponse struct {
 	StatusCode     FCPResponseStatus
 	ErrorMsg       string
@@ -245,7 +245,7 @@ type FilUnsealRangeResponse struct {
 	allocs61e219c9 interface{}
 }
 
-// FilVerifySealResponse as declared in filecoin-ffi/filcrypto.h:270
+// FilVerifySealResponse as declared in filecoin-ffi/filcrypto.h:275
 type FilVerifySealResponse struct {
 	StatusCode     FCPResponseStatus
 	ErrorMsg       string
@@ -254,7 +254,7 @@ type FilVerifySealResponse struct {
 	allocsd4397079 interface{}
 }
 
-// FilGenerateWinningPoStSectorChallenge as declared in filecoin-ffi/filcrypto.h:277
+// FilGenerateWinningPoStSectorChallenge as declared in filecoin-ffi/filcrypto.h:282
 type FilGenerateWinningPoStSectorChallenge struct {
 	ErrorMsg       string
 	StatusCode     FCPResponseStatus
@@ -264,7 +264,7 @@ type FilGenerateWinningPoStSectorChallenge struct {
 	allocs69d2a405 interface{}
 }
 
-// FilGenerateFallbackSectorChallengesResponse as declared in filecoin-ffi/filcrypto.h:287
+// FilGenerateFallbackSectorChallengesResponse as declared in filecoin-ffi/filcrypto.h:292
 type FilGenerateFallbackSectorChallengesResponse struct {
 	ErrorMsg         string
 	StatusCode       FCPResponseStatus
@@ -277,7 +277,7 @@ type FilGenerateFallbackSectorChallengesResponse struct {
 	allocs7047a3fa   interface{}
 }
 
-// FilVanillaProof as declared in filecoin-ffi/filcrypto.h:292
+// FilVanillaProof as declared in filecoin-ffi/filcrypto.h:297
 type FilVanillaProof struct {
 	ProofLen       uint
 	ProofPtr       []byte
@@ -285,7 +285,7 @@ type FilVanillaProof struct {
 	allocsb3e7638c interface{}
 }
 
-// FilGenerateSingleVanillaProofResponse as declared in filecoin-ffi/filcrypto.h:298
+// FilGenerateSingleVanillaProofResponse as declared in filecoin-ffi/filcrypto.h:303
 type FilGenerateSingleVanillaProofResponse struct {
 	ErrorMsg       string
 	VanillaProof   FilVanillaProof
@@ -294,7 +294,7 @@ type FilGenerateSingleVanillaProofResponse struct {
 	allocsf9d21b04 interface{}
 }
 
-// FilPrivateReplicaInfo as declared in filecoin-ffi/filcrypto.h:306
+// FilPrivateReplicaInfo as declared in filecoin-ffi/filcrypto.h:311
 type FilPrivateReplicaInfo struct {
 	RegisteredProof FilRegisteredPoStProof
 	CacheDirPath    string
@@ -305,7 +305,7 @@ type FilPrivateReplicaInfo struct {
 	allocs81a31e9b  interface{}
 }
 
-// FilPoStProof as declared in filecoin-ffi/filcrypto.h:312
+// FilPoStProof as declared in filecoin-ffi/filcrypto.h:317
 type FilPoStProof struct {
 	RegisteredProof FilRegisteredPoStProof
 	ProofLen        uint
@@ -314,7 +314,7 @@ type FilPoStProof struct {
 	allocs3451bfa   interface{}
 }
 
-// FilGenerateWinningPoStResponse as declared in filecoin-ffi/filcrypto.h:319
+// FilGenerateWinningPoStResponse as declared in filecoin-ffi/filcrypto.h:324
 type FilGenerateWinningPoStResponse struct {
 	ErrorMsg       string
 	ProofsLen      uint
@@ -324,7 +324,7 @@ type FilGenerateWinningPoStResponse struct {
 	allocs1405b8ec interface{}
 }
 
-// FilVerifyWinningPoStResponse as declared in filecoin-ffi/filcrypto.h:325
+// FilVerifyWinningPoStResponse as declared in filecoin-ffi/filcrypto.h:330
 type FilVerifyWinningPoStResponse struct {
 	StatusCode     FCPResponseStatus
 	ErrorMsg       string
@@ -333,7 +333,7 @@ type FilVerifyWinningPoStResponse struct {
 	allocsaca6860c interface{}
 }
 
-// FilPublicReplicaInfo as declared in filecoin-ffi/filcrypto.h:331
+// FilPublicReplicaInfo as declared in filecoin-ffi/filcrypto.h:336
 type FilPublicReplicaInfo struct {
 	RegisteredProof FilRegisteredPoStProof
 	CommR           [32]byte
@@ -342,7 +342,7 @@ type FilPublicReplicaInfo struct {
 	allocs81b617c2  interface{}
 }
 
-// FilGenerateWindowPoStResponse as declared in filecoin-ffi/filcrypto.h:340
+// FilGenerateWindowPoStResponse as declared in filecoin-ffi/filcrypto.h:345
 type FilGenerateWindowPoStResponse struct {
 	ErrorMsg         string
 	ProofsLen        uint
@@ -354,7 +354,7 @@ type FilGenerateWindowPoStResponse struct {
 	allocs2a5f3ba8   interface{}
 }
 
-// FilVerifyWindowPoStResponse as declared in filecoin-ffi/filcrypto.h:346
+// FilVerifyWindowPoStResponse as declared in filecoin-ffi/filcrypto.h:351
 type FilVerifyWindowPoStResponse struct {
 	StatusCode     FCPResponseStatus
 	ErrorMsg       string
@@ -363,7 +363,7 @@ type FilVerifyWindowPoStResponse struct {
 	allocs34c4d49f interface{}
 }
 
-// FilMergeWindowPoStPartitionProofsResponse as declared in filecoin-ffi/filcrypto.h:352
+// FilMergeWindowPoStPartitionProofsResponse as declared in filecoin-ffi/filcrypto.h:357
 type FilMergeWindowPoStPartitionProofsResponse struct {
 	ErrorMsg       string
 	Proof          FilPoStProof
@@ -372,7 +372,7 @@ type FilMergeWindowPoStPartitionProofsResponse struct {
 	allocs3369154e interface{}
 }
 
-// FilPartitionSnarkProof as declared in filecoin-ffi/filcrypto.h:358
+// FilPartitionSnarkProof as declared in filecoin-ffi/filcrypto.h:363
 type FilPartitionSnarkProof struct {
 	RegisteredProof FilRegisteredPoStProof
 	ProofLen        uint
@@ -381,7 +381,7 @@ type FilPartitionSnarkProof struct {
 	allocs4de03739  interface{}
 }
 
-// FilGetNumPartitionForFallbackPoStResponse as declared in filecoin-ffi/filcrypto.h:364
+// FilGetNumPartitionForFallbackPoStResponse as declared in filecoin-ffi/filcrypto.h:369
 type FilGetNumPartitionForFallbackPoStResponse struct {
 	ErrorMsg       string
 	StatusCode     FCPResponseStatus
@@ -390,7 +390,7 @@ type FilGetNumPartitionForFallbackPoStResponse struct {
 	allocsc0084478 interface{}
 }
 
-// FilGenerateSingleWindowPoStWithVanillaResponse as declared in filecoin-ffi/filcrypto.h:372
+// FilGenerateSingleWindowPoStWithVanillaResponse as declared in filecoin-ffi/filcrypto.h:377
 type FilGenerateSingleWindowPoStWithVanillaResponse struct {
 	ErrorMsg         string
 	PartitionProof   FilPartitionSnarkProof
@@ -401,7 +401,7 @@ type FilGenerateSingleWindowPoStWithVanillaResponse struct {
 	allocs96c012c3   interface{}
 }
 
-// FilEmptySectorUpdateEncodeIntoResponse as declared in filecoin-ffi/filcrypto.h:380
+// FilEmptySectorUpdateEncodeIntoResponse as declared in filecoin-ffi/filcrypto.h:385
 type FilEmptySectorUpdateEncodeIntoResponse struct {
 	ErrorMsg       string
 	StatusCode     FCPResponseStatus
@@ -412,7 +412,7 @@ type FilEmptySectorUpdateEncodeIntoResponse struct {
 	allocs8d3238a7 interface{}
 }
 
-// FilEmptySectorUpdateDecodeFromResponse as declared in filecoin-ffi/filcrypto.h:385
+// FilEmptySectorUpdateDecodeFromResponse as declared in filecoin-ffi/filcrypto.h:390
 type FilEmptySectorUpdateDecodeFromResponse struct {
 	StatusCode     FCPResponseStatus
 	ErrorMsg       string
@@ -420,7 +420,7 @@ type FilEmptySectorUpdateDecodeFromResponse struct {
 	allocsf02a01b8 interface{}
 }
 
-// FilEmptySectorUpdateRemoveEncodedDataResponse as declared in filecoin-ffi/filcrypto.h:390
+// FilEmptySectorUpdateRemoveEncodedDataResponse as declared in filecoin-ffi/filcrypto.h:395
 type FilEmptySectorUpdateRemoveEncodedDataResponse struct {
 	StatusCode     FCPResponseStatus
 	ErrorMsg       string
@@ -428,7 +428,7 @@ type FilEmptySectorUpdateRemoveEncodedDataResponse struct {
 	allocs50783b83 interface{}
 }
 
-// FilPartitionProof as declared in filecoin-ffi/filcrypto.h:395
+// FilPartitionProof as declared in filecoin-ffi/filcrypto.h:400
 type FilPartitionProof struct {
 	ProofLen       uint
 	ProofPtr       []byte
@@ -436,7 +436,7 @@ type FilPartitionProof struct {
 	allocs566a2be6 interface{}
 }
 
-// FilPartitionProofResponse as declared in filecoin-ffi/filcrypto.h:402
+// FilPartitionProofResponse as declared in filecoin-ffi/filcrypto.h:407
 type FilPartitionProofResponse struct {
 	StatusCode     FCPResponseStatus
 	ErrorMsg       string
@@ -446,7 +446,7 @@ type FilPartitionProofResponse struct {
 	allocs51343e7a interface{}
 }
 
-// FilVerifyPartitionProofResponse as declared in filecoin-ffi/filcrypto.h:408
+// FilVerifyPartitionProofResponse as declared in filecoin-ffi/filcrypto.h:413
 type FilVerifyPartitionProofResponse struct {
 	StatusCode    FCPResponseStatus
 	ErrorMsg      string
@@ -455,7 +455,7 @@ type FilVerifyPartitionProofResponse struct {
 	allocsaed1b67 interface{}
 }
 
-// FilEmptySectorUpdateProofResponse as declared in filecoin-ffi/filcrypto.h:415
+// FilEmptySectorUpdateProofResponse as declared in filecoin-ffi/filcrypto.h:420
 type FilEmptySectorUpdateProofResponse struct {
 	StatusCode    FCPResponseStatus
 	ErrorMsg      string
@@ -465,7 +465,7 @@ type FilEmptySectorUpdateProofResponse struct {
 	allocs5c2faef interface{}
 }
 
-// FilVerifyEmptySectorUpdateProofResponse as declared in filecoin-ffi/filcrypto.h:421
+// FilVerifyEmptySectorUpdateProofResponse as declared in filecoin-ffi/filcrypto.h:426
 type FilVerifyEmptySectorUpdateProofResponse struct {
 	StatusCode    FCPResponseStatus
 	ErrorMsg      string
@@ -474,7 +474,7 @@ type FilVerifyEmptySectorUpdateProofResponse struct {
 	allocs50b7b13 interface{}
 }
 
-// FilGeneratePieceCommitmentResponse as declared in filecoin-ffi/filcrypto.h:432
+// FilGeneratePieceCommitmentResponse as declared in filecoin-ffi/filcrypto.h:437
 type FilGeneratePieceCommitmentResponse struct {
 	StatusCode      FCPResponseStatus
 	ErrorMsg        string
@@ -484,7 +484,7 @@ type FilGeneratePieceCommitmentResponse struct {
 	allocs4b00fda4  interface{}
 }
 
-// FilGenerateDataCommitmentResponse as declared in filecoin-ffi/filcrypto.h:438
+// FilGenerateDataCommitmentResponse as declared in filecoin-ffi/filcrypto.h:443
 type FilGenerateDataCommitmentResponse struct {
 	StatusCode     FCPResponseStatus
 	ErrorMsg       string
@@ -493,7 +493,7 @@ type FilGenerateDataCommitmentResponse struct {
 	allocs87da7dd9 interface{}
 }
 
-// FilClearCacheResponse as declared in filecoin-ffi/filcrypto.h:443
+// FilClearCacheResponse as declared in filecoin-ffi/filcrypto.h:448
 type FilClearCacheResponse struct {
 	ErrorMsg       string
 	StatusCode     FCPResponseStatus
@@ -501,7 +501,7 @@ type FilClearCacheResponse struct {
 	allocsa9a80400 interface{}
 }
 
-// FilStringResponse as declared in filecoin-ffi/filcrypto.h:452
+// FilStringResponse as declared in filecoin-ffi/filcrypto.h:457
 type FilStringResponse struct {
 	StatusCode     FCPResponseStatus
 	ErrorMsg       string
@@ -510,7 +510,7 @@ type FilStringResponse struct {
 	allocs4f413043 interface{}
 }
 
-// FilFinalizeTicketResponse as declared in filecoin-ffi/filcrypto.h:458
+// FilFinalizeTicketResponse as declared in filecoin-ffi/filcrypto.h:463
 type FilFinalizeTicketResponse struct {
 	StatusCode     FCPResponseStatus
 	ErrorMsg       string
@@ -519,7 +519,7 @@ type FilFinalizeTicketResponse struct {
 	allocsb370fa86 interface{}
 }
 
-// FilGpuDeviceResponse as declared in filecoin-ffi/filcrypto.h:465
+// FilGpuDeviceResponse as declared in filecoin-ffi/filcrypto.h:470
 type FilGpuDeviceResponse struct {
 	StatusCode     FCPResponseStatus
 	ErrorMsg       string
@@ -529,7 +529,7 @@ type FilGpuDeviceResponse struct {
 	allocs58f92915 interface{}
 }
 
-// FilInitLogFdResponse as declared in filecoin-ffi/filcrypto.h:470
+// FilInitLogFdResponse as declared in filecoin-ffi/filcrypto.h:475
 type FilInitLogFdResponse struct {
 	StatusCode     FCPResponseStatus
 	ErrorMsg       string

--- a/rust/src/fvm/cgo/error.rs
+++ b/rust/src/fvm/cgo/error.rs
@@ -14,3 +14,6 @@ pub const ERR_IO: i32 = -3;
 
 /// The error code returned by cgo when an argument is invalid.
 pub const ERR_INVALID_ARGUMENT: i32 = -4;
+
+/// The error code returned by cgo when the application panics.
+pub const ERR_PANIC: i32 = -5;


### PR DESCRIPTION
Otherwise, we could panic across an FFI boundary, which is undefined behavior.