### PR TITLE
build: avoid updating the lockfile when building

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,7 +231,7 @@ commands:
             RELEASE_NAME="${CIRCLE_PROJECT_REPONAME}-$(uname)-standard"
 
             # Note: the blst dependency uses the portable configuration for maximum compatibility
-            ./scripts/build-release.sh filcrypto $(cat ./rust-toolchain) build --verbose --locked --no-default-features --features multicore-sdr,opencl,blst-portable
+            ./scripts/build-release.sh filcrypto $(cat ./rust-toolchain) build --verbose --no-default-features --features multicore-sdr,opencl,blst-portable
             ./scripts/package-release.sh $TARBALL_PATH
             ./scripts/publish-release.sh $TARBALL_PATH $RELEASE_NAME
       - run:
@@ -242,7 +242,7 @@ commands:
             TARBALL_PATH="/tmp/${CIRCLE_PROJECT_REPONAME}-$(uname)-optimized.tar.gz"
             RUSTFLAGS="-C target-feature=$(cat rustc-target-features-optimized.json | jq -r '.[].rustc_target_feature' | tr '\n' ',')"
 
-            ./scripts/build-release.sh filcrypto $(cat ./rust-toolchain) build --verbose --locked --no-default-features --features multicore-sdr,opencl
+            ./scripts/build-release.sh filcrypto $(cat ./rust-toolchain) build --verbose --no-default-features --features multicore-sdr,opencl
             ./scripts/package-release.sh $TARBALL_PATH
 
   publish_darwin_release:
@@ -256,7 +256,7 @@ commands:
             TARBALL_PATH="/tmp/${RELEASE_NAME}.tar.gz"
 
             # Note: the blst dependency uses the portable configuration for maximum compatibility
-            ./scripts/build-release.sh filcrypto $(cat rust-toolchain) lipo --targets x86_64-apple-darwin,aarch64-apple-darwin --verbose --locked --no-default-features --features multicore-sdr,opencl,blst-portable
+            ./scripts/build-release.sh filcrypto $(cat rust-toolchain) lipo --targets x86_64-apple-darwin,aarch64-apple-darwin --verbose --no-default-features --features multicore-sdr,opencl,blst-portable
             ./scripts/package-release.sh $TARBALL_PATH
             ./scripts/publish-release.sh $TARBALL_PATH $RELEASE_NAME
   configure_environment_variables:

--- a/rust/scripts/build-release.sh
+++ b/rust/scripts/build-release.sh
@@ -40,7 +40,7 @@ main() {
 
     RUSTFLAGS="${__rust_flags}" \
         cargo +$2 $3 \
-        --release ${@:4} 2>&1 | tee ${__build_output_log_tmp}
+        --release --locked ${@:4} 2>&1 | tee ${__build_output_log_tmp}
 
     # parse build output for linker flags
     #
@@ -66,7 +66,7 @@ main() {
 
     # generate filcrypto.h
     RUSTFLAGS="${__rust_flags}" HEADER_DIR="." \
-        cargo test build_headers --features c-headers 
+        cargo test --locked build_headers --features c-headers
 
     # generate pkg-config
     #

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -8,7 +8,7 @@ pub mod proofs;
 pub mod util;
 
 // Generates the headers.
-// Run `HEADER_DIR=<dir> cargo test build_headers --features c-headers` to build
+// Run `HEADER_DIR=<dir> cargo test --locked build_headers --features c-headers` to build
 #[safer_ffi::cfg_headers]
 #[test]
 fn build_headers() -> std::io::Result<()> {


### PR DESCRIPTION
This also removes the macos specific and undocumented "build.sh" script.