### PR TITLE
chore: CI: use large macOS machine for publishing the FFI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,7 @@ jobs:
     macos:
       xcode: "12.5.0"
     working_directory: ~/crate
+    resource_class: large
     steps:
       - configure_environment_variables:
           linux: false


### PR DESCRIPTION
Waiting for CI can be annoying, hence I thought it makes sense to use large machines where possible. That job is now about a third faster (20 vs 30mins).