### PR TITLE
fix: allow zero-length slice allocs

### DIFF
--- a/cgo/helpers.go
+++ b/cgo/helpers.go
@@ -57,16 +57,13 @@ func AsSliceRefUint64(goBytes []uint64) SliceRefUint64 {
 	}
 }
 
-func AllocSliceBoxedUint8(goBytes []byte) (SliceBoxedUint8, error) {
+func AllocSliceBoxedUint8(goBytes []byte) SliceBoxedUint8 {
 	len := len(goBytes)
-	if len == 0 {
-		return SliceBoxedUint8{}, errors.New("SlicedBoxedUint8 must not be empty")
-	}
 
 	ptr := C.alloc_boxed_slice(C.size_t(len))
 	copy(ptr.slice(), goBytes)
 
-	return ptr, nil
+	return ptr
 }
 
 func AsSliceRefUint(goSlice []uint) SliceRefUint {
@@ -219,7 +216,7 @@ func AsByteArray32(goSlice []byte) ByteArray32 {
 // CheckErr returns `nil` if the `code` indicates success and an error otherwise.
 func CheckErr(resp result) error {
 	if resp == nil {
-		return errors.New("failed")
+		return errors.New("nil result from Filecoin FFI")
 	}
 	if resp.statusCode() == FCPResponseStatusNoError {
 		return nil
@@ -238,23 +235,14 @@ func NewAggregationInputs(commR ByteArray32, commD ByteArray32, sectorId uint64,
 	}
 }
 
-func NewPrivateReplicaInfo(pp RegisteredPoStProof, cacheDirPath string, commR ByteArray32, replicaPath string, sectorId uint64) (PrivateReplicaInfo, error) {
-	cacheDirPathBytes, err := AllocSliceBoxedUint8([]byte(cacheDirPath))
-	if err != nil {
-		return PrivateReplicaInfo{}, err
-	}
-	replicaPathBytes, err := AllocSliceBoxedUint8([]byte(replicaPath))
-	if err != nil {
-		return PrivateReplicaInfo{}, err
-	}
-
+func NewPrivateReplicaInfo(pp RegisteredPoStProof, cacheDirPath string, commR ByteArray32, replicaPath string, sectorId uint64) PrivateReplicaInfo {
 	return PrivateReplicaInfo{
 		registered_proof: pp,
-		cache_dir_path:   cacheDirPathBytes,
-		replica_path:     replicaPathBytes,
+		cache_dir_path:   AllocSliceBoxedUint8([]byte(cacheDirPath)),
+		replica_path:     AllocSliceBoxedUint8([]byte(replicaPath)),
 		sector_id:        C.uint64_t(sectorId),
 		comm_r:           commR,
-	}, nil
+	}
 }
 
 func NewPublicReplicaInfo(pp RegisteredPoStProof, commR ByteArray32, sectorId uint64) PublicReplicaInfo {
@@ -265,15 +253,11 @@ func NewPublicReplicaInfo(pp RegisteredPoStProof, commR ByteArray32, sectorId ui
 	}
 }
 
-func NewPoStProof(pp RegisteredPoStProof, proof []byte) (PoStProof, error) {
-	proofBytes, err := AllocSliceBoxedUint8(proof)
-	if err != nil {
-		return PoStProof{}, nil
-	}
+func NewPoStProof(pp RegisteredPoStProof, proof []byte) PoStProof {
 	return PoStProof{
 		registered_proof: pp,
-		proof:            proofBytes,
-	}, nil
+		proof:            AllocSliceBoxedUint8(proof),
+	}
 }
 
 func NewPublicPieceInfo(numBytes uint64, commP ByteArray32) PublicPieceInfo {
@@ -283,13 +267,9 @@ func NewPublicPieceInfo(numBytes uint64, commP ByteArray32) PublicPieceInfo {
 	}
 }
 
-func NewPartitionSnarkProof(pp RegisteredPoStProof, proof []byte) (PartitionSnarkProof, error) {
-	proofBytes, err := AllocSliceBoxedUint8(proof)
-	if err != nil {
-		return PartitionSnarkProof{}, err
-	}
+func NewPartitionSnarkProof(pp RegisteredPoStProof, proof []byte) PartitionSnarkProof {
 	return PartitionSnarkProof{
 		registered_proof: pp,
-		proof:            proofBytes,
-	}, nil
+		proof:            AllocSliceBoxedUint8(proof),
+	}
 }

--- a/cgo/helpers_test.go
+++ b/cgo/helpers_test.go
@@ -60,8 +60,7 @@ func TestByteArray32(t *testing.T) {
 func TestAllocSliceBoxedUint8(t *testing.T) {
 	foo := []byte("hello world")
 
-	boxed, err := AllocSliceBoxedUint8(foo)
-	assert.Nil(t, err)
+	boxed := AllocSliceBoxedUint8(foo)
 	defer boxed.Destroy()
 	assert.Equal(t, boxed.slice(), foo)
 }

--- a/distributed.go
+++ b/distributed.go
@@ -84,10 +84,7 @@ func GenerateWinningPoStWithVanilla(
 	if err != nil {
 		return nil, err
 	}
-	fproofs, cleanup, err := toVanillaProofs(proofs)
-	if err != nil {
-		return nil, err
-	}
+	fproofs, cleanup := toVanillaProofs(proofs)
 	defer cleanup()
 
 	randomnessBytes := cgo.AsByteArray32(randomness)
@@ -119,10 +116,7 @@ func GenerateWindowPoStWithVanilla(
 	if err != nil {
 		return nil, err
 	}
-	fproofs, cleaner, err := toVanillaProofs(proofs)
-	if err != nil {
-		return nil, err
-	}
+	fproofs, cleaner := toVanillaProofs(proofs)
 	defer cleaner()
 
 	randomnessBytes := cgo.AsByteArray32(randomness)
@@ -157,10 +151,7 @@ func GenerateSinglePartitionWindowPoStWithVanilla(
 	if err != nil {
 		return nil, err
 	}
-	fproofs, cleaner, err := toVanillaProofs(proofs)
-	if err != nil {
-		return nil, err
-	}
+	fproofs, cleaner := toVanillaProofs(proofs)
 	defer cleaner()
 
 	randomnessBytes := cgo.AsByteArray32(randomness)
@@ -197,10 +188,7 @@ func MergeWindowPoStPartitionProofs(
 		return nil, err
 	}
 
-	fproofs, cleaner, err := toPartitionProofs(partitionProofs)
-	if err != nil {
-		return nil, err
-	}
+	fproofs, cleaner := toPartitionProofs(partitionProofs)
 	defer cleaner()
 
 	resp, err := cgo.MergeWindowPoStPartitionProofs(pp, cgo.AsSliceRefSliceBoxedUint8(fproofs))
@@ -221,15 +209,11 @@ func MergeWindowPoStPartitionProofs(
 	return &out, nil
 }
 
-func toPartitionProofs(src []PartitionProof) ([]cgo.SliceBoxedUint8, func(), error) {
+func toPartitionProofs(src []PartitionProof) ([]cgo.SliceBoxedUint8, func()) {
 	out := make([]cgo.SliceBoxedUint8, len(src))
 	for idx := range out {
-		psp, err := cgo.AllocSliceBoxedUint8(src[idx].ProofBytes)
-		if err != nil {
-			return nil, makeCleanerSBU(out, idx), err
-		}
-		out[idx] = psp
+		out[idx] = cgo.AllocSliceBoxedUint8(src[idx].ProofBytes)
 	}
 
-	return out, makeCleanerSBU(out, len(src)), nil
+	return out, makeCleanerSBU(out, len(src))
 }

--- a/sector_update.go
+++ b/sector_update.go
@@ -219,11 +219,8 @@ func (FunctionsSectorUpdate) VerifyVanillaProofs(
 		return false, xerrors.Errorf("transorming new CommD: %w", err)
 	}
 
-	proofs, cleanup, err := toUpdateVanillaProofs(vanillaProofs)
+	proofs, cleanup := toUpdateVanillaProofs(vanillaProofs)
 	defer cleanup()
-	if err != nil {
-		return false, nil
-	}
 
 	return cgo.VerifyEmptySectorUpdatePartitionProofs(
 		up,
@@ -259,11 +256,8 @@ func (FunctionsSectorUpdate) GenerateUpdateProofWithVanilla(
 		return nil, xerrors.Errorf("transorming new CommD: %w", err)
 	}
 
-	proofs, cleanup, err := toUpdateVanillaProofs(vanillaProofs)
+	proofs, cleanup := toUpdateVanillaProofs(vanillaProofs)
 	defer cleanup()
-	if err != nil {
-		return nil, err
-	}
 
 	return cgo.GenerateEmptySectorUpdateProofWithVanilla(
 		up,
@@ -274,25 +268,17 @@ func (FunctionsSectorUpdate) GenerateUpdateProofWithVanilla(
 	)
 }
 
-func toUpdateVanillaProofs(src [][]byte) ([]cgo.SliceBoxedUint8, func(), error) {
+func toUpdateVanillaProofs(src [][]byte) ([]cgo.SliceBoxedUint8, func()) {
 	out := make([]cgo.SliceBoxedUint8, len(src))
 	for idx := range out {
-		b, err := cgo.AllocSliceBoxedUint8(src[idx])
-		if err != nil {
-			// only deallocate allocated ones
-			for i := 0; idx < i; i++ {
-				out[i].Destroy()
-			}
-			return nil, nil, err
-		}
-		out[idx] = b
+		out[idx] = cgo.AllocSliceBoxedUint8(src[idx])
 	}
 
 	return out, func() {
 		for idx := range out {
 			out[idx].Destroy()
 		}
-	}, nil
+	}
 }
 
 func (FunctionsSectorUpdate) GenerateUpdateProof(


### PR DESCRIPTION
They're fine. We can't represent them as null, but rust will internally represent them as 0x1. We could just _assume_ that, but it's safer to call into rust and let it handle this case.

If we don't do this, some of the lotus tests fail.