### PR TITLE
fix: copy nil

### DIFF
--- a/cgo/types.go
+++ b/cgo/types.go
@@ -105,12 +105,17 @@ type FvmMachineExecuteResponseGo struct {
 }
 
 func (ptr SliceBoxedUint8) slice() []byte {
+	if ptr.ptr == nil {
+		return nil
+	}
 	return unsafe.Slice((*byte)(ptr.ptr), int(ptr.len))
 }
 
 func (ptr SliceBoxedUint8) copy() []byte {
-	if ptr.len == 0 {
+	if ptr.ptr == nil {
 		return nil
+	} else if ptr.len == 0 {
+		return []byte{}
 	}
 
 	res := make([]byte, int(ptr.len))
@@ -322,11 +327,16 @@ func (ptr *resultVoid) destroy() {
 }
 
 func (ptr SliceBoxedUint64) slice() []uint64 {
+	if ptr.ptr == nil {
+		return nil
+	}
 	return unsafe.Slice((*uint64)(unsafe.Pointer(ptr.ptr)), int(ptr.len))
 }
 
 func (ptr SliceBoxedUint64) copy() []uint64 {
-	if ptr.len == 0 {
+	if ptr.ptr == nil {
+		return nil
+	} else if ptr.len == 0 {
 		return []uint64{}
 	}
 
@@ -352,11 +362,16 @@ func (ptr *resultSliceBoxedUint64) destroy() {
 }
 
 func (ptr SliceBoxedPoStProof) slice() []PoStProof {
+	if ptr.ptr == nil {
+		return nil
+	}
 	return unsafe.Slice((*PoStProof)(unsafe.Pointer(ptr.ptr)), int(ptr.len))
 }
 
 func (ptr SliceBoxedPoStProof) copy() []PoStProofGo {
-	if ptr.len == 0 {
+	if ptr.ptr == nil {
+		return nil
+	} else if ptr.len == 0 {
 		return []PoStProofGo{}
 	}
 
@@ -408,11 +423,16 @@ func (ptr *resultGenerateWindowPoSt) destroy() {
 }
 
 func (ptr SliceBoxedSliceBoxedUint8) slice() []SliceBoxedUint8 {
+	if ptr.ptr == nil {
+		return nil
+	}
 	return unsafe.Slice((*SliceBoxedUint8)(unsafe.Pointer(ptr.ptr)), int(ptr.len))
 }
 
 func (ptr SliceBoxedSliceBoxedUint8) copyAsBytes() [][]byte {
-	if ptr.len == 0 {
+	if ptr.ptr == nil {
+		return nil
+	} else if ptr.len == 0 {
 		return [][]byte{}
 	}
 
@@ -426,7 +446,9 @@ func (ptr SliceBoxedSliceBoxedUint8) copyAsBytes() [][]byte {
 }
 
 func (ptr SliceBoxedSliceBoxedUint8) copyAsStrings() []string {
-	if ptr.len == 0 {
+	if ptr.ptr == nil {
+		return nil
+	} else if ptr.len == 0 {
 		return []string{}
 	}
 	ref := ptr.slice()
@@ -486,11 +508,16 @@ func (ptr *resultEmptySectorUpdateEncodeInto) destroy() {
 }
 
 func (ptr SliceBoxedSliceBoxedUint64) slice() []SliceBoxedUint64 {
+	if ptr.ptr == nil {
+		return nil
+	}
 	return unsafe.Slice((*SliceBoxedUint64)(unsafe.Pointer(ptr.ptr)), int(ptr.len))
 }
 
 func (ptr SliceBoxedSliceBoxedUint64) copy() [][]uint64 {
-	if ptr.len == 0 {
+	if ptr.ptr == nil {
+		return nil
+	} else if ptr.len == 0 {
 		return [][]uint64{}
 	}
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -88,9 +88,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
+checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
 
 [[package]]
 name = "anymap"
@@ -278,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "base-x"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
+checksum = "dc19a4937b4fbd3fe3379793130e42060d10627a360f2127802b10b87e7baf74"
 
 [[package]]
 name = "base64"
@@ -659,9 +659,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.10"
+version = "3.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3124f3f75ce09e22d1410043e1e24f2ecc44fad3afe4f08408f1f7663d68da2b"
+checksum = "7c167e37342afc5f33fd87bbc870cedd020d2a6dffa05d45ccd9241fbdd146db"
 dependencies = [
  "atty",
  "bitflags 1.3.2",
@@ -1343,11 +1343,11 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_account"
-version = "7.2.0"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ab1eb2a815bd10853da7bd6c8626669551a97961f5cffc825f7ba28db00080"
+checksum = "b46b4ed5f5e18da44b4981361be4d87dae1753a830c05737ec2d2bd9d46f419b"
 dependencies = [
- "fil_actors_runtime 7.2.0",
+ "fil_actors_runtime 7.2.1",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_shared 0.6.0",
@@ -1396,11 +1396,11 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_cron"
-version = "7.2.0"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54c50223e8f8c30235d8f7fa3d43d724dc675b83bdc4ac898666b8199bc9b132"
+checksum = "b018030ea343ed767aa06da132edb661d70a1b49d0ff589724b3409b48550c31"
 dependencies = [
- "fil_actors_runtime 7.2.0",
+ "fil_actors_runtime 7.2.1",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_shared 0.6.0",
@@ -1433,13 +1433,13 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_init"
-version = "7.2.0"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784dfb55c87a977c5f54f096a64083e22b276d778ae0675064b8d42927e4039b"
+checksum = "2ce0ba0af37891135e640794d70839ec2f57fae1cc70240391721839b640aa72"
 dependencies = [
  "anyhow",
  "cid",
- "fil_actors_runtime 7.2.0",
+ "fil_actors_runtime 7.2.1",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_ipld_hamt 0.4.0",
@@ -1474,14 +1474,14 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_market"
-version = "7.2.0"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9749daecda9c9307e6dfc0c505ce44dce526d62024135e30ead1c4af5a4ddcca"
+checksum = "0222db792ed187d37f7da6f6019eea538fd927c9ede4e2c755d743934715b466"
 dependencies = [
  "ahash",
  "anyhow",
  "cid",
- "fil_actors_runtime 7.2.0",
+ "fil_actors_runtime 7.2.1",
  "fvm_ipld_bitfield",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
@@ -1521,14 +1521,14 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_miner"
-version = "7.2.0"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "893c7afc0308e5e190b5b2eb25e2cc95393dfcbfc9573a37506dc8c9b2c159b3"
+checksum = "322a4a3f1c8448c8480ac75b7859996a0900ccacdaa2a34bacacdbdf21d796e4"
 dependencies = [
  "anyhow",
  "byteorder 1.4.3",
  "cid",
- "fil_actors_runtime 7.2.0",
+ "fil_actors_runtime 7.2.1",
  "fvm_ipld_amt",
  "fvm_ipld_bitfield",
  "fvm_ipld_blockstore",
@@ -1567,13 +1567,13 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_multisig"
-version = "7.2.0"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c329ac34545634df336fea1faf518561061bb3c38dcec7374f97f3af23ce8ba"
+checksum = "16ffc143f5cc20b8a6d91c2801feb51bfc7fe5f31bf278543a232aa644a697e6"
 dependencies = [
  "anyhow",
  "cid",
- "fil_actors_runtime 7.2.0",
+ "fil_actors_runtime 7.2.1",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_ipld_hamt 0.4.0",
@@ -1606,13 +1606,13 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_paych"
-version = "7.2.0"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae7d68c5632b0135759016fa39844285244cd4d252e7bf4f3432d37669176f61"
+checksum = "e655a05234a1fbce95f906eb01143ea38fb5ec2e68592073521b9480960f904a"
 dependencies = [
  "anyhow",
  "cid",
- "fil_actors_runtime 7.2.0",
+ "fil_actors_runtime 7.2.1",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_shared 0.6.0",
@@ -1647,13 +1647,13 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_power"
-version = "7.2.0"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "371226ea6dfc7cb7ca6db8210d3d2f9fc6b820d488ef035d8514e0de8b5df1ac"
+checksum = "8aff153971f2e2237969a9a601280c8cba91de41d3ce3cd396bd25ba3af502d0"
 dependencies = [
  "anyhow",
  "cid",
- "fil_actors_runtime 7.2.0",
+ "fil_actors_runtime 7.2.1",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_ipld_hamt 0.4.0",
@@ -1688,11 +1688,11 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_reward"
-version = "7.2.0"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "828e313a96da3aa50dc6e1bbf5f54cc657d6b303bfe90302cc53270e2e933180"
+checksum = "69faa6bee076f0ad829f2b42016640f7772f739dd36f3c975d89f680bdb2ceec"
 dependencies = [
- "fil_actors_runtime 7.2.0",
+ "fil_actors_runtime 7.2.1",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_shared 0.6.0",
@@ -1721,11 +1721,11 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_system"
-version = "7.2.0"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ae84eae1d9e9bc5596565f330e7d1cc704b6020b33788b2e32feac788d41b5"
+checksum = "3b81b4e98b07428bba01969632d5c996033728386b91831d496a62844acad451"
 dependencies = [
- "fil_actors_runtime 7.2.0",
+ "fil_actors_runtime 7.2.1",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_shared 0.6.0",
@@ -1755,13 +1755,13 @@ dependencies = [
 
 [[package]]
 name = "fil_actor_verifreg"
-version = "7.2.0"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "184108b428502135349eae651aff2aa4a9fecffce10aa6003b1c5179f05c9c71"
+checksum = "14383b52216fdebaadc68b164c929e551f263799c3e2a08e228f9259cd19329c"
 dependencies = [
  "anyhow",
  "cid",
- "fil_actors_runtime 7.2.0",
+ "fil_actors_runtime 7.2.1",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_ipld_hamt 0.4.0",
@@ -1804,9 +1804,9 @@ dependencies = [
 
 [[package]]
 name = "fil_actors_runtime"
-version = "7.2.0"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b697964b0e4db5048b76036bd2d0e08668ba49d61c9e22c581e766f0690e46"
+checksum = "deb7ae005ed35034fe64b95f22b9ab0c31166a7131f838b633d461f91d0431e2"
 dependencies = [
  "anyhow",
  "base64",
@@ -1860,19 +1860,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6f790de3c8ef02e5f7be8d31d3e6fcf5217a2f45190d5fd9bef27171be2c99"
 dependencies = [
  "cid",
- "fil_actor_account 7.2.0",
+ "fil_actor_account 7.2.1",
  "fil_actor_bundler",
- "fil_actor_cron 7.2.0",
- "fil_actor_init 7.2.0",
- "fil_actor_market 7.2.0",
- "fil_actor_miner 7.2.0",
- "fil_actor_multisig 7.2.0",
- "fil_actor_paych 7.2.0",
- "fil_actor_power 7.2.0",
- "fil_actor_reward 7.2.0",
- "fil_actor_system 7.2.0",
- "fil_actor_verifreg 7.2.0",
- "fil_actors_runtime 7.2.0",
+ "fil_actor_cron 7.2.1",
+ "fil_actor_init 7.2.1",
+ "fil_actor_market 7.2.1",
+ "fil_actor_miner 7.2.1",
+ "fil_actor_multisig 7.2.1",
+ "fil_actor_paych 7.2.1",
+ "fil_actor_power 7.2.1",
+ "fil_actor_reward 7.2.1",
+ "fil_actor_system 7.2.1",
+ "fil_actor_verifreg 7.2.1",
+ "fil_actors_runtime 7.2.1",
 ]
 
 [[package]]
@@ -2478,9 +2478,9 @@ dependencies = [
 
 [[package]]
 name = "ghost"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5bcf1bbeab73aa4cf2fde60a846858dc036163c7c33bec309f8d17de785479"
+checksum = "76c813ffb63e8fd3df6f1ac3cc1ea392c7612ac2de4d0b44dcbfe03e5c4bf94a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3094,9 +3094,9 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -3238,9 +3238,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "pin-utils"


### PR DESCRIPTION
When the slice pointer is nil, the length is undefined (because the underlying "option" is none). So we return `nil` in this case instead of trying to copy.