### PR TITLE
feat: update FVM to v6.0.0

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -233,9 +233,9 @@ version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -594,11 +594,11 @@ dependencies = [
  "heck 0.3.3",
  "indexmap",
  "log",
- "proc-macro2 1.0.36",
- "quote 1.0.17",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
  "serde",
  "serde_json",
- "syn 1.0.90",
+ "syn 1.0.91",
  "tempfile",
  "toml",
 ]
@@ -716,9 +716,9 @@ checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -789,18 +789,18 @@ checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.82.2"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9956ad3efeb062596e0b25a1091730080cb6483b500bd106b92c7a55e9e0b1"
+checksum = "38faa2a16616c8e78a18d37b4726b98bfd2de192f2fdc8a39ddf568a408a0f75"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.82.2"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efc67870c31cae7d03808dfa430ee9ccda9bd82c61b49b939d925d9155cfc42d"
+checksum = "26f192472a3ba23860afd07d2b0217dc628f21fcc72617aa1336d98e1671f33b"
 dependencies = [
  "cranelift-bforest",
  "cranelift-codegen-meta",
@@ -815,33 +815,33 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.82.2"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0f0172d25539fcc64f581d3dce0df00e2065b00e1c750e18832d2cf1e0d27e0"
+checksum = "0f32ddb89e9b89d3d9b36a5b7d7ea3261c98235a76ac95ba46826b8ec40b1a24"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.82.2"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f6cc5717ae2ea849e5c819eb70c95792c2843294d9503700ac55d8d159e2160"
+checksum = "01fd0d9f288cc1b42d9333b7a776b17e278fc888c28e6a0f09b5573d45a150bc"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.82.2"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e822e0169d7a078cbc7ed19bca6636752c093e25d994a4febd9914d1118f3945"
+checksum = "9e3bfe172b83167604601faf9dc60453e0d0a93415b57a9c4d1a7ae6849185cf"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.82.2"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3bc8bd3bb8932e70b71c0de6cba277ae112d4e51dadde2e318f60f2fbe97bc"
+checksum = "a006e3e32d80ce0e4ba7f1f9ddf66066d052a8c884a110b91d05404d6ce26dce"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -851,9 +851,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.82.2"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8090cade0761622fcb1c805c8ce2c2f085a2467bdee7e21cd9ba399026cf7ac"
+checksum = "501241b0cdf903412ec9075385ac9f2b1eb18a89044d1538e97fab603231f70c"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -862,9 +862,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.82.2"
+version = "0.82.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be110a4560fa997ba8bc8376a459ec4d8707074f88058a17b29f43c27e983ad0"
+checksum = "16d9e4211bbc3268042a96dd4de5bd979cda22434991d035f5f8eacba987fad2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -995,8 +995,8 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f877be4f7c9f246b183111634f75baa039715e3f46ce860677d3b19a69fb229c"
 dependencies = [
- "quote 1.0.17",
- "syn 1.0.90",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -1035,10 +1035,10 @@ checksum = "8e91455b86830a1c21799d94524df0845183fa55bafd9aa137b01c7d1065fa36"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.36",
- "quote 1.0.17",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
  "strsim 0.10.0",
- "syn 1.0.90",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -1048,8 +1048,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29b5acf0dea37a7f66f7b25d2c5e93fd46f8f6968b1a5d7a3e02e97768afc95a"
 dependencies = [
  "darling_core",
- "quote 1.0.17",
- "syn 1.0.90",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -1075,7 +1075,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5bbed42daaa95e780b60a50546aa345b8413a1e46f9a40a12907d3598f038db"
 dependencies = [
  "data-encoding",
- "syn 1.0.90",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -1084,9 +1084,9 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c5905670fd9c320154f3a4a01c9e609733cd7b753f3c58777ab7d5ce26686b3"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -1105,9 +1105,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66e616858f6187ed828df7c64a6d71720d83767a7f19740b2d1b6fe6327b36e5"
 dependencies = [
  "darling",
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -1117,7 +1117,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58a94ace95092c5acb1e97a7e846b310cfbd499652f72297da7493f618a98d73"
 dependencies = [
  "derive_builder_core",
- "syn 1.0.90",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -1127,10 +1127,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
- "proc-macro2 1.0.36",
- "quote 1.0.17",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
  "rustc_version",
- "syn 1.0.90",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -1285,8 +1285,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af4a304bcd894a5d41f8b379d01e09bff28fd8df257216a33699658ea37bccb8"
 dependencies = [
  "execute-command-tokens",
- "quote 1.0.17",
- "syn 1.0.90",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -1373,11 +1373,11 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_account"
-version = "6.1.1"
+version = "6.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63dbe7d8e11bd9edd6d78fea3f1cba729c09c227ee7d73544a223960ecc4ebfd"
+checksum = "3b56c843049bb0649b6afdffd389f2b9961810ef5172770eb2fe2d80890acde3"
 dependencies = [
- "fil_actors_runtime 6.1.1",
+ "fil_actors_runtime 6.1.2",
  "fvm_shared 0.2.2",
  "num-derive",
  "num-traits",
@@ -1386,30 +1386,35 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_account"
-version = "7.1.1"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f603b78eee63577682ada6f50951e5bc0f7828b4c331434f16b4c97c50b42655"
+checksum = "26a393b9ba67dc8b7848b196be02fad01b8ab6df747a20f998d8acf4c9c426c4"
 dependencies = [
- "fil_actors_runtime 7.1.1",
- "fvm_shared 0.2.2",
+ "fil_actors_runtime 7.1.3",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
+ "fvm_shared 0.4.1",
  "num-derive",
  "num-traits",
  "serde",
+ "serde_tuple",
 ]
 
 [[package]]
 name = "fil_actor_bundler"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdb9c600e969dec295da976f2f649babefe6f216cb6db9a26ecc35b2cd5a2c1"
+checksum = "713dbeea1f761c8a55c188f21d2ba3e52851d3362d3f231f9e52cd145c4a43f0"
 dependencies = [
  "anyhow",
  "async-std",
  "cid",
  "clap 3.1.8",
  "futures",
- "fvm_ipld_car 0.2.0",
- "fvm_shared 0.2.2",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_car",
+ "fvm_ipld_encoding",
+ "fvm_shared 0.5.1",
  "serde",
  "serde_ipld_dagcbor",
  "serde_json",
@@ -1417,11 +1422,11 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_cron"
-version = "6.1.1"
+version = "6.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49d21e5c1f0e367ffa67189fd75da81e4ba53b6ed59844ee9755e3138bd7d42"
+checksum = "784463059a830a8b5825e940cdca4a999d5c2bd61066eb6f7c719d68526cb59c"
 dependencies = [
- "fil_actors_runtime 6.1.1",
+ "fil_actors_runtime 6.1.2",
  "fvm_shared 0.2.2",
  "log",
  "num-derive",
@@ -1431,11 +1436,31 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_cron"
-version = "7.1.1"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4405e9d59a6427f5b061f7effadc5f2fc8db10646475ae4d9bbb2f28b32bd897"
+checksum = "c030dbefeb48c61b51c16753ffdbc18d6bd08760106b5e0ddb1f560d62d20dd7"
 dependencies = [
- "fil_actors_runtime 7.1.1",
+ "fil_actors_runtime 7.1.3",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
+ "fvm_shared 0.4.1",
+ "log",
+ "num-derive",
+ "num-traits",
+ "serde",
+ "serde_tuple",
+]
+
+[[package]]
+name = "fil_actor_init"
+version = "6.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "753d19ef20872f8117b9d0c4ce50a4d745f97b871d5f343e37bd6647456a59c6"
+dependencies = [
+ "anyhow",
+ "cid",
+ "fil_actors_runtime 6.1.2",
+ "fvm_ipld_hamt 0.2.0",
  "fvm_shared 0.2.2",
  "log",
  "num-derive",
@@ -1445,31 +1470,35 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_init"
-version = "6.1.1"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e127ac25c3263d65957c6206e56d716b18c20df32201a793c346693e6051d9"
+checksum = "983813a369ce985523a8fcac18910bd59cac4e1aecf703248ed5c54a1914d399"
 dependencies = [
  "anyhow",
  "cid",
- "fil_actors_runtime 6.1.1",
- "fvm_ipld_hamt 0.2.0",
- "fvm_shared 0.2.2",
+ "fil_actors_runtime 7.1.3",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
+ "fvm_ipld_hamt 0.4.0",
+ "fvm_shared 0.4.1",
  "log",
  "num-derive",
  "num-traits",
  "serde",
+ "serde_tuple",
 ]
 
 [[package]]
-name = "fil_actor_init"
-version = "7.1.1"
+name = "fil_actor_market"
+version = "6.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd31fb70336776388b330d695088086b4b8fefe73bb0dca4c79e5a58048c58f"
+checksum = "8ec5bfffc1d7fc85cce55596ee498348ee6b81f4d6d922aa769419e0be693e37"
 dependencies = [
+ "ahash",
  "anyhow",
  "cid",
- "fil_actors_runtime 7.1.1",
- "fvm_ipld_hamt 0.2.0",
+ "fil_actors_runtime 6.1.2",
+ "fvm_ipld_bitfield 0.2.1",
  "fvm_shared 0.2.2",
  "log",
  "num-derive",
@@ -1479,53 +1508,38 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_market"
-version = "6.1.1"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1597d947a9718690235d6941ed43a7cd27c60fa1952c5af5221d9601216d812"
+checksum = "240bd4b50a847de1cb9395d763ab2109cef8f25a2a543b2252b9dcacc825dd1d"
 dependencies = [
  "ahash",
  "anyhow",
  "cid",
- "fil_actors_runtime 6.1.1",
- "fvm_ipld_bitfield",
- "fvm_shared 0.2.2",
+ "fil_actors_runtime 7.1.3",
+ "fvm_ipld_bitfield 0.5.0",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
+ "fvm_ipld_hamt 0.4.0",
+ "fvm_shared 0.4.1",
  "log",
  "num-derive",
  "num-traits",
  "serde",
-]
-
-[[package]]
-name = "fil_actor_market"
-version = "7.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d933da0ea2ac22b7114d6e96ea0a3a67638091c4309e2384d7aba151919ef44"
-dependencies = [
- "ahash",
- "anyhow",
- "cid",
- "fil_actors_runtime 7.1.1",
- "fvm_ipld_bitfield",
- "fvm_ipld_hamt 0.2.0",
- "fvm_shared 0.2.2",
- "log",
- "num-derive",
- "num-traits",
- "serde",
+ "serde_tuple",
 ]
 
 [[package]]
 name = "fil_actor_miner"
-version = "6.1.1"
+version = "6.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c918890e1dc529c53ab3e1cd049dcd869d7f35282c3b6100f6955f6bdfea2063"
+checksum = "fdace21550831f84e89b02ebeb432f08e866e83d6b8869a15c0575750bbe66e0"
 dependencies = [
  "anyhow",
  "byteorder 1.4.3",
  "cid",
- "fil_actors_runtime 6.1.1",
+ "fil_actors_runtime 6.1.2",
  "fvm_ipld_amt 0.2.0",
- "fvm_ipld_bitfield",
+ "fvm_ipld_bitfield 0.2.1",
  "fvm_ipld_hamt 0.2.0",
  "fvm_shared 0.2.2",
  "itertools 0.10.3",
@@ -1538,35 +1552,38 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_miner"
-version = "7.1.1"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e550b1dacbec0a350b75f4ef93f03be5d27d41fdfa2e03f2e5eb0f17cf6c8641"
+checksum = "713458e3c64d14a6957ee354e053cb1a9d77e98ca9676354dc6b73ae7f52b11b"
 dependencies = [
  "anyhow",
  "byteorder 1.4.3",
  "cid",
- "fil_actors_runtime 7.1.1",
- "fvm_ipld_amt 0.2.0",
- "fvm_ipld_bitfield",
- "fvm_ipld_hamt 0.2.0",
- "fvm_shared 0.2.2",
+ "fil_actors_runtime 7.1.3",
+ "fvm_ipld_amt 0.4.0",
+ "fvm_ipld_bitfield 0.5.0",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
+ "fvm_ipld_hamt 0.4.0",
+ "fvm_shared 0.4.1",
  "itertools 0.10.3",
  "lazy_static",
  "log",
  "num-derive",
  "num-traits",
  "serde",
+ "serde_tuple",
 ]
 
 [[package]]
 name = "fil_actor_multisig"
-version = "6.1.1"
+version = "6.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d528cd8fcaad887c08a2a09039d67d84a8fcf526acf7308e9fd7e769ed3a1f47"
+checksum = "fbc306f0734a818b9ef57eba13a5f706f0f77ab9a9df09ddad655b0298cb79dc"
 dependencies = [
  "anyhow",
  "cid",
- "fil_actors_runtime 6.1.1",
+ "fil_actors_runtime 6.1.2",
  "fvm_ipld_hamt 0.2.0",
  "fvm_shared 0.2.2",
  "indexmap",
@@ -1578,31 +1595,34 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_multisig"
-version = "7.1.1"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde6a801f9439cdb18232bfb6e0a575c80e537d4c4299e4ca8a3d8c51e51f364"
+checksum = "72afec59873ecb3de7fe83c74709555f381a067823e71a417f555b1c17bfdee8"
 dependencies = [
  "anyhow",
  "cid",
- "fil_actors_runtime 7.1.1",
- "fvm_ipld_hamt 0.2.0",
- "fvm_shared 0.2.2",
+ "fil_actors_runtime 7.1.3",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
+ "fvm_ipld_hamt 0.4.0",
+ "fvm_shared 0.4.1",
  "indexmap",
  "integer-encoding",
  "num-derive",
  "num-traits",
  "serde",
+ "serde_tuple",
 ]
 
 [[package]]
 name = "fil_actor_paych"
-version = "6.1.1"
+version = "6.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4921eda0a5e580948c9cd362cf194ba08ec511e4c0e04baeda04e8a79fbdab7e"
+checksum = "f19959520342da43fddd2477911b24eef9c3354ee6bdd4544d665760c623bfcb"
 dependencies = [
  "anyhow",
  "cid",
- "fil_actors_runtime 6.1.1",
+ "fil_actors_runtime 6.1.2",
  "fvm_shared 0.2.2",
  "num-derive",
  "num-traits",
@@ -1611,28 +1631,31 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_paych"
-version = "7.1.1"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31fe5cea0956ef3abc7ab713b17b031b7c26178433de49fe720b2b48682c58e8"
+checksum = "6fd076dd51c20bf412f9b257fc523c7646d8deea358fbce4afcdecafa0003d2b"
 dependencies = [
  "anyhow",
  "cid",
- "fil_actors_runtime 7.1.1",
- "fvm_shared 0.2.2",
+ "fil_actors_runtime 7.1.3",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
+ "fvm_shared 0.4.1",
  "num-derive",
  "num-traits",
  "serde",
+ "serde_tuple",
 ]
 
 [[package]]
 name = "fil_actor_power"
-version = "6.1.1"
+version = "6.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a0af455c80ba5e612fe2ef8a02b28c82ce6927b5bd835978c98177dd8d19dae"
+checksum = "9a1649573f79b13ebabc3bea55a7cb197242551455f5e52ff148e4b76293057b"
 dependencies = [
  "anyhow",
  "cid",
- "fil_actors_runtime 6.1.1",
+ "fil_actors_runtime 6.1.2",
  "fvm_ipld_hamt 0.2.0",
  "fvm_shared 0.2.2",
  "indexmap",
@@ -1646,17 +1669,35 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_power"
-version = "7.1.1"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dec674a6962d7657a994a39944237869206aa55ba4c0432026133bc14c8ad73"
+checksum = "72a954b7e5291db382c1a4856957918d491293191efcd9216823a5844119a32e"
 dependencies = [
  "anyhow",
  "cid",
- "fil_actors_runtime 7.1.1",
- "fvm_ipld_hamt 0.2.0",
- "fvm_shared 0.2.2",
+ "fil_actors_runtime 7.1.3",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
+ "fvm_ipld_hamt 0.4.0",
+ "fvm_shared 0.4.1",
  "indexmap",
  "integer-encoding",
+ "lazy_static",
+ "log",
+ "num-derive",
+ "num-traits",
+ "serde",
+ "serde_tuple",
+]
+
+[[package]]
+name = "fil_actor_reward"
+version = "6.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe5752e16cdc29fb7e1439f18b84fa5b093d780f3231c9730bf890a776fffbd7"
+dependencies = [
+ "fil_actors_runtime 6.1.2",
+ "fvm_shared 0.2.2",
  "lazy_static",
  "log",
  "num-derive",
@@ -1666,41 +1707,29 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_reward"
-version = "6.1.1"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e7c28eb5e35c46b081813f91c3ca22cb078d36094d13a70c74c5b355b530ee"
+checksum = "bd1db90bc4d7d439dbdd2599b6c1d4dd29e707e8b776be32f7a4d86f687ebe04"
 dependencies = [
- "fil_actors_runtime 6.1.1",
- "fvm_shared 0.2.2",
+ "fil_actors_runtime 7.1.3",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
+ "fvm_shared 0.4.1",
  "lazy_static",
  "log",
  "num-derive",
  "num-traits",
  "serde",
-]
-
-[[package]]
-name = "fil_actor_reward"
-version = "7.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "027041f8c8715ca35091e8d838c7844c635ab194468aecd128dd2310e3c9f7a4"
-dependencies = [
- "fil_actors_runtime 7.1.1",
- "fvm_shared 0.2.2",
- "lazy_static",
- "log",
- "num-derive",
- "num-traits",
- "serde",
+ "serde_tuple",
 ]
 
 [[package]]
 name = "fil_actor_system"
-version = "6.1.1"
+version = "6.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34938a56917f7504a7a42752f4d960cc57410554784cc2789752ea9e936d042"
+checksum = "86588083450c26256ac8ff7464db3653665634ab770c0c255af320f14c086e00"
 dependencies = [
- "fil_actors_runtime 6.1.1",
+ "fil_actors_runtime 6.1.2",
  "fvm_shared 0.2.2",
  "num-derive",
  "num-traits",
@@ -1709,12 +1738,14 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_system"
-version = "7.1.1"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2570e4c73dd5bd12f85cbeb9132e69b02c26e43d3339e13d233a9da5a7db8a7"
+checksum = "55517aa9100834b84200290d7fd0189464e2dffc7f8f6909c4a3b72e6246b7bc"
 dependencies = [
- "fil_actors_runtime 7.1.1",
- "fvm_shared 0.2.2",
+ "fil_actors_runtime 7.1.3",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
+ "fvm_shared 0.4.1",
  "num-derive",
  "num-traits",
  "serde",
@@ -1722,13 +1753,13 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_verifreg"
-version = "6.1.1"
+version = "6.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97adc9028d4c30a4f30387a3239cddecd98dd5d800c09a66c5a139fba0526c5d"
+checksum = "a382b414fa830947f6e0793d5e1fb43fa029909a4dc79cd136530d1ee247c956"
 dependencies = [
  "anyhow",
  "cid",
- "fil_actors_runtime 6.1.1",
+ "fil_actors_runtime 6.1.2",
  "fvm_shared 0.2.2",
  "lazy_static",
  "num-derive",
@@ -1738,26 +1769,29 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_verifreg"
-version = "7.1.1"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "967cf3d43d3e51ddcd9116cdd0a8bb6ace505e3177a152a1112d94088783e198"
+checksum = "2bcb5b7262f3722dd9c4844d68d1b223e95dc8d106b00b48c4e43e17e35be92b"
 dependencies = [
  "anyhow",
  "cid",
- "fil_actors_runtime 7.1.1",
- "fvm_ipld_hamt 0.2.0",
- "fvm_shared 0.2.2",
+ "fil_actors_runtime 7.1.3",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
+ "fvm_ipld_hamt 0.4.0",
+ "fvm_shared 0.4.1",
  "lazy_static",
  "num-derive",
  "num-traits",
  "serde",
+ "serde_tuple",
 ]
 
 [[package]]
 name = "fil_actors_runtime"
-version = "6.1.1"
+version = "6.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33930dc0ec8bf9a031cb21fb42eaabb9e635081cffdd0920cbbb5c78764f7113"
+checksum = "45c4f5a8c8db525a4b7d8f3c3cf24230133f34b3f90a7f0e85d7fb187270d257"
 dependencies = [
  "anyhow",
  "base64",
@@ -1765,7 +1799,7 @@ dependencies = [
  "cid",
  "fvm_ipld_amt 0.2.0",
  "fvm_ipld_hamt 0.2.0",
- "fvm_sdk",
+ "fvm_sdk 0.2.2",
  "fvm_shared 0.2.2",
  "getrandom 0.2.6",
  "indexmap",
@@ -1781,18 +1815,21 @@ dependencies = [
 
 [[package]]
 name = "fil_actors_runtime"
-version = "7.1.1"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55edd95ab33981cf853eb28b41eb3a57a3b510edd5cfdd821e1a63014cc048f8"
+checksum = "8e09386a7296fe3d833ea05d99cb835d0a88fec57d5aedccccb2a035637a3879"
 dependencies = [
  "anyhow",
  "base64",
+ "blake2b_simd 1.0.0",
  "byteorder 1.4.3",
  "cid",
- "fvm_ipld_amt 0.2.0",
- "fvm_ipld_hamt 0.2.0",
- "fvm_sdk",
- "fvm_shared 0.2.2",
+ "fvm_ipld_amt 0.4.0",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
+ "fvm_ipld_hamt 0.4.0",
+ "fvm_sdk 0.4.0",
+ "fvm_shared 0.4.1",
  "getrandom 0.2.6",
  "indexmap",
  "integer-encoding",
@@ -1801,51 +1838,52 @@ dependencies = [
  "num-derive",
  "num-traits",
  "serde",
+ "serde_tuple",
  "thiserror",
  "unsigned-varint",
 ]
 
 [[package]]
 name = "fil_builtin_actors_bundle"
-version = "6.1.1"
+version = "6.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e69d3cdc48067f6410de8c9f1da84c64f3d7a33177de52237fa8fe92b81b9fa"
+checksum = "38ca1a03714357590c2aaacef5f5e8a45cf061f5f78b3b19672a700028c9a38f"
 dependencies = [
  "cid",
- "fil_actor_account 6.1.1",
+ "fil_actor_account 6.1.2",
  "fil_actor_bundler",
- "fil_actor_cron 6.1.1",
- "fil_actor_init 6.1.1",
- "fil_actor_market 6.1.1",
- "fil_actor_miner 6.1.1",
- "fil_actor_multisig 6.1.1",
- "fil_actor_paych 6.1.1",
- "fil_actor_power 6.1.1",
- "fil_actor_reward 6.1.1",
- "fil_actor_system 6.1.1",
- "fil_actor_verifreg 6.1.1",
+ "fil_actor_cron 6.1.2",
+ "fil_actor_init 6.1.2",
+ "fil_actor_market 6.1.2",
+ "fil_actor_miner 6.1.2",
+ "fil_actor_multisig 6.1.2",
+ "fil_actor_paych 6.1.2",
+ "fil_actor_power 6.1.2",
+ "fil_actor_reward 6.1.2",
+ "fil_actor_system 6.1.2",
+ "fil_actor_verifreg 6.1.2",
 ]
 
 [[package]]
 name = "fil_builtin_actors_bundle"
-version = "7.1.1"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "133679f7ee23c89b1cdfe6a061d0729046c7f2d060d207463b4517e53ea9b3eb"
+checksum = "510c9c6c137af2edf0d780ef6a32280edf73210ac4479aac148cf951e004c373"
 dependencies = [
  "cid",
- "fil_actor_account 7.1.1",
+ "fil_actor_account 7.1.3",
  "fil_actor_bundler",
- "fil_actor_cron 7.1.1",
- "fil_actor_init 7.1.1",
- "fil_actor_market 7.1.1",
- "fil_actor_miner 7.1.1",
- "fil_actor_multisig 7.1.1",
- "fil_actor_paych 7.1.1",
- "fil_actor_power 7.1.1",
- "fil_actor_reward 7.1.1",
- "fil_actor_system 7.1.1",
- "fil_actor_verifreg 7.1.1",
- "fil_actors_runtime 7.1.1",
+ "fil_actor_cron 7.1.3",
+ "fil_actor_init 7.1.3",
+ "fil_actor_market 7.1.3",
+ "fil_actor_miner 7.1.3",
+ "fil_actor_multisig 7.1.3",
+ "fil_actor_paych 7.1.3",
+ "fil_actor_power 7.1.3",
+ "fil_actor_reward 7.1.3",
+ "fil_actor_system 7.1.3",
+ "fil_actor_verifreg 7.1.3",
+ "fil_actors_runtime 7.1.3",
 ]
 
 [[package]]
@@ -1874,8 +1912,8 @@ dependencies = [
  "drop_struct_macro_derive",
  "fff",
  "ffi-toolkit",
- "fil_builtin_actors_bundle 6.1.1",
- "fil_builtin_actors_bundle 7.1.1",
+ "fil_builtin_actors_bundle 6.1.2",
+ "fil_builtin_actors_bundle 7.1.3",
  "fil_logger",
  "filecoin-proofs-api",
  "filepath",
@@ -1883,9 +1921,9 @@ dependencies = [
  "futures",
  "fvm",
  "fvm_ipld_blockstore",
- "fvm_ipld_car 0.4.0",
+ "fvm_ipld_car",
  "fvm_ipld_encoding",
- "fvm_shared 0.4.1",
+ "fvm_shared 0.5.1",
  "group",
  "lazy_static",
  "libc",
@@ -2143,9 +2181,9 @@ version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -2180,9 +2218,9 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90d41dc54c85611a2af7d1755b32c26ded3ca8ded980fe23c195189eccbd9ec5"
+checksum = "d3af2609c73739143b3ab886b26831ba797cd36be79811fbce312e485f5c8160"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2197,8 +2235,8 @@ dependencies = [
  "fvm_ipld_amt 0.4.0",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
- "fvm_ipld_hamt 0.4.0",
- "fvm_shared 0.4.1",
+ "fvm_ipld_hamt 0.5.0",
+ "fvm_shared 0.5.1",
  "lazy_static",
  "log",
  "multihash",
@@ -2236,6 +2274,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3394e5f9c2adb4d586519bc24bbfd659366e01e7ffa6cda676be94a62bab474"
 dependencies = [
+ "ahash",
  "anyhow",
  "cid",
  "fvm_ipld_blockstore",
@@ -2259,6 +2298,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "fvm_ipld_bitfield"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9011349297962982b8ab2663c220034525ec0f95f408c2b561d3d98867f1a803"
+dependencies = [
+ "cs_serde_bytes",
+ "fvm_ipld_encoding",
+ "serde",
+ "thiserror",
+ "unsigned-varint",
+]
+
+[[package]]
 name = "fvm_ipld_blockstore"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2266,20 +2318,6 @@ checksum = "1985eae58ec2fbf54535ce115c72a2141459fb7fb4ff7379e17bffae0e302578"
 dependencies = [
  "anyhow",
  "cid",
-]
-
-[[package]]
-name = "fvm_ipld_car"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce7ed46e948d0e83894d77dcb9b351615ef7ee15dc2a09b35fe9878d8cca5e5c"
-dependencies = [
- "cid",
- "futures",
- "fvm_shared 0.2.2",
- "integer-encoding",
- "serde",
- "thiserror",
 ]
 
 [[package]]
@@ -2355,6 +2393,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "fvm_ipld_hamt"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ac7613553b33f6456843dcc162d136dc4dc21e2d52e240c050bc23dbcdfecfc"
+dependencies = [
+ "anyhow",
+ "byteorder 1.4.3",
+ "cid",
+ "cs_serde_bytes",
+ "forest_hash_utils",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
+ "libipld-core",
+ "multihash",
+ "once_cell",
+ "serde",
+ "sha2 0.10.2",
+ "thiserror",
+]
+
+[[package]]
 name = "fvm_sdk"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2362,6 +2421,21 @@ checksum = "903fa0cda6338b8f1371a95ca698969376084effd7a7ee29eb18758c2565d356"
 dependencies = [
  "cid",
  "fvm_shared 0.2.2",
+ "lazy_static",
+ "log",
+ "num-traits",
+ "thiserror",
+]
+
+[[package]]
+name = "fvm_sdk"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee9d472c4f0ad63f91a23b2ef72d9015935a3be040fa3a0ee3a0d6c4549e394"
+dependencies = [
+ "cid",
+ "fvm_ipld_encoding",
+ "fvm_shared 0.4.1",
  "lazy_static",
  "log",
  "num-traits",
@@ -2403,6 +2477,37 @@ name = "fvm_shared"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bceae71555508197a56161d5b2a30de2b8cf9ff83528a71def2ee67169f94572"
+dependencies = [
+ "anyhow",
+ "bimap",
+ "blake2b_simd 1.0.0",
+ "byteorder 1.4.3",
+ "chrono",
+ "cid",
+ "cs_serde_bytes",
+ "data-encoding",
+ "data-encoding-macro",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding",
+ "lazy_static",
+ "log",
+ "multihash",
+ "num-bigint 0.4.3",
+ "num-derive",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "serde_repr",
+ "serde_tuple",
+ "thiserror",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "fvm_shared"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "295109128cf0ae81063f1e033e56e3aab858b93eeabe446f80beb34709955de2"
 dependencies = [
  "anyhow",
  "bimap",
@@ -2494,9 +2599,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "gloo-timers"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d12a7f4e95cfe710f1d624fb1210b7d961a5fb05c4fd942f4feab06e61f590e"
+checksum = "5fb7d06c1c8cc2a29bee7ec961009a0b2caa0793ee4900c2ffb348734ba1c8f9"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2671,9 +2776,9 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "js-sys"
-version = "0.3.56"
+version = "0.3.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
+checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2724,9 +2829,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.121"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
+checksum = "cb691a747a7ab48abc15c5b42066eaafde10dc427e3b6ee2a1cf43db04c763bd"
 
 [[package]]
 name = "libipld-core"
@@ -2934,9 +3039,9 @@ checksum = "fc076939022111618a5026d3be019fd8b366e76314538ff9a1b59ffbcbf98bcd"
 dependencies = [
  "proc-macro-crate",
  "proc-macro-error",
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
  "synstructure",
 ]
 
@@ -3038,9 +3143,9 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -3269,9 +3374,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
  "version_check",
 ]
 
@@ -3281,8 +3386,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.17",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
  "version_check",
 ]
 
@@ -3297,9 +3402,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
 dependencies = [
  "unicode-xid 0.2.2",
 ]
@@ -3324,11 +3429,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
+checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
- "proc-macro2 1.0.36",
+ "proc-macro2 1.0.37",
 ]
 
 [[package]]
@@ -3453,9 +3558,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+checksum = "fd249e82c21598a9a426a4e00dd7adc1d640b22445ec8545feef801d1a74c221"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -3465,14 +3570,13 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+checksum = "9f51245e1e62e1f1629cbfec37b5793bbabcaeb90f30e94d2ba03564687353e4"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "lazy_static",
  "num_cpus",
 ]
 
@@ -3588,9 +3692,9 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43ce8670a1a1d0fc2514a3b846dacdb65646f9bd494b6674cfacbb4ce430bd7e"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -3622,9 +3726,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.33.5"
+version = "0.33.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03627528abcc4a365554d32a9f3bbf67f7694c102cfeda792dc86a2d6057cc85"
+checksum = "7ac32d9fc97153ca55305284cb6c2dcbb84e1fc6d7ac13392cea02222f2d8741"
 dependencies = [
  "bitflags 1.3.2",
  "errno 0.2.8",
@@ -3709,9 +3813,9 @@ version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -3742,9 +3846,9 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98d0516900518c29efa217c298fa1f4e6c6ffc85ae29fd7f4ee48f176e1a9ed5"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -3763,9 +3867,9 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4076151d1a2b688e25aaf236997933c66e18b870d0369f8b248b8ab2be630d7e"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -4070,12 +4174,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.90"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
+checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.17",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
  "unicode-xid 0.2.2",
 ]
 
@@ -4085,9 +4189,9 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
  "unicode-xid 0.2.2",
 ]
 
@@ -4166,9 +4270,9 @@ version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -4301,9 +4405,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
+checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -4311,24 +4415,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
+checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
 dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb6ec270a31b1d3c7e266b999739109abce8b6c87e4b31fcfcd788b65267395"
+checksum = "6f741de44b75e14c35df886aff5f1eb73aa114fa5d4d00dcd37b5e01259bf3b2"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -4338,32 +4442,32 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
+checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
 dependencies = [
- "quote 1.0.17",
+ "quote 1.0.18",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
+checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
+checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
 
 [[package]]
 name = "wasmparser"
@@ -4373,9 +4477,9 @@ checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
 
 [[package]]
 name = "wasmtime"
-version = "0.35.2"
+version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "637f73fff13248d13882246b67a8208d466c36d7b836b783a62903cb96f11b61"
+checksum = "21ffb4705016d5ca91e18a72ed6822dab50e6d5ddd7045461b17ef19071cdef1"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -4403,9 +4507,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "0.35.2"
+version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d233418e5f560e8010fe13e60943df8be0685c68cbdf9f588dd846a727f2e4"
+checksum = "f04c810078a491b7bc4866ebe045f714d2b95e6b539e1f64009a4a7606be11de"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -4425,9 +4529,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "0.35.2"
+version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f38f25934156bb5496b3fd30be10c8ef41936330d9c936654ebf4eac02e352e"
+checksum = "61448266ea164b1ac406363cdcfac81c7c44db4d94c7a81c8620ac6c5c6cdf59"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -4445,9 +4549,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "0.35.2"
+version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7d3293e643c3b397012a579b025116e5818118a7982373551df8f8b0a4c524"
+checksum = "156b4623c6b0d4b8c24afb846c20525922f538ef464cc024abab7ea8de2109a2"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -4470,18 +4574,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "0.35.2"
+version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8b4b40b84a96da6fcd7f2460747564091b9b8dedcc7bd66c0cb741adf451de8"
+checksum = "d5dc31f811760a6c76b2672c404866fd19b75e5fb3b0075a3e377a6846490654"
 dependencies = [
  "lazy_static",
 ]
 
 [[package]]
 name = "wasmtime-runtime"
-version = "0.35.2"
+version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b60eb01e3413a54e791a397d556962876902d7481be496b4b9eb1dc68de14fce"
+checksum = "f907beaff69d4d920fa4688411ee4cc75c0f01859e424677f9e426e2ef749864"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -4504,9 +4608,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "0.35.2"
+version = "0.35.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86cd8d51aa648f2ba5a25bd11a74c08ce2b66796a5bbd5c099ab5db672a2e68f"
+checksum = "514ef0e5fd197b9609dc9eb74beba0c84d5a12b2417cbae55534633329ba4852"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -4516,9 +4620,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.56"
+version = "0.3.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
+checksum = "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4610,8 +4714,8 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eb56561c1f8f5441784ea91f52ae8b44268d920f2a59121968fec9297fa7157"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
  "synstructure",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -39,13 +39,13 @@ memmap = "0.7"
 rust-gpu-tools = { version = "0.5", default-features = false }
 storage-proofs-porep = { version = "~11.0", default-features = false }
 fr32 = { version = "~4.0", default-features = false }
-fvm = { version = "0.5.1", default-features = false }
+fvm = { version = "0.6.0", default-features = false }
 fvm_ipld_car = "0.4.0"
-fvm_shared = "0.4.1"
+fvm_shared = "0.5.1"
 fvm_ipld_blockstore = "0.1.0"
 fvm_ipld_encoding = "0.1.0"
-actors-v6 = { package = "fil_builtin_actors_bundle", version = "6.1.1" }
-actors-v7 = { package = "fil_builtin_actors_bundle", version = "7.1.1" }
+actors-v6 = { package = "fil_builtin_actors_bundle", version = "6.1.2" }
+actors-v7 = { package = "fil_builtin_actors_bundle", version = "7.1.3" }
 num-traits = "0.2.14"
 num-bigint = "0.4"
 cid = { version = "0.8.3", features = ["serde-codec"] }

--- a/rust/src/fvm/types.rs
+++ b/rust/src/fvm/types.rs
@@ -59,7 +59,7 @@ impl Default for fil_FvmMachineExecuteResponse {
         fil_FvmMachineExecuteResponse {
             error_msg: ptr::null(),
             status_code: FCPResponseStatus::FCPNoError,
-            exit_code: ExitCode::Ok as u64,
+            exit_code: ExitCode::OK.value() as u64,
             return_ptr: ptr::null(),
             return_len: 0,
             gas_used: 0,


### PR DESCRIPTION
- Basic FIP0032 support (nv16+).
- Internal changes.