### PR TITLE
chore: update proofs for v16 release

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1631,9 +1631,9 @@ dependencies = [
 
 [[package]]
 name = "filecoin-hashers"
-version = "6.1.0"
+version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5459189a6cd4eff6e425be7295e5e083dee3c9b1508291b955869f3b6b24f0cd"
+checksum = "31b13b919031ffcf145e4a03f1d0e0ec52d9df52ea2ea77fa20141403b07d0cd"
 dependencies = [
  "anyhow",
  "bellperson",
@@ -1651,9 +1651,9 @@ dependencies = [
 
 [[package]]
 name = "filecoin-proofs"
-version = "11.1.0"
+version = "11.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2993a1de1b2cff6c7212da3a4fd53ab91936c4ab6bfd00b09a19a79dfbf6d47a"
+checksum = "e956a3235e86b88bfb3ffedf700ab1ff17145ac8d3936cd57d8bdef664d6a5d0"
 dependencies = [
  "anyhow",
  "bellperson",
@@ -1763,9 +1763,9 @@ dependencies = [
 
 [[package]]
 name = "fr32"
-version = "4.1.0"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355338c73ad12186e0f99c563f2e5666f837d5c04edfd4302e7b89b356b8c86e"
+checksum = "80932cb34221f04d5a79245d1d9d3aff991abc0ae7cc49100694b6e478bb8a19"
 dependencies = [
  "anyhow",
  "bellperson",
@@ -3639,9 +3639,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-proofs-core"
-version = "11.1.0"
+version = "11.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b46f91043e71be271bbe34d4d22916e2ba55a0d128d5a18bd4dcfff44f4bc3ec"
+checksum = "b3bff040dcf0834917f69db391f4fb5e72d43c7d5cb90b5bbd4ae9d6b744a894"
 dependencies = [
  "aes",
  "anyhow",
@@ -3680,9 +3680,9 @@ dependencies = [
 
 [[package]]
 name = "storage-proofs-porep"
-version = "11.1.0"
+version = "11.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343b7faebb6376e20a44f91a34ee3e9c1533069434b6a1a05ed1c7b95c53c1d3"
+checksum = "395dd7a7802d002def493315e0ec8e6bda274c7a31406c5104dfc1a19fbfc7b3"
 dependencies = [
  "anyhow",
  "bellperson",
@@ -3723,9 +3723,9 @@ dependencies = [
 
 [[package]]
 name = "storage-proofs-post"
-version = "11.1.0"
+version = "11.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "741f7f1bcae57dcc449dd8189eb6984f3332b73d214ab7945a5c3f6c9a05a8ad"
+checksum = "e868618ef3b6968928924a38410e816752799ce26242799497bd1461b6228a22"
 dependencies = [
  "anyhow",
  "bellperson",
@@ -3752,9 +3752,9 @@ dependencies = [
 
 [[package]]
 name = "storage-proofs-update"
-version = "11.1.0"
+version = "11.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "734fae4ec0920273ba044ffad9d55c6214f15dffd914d35f15540ec15632a91b"
+checksum = "0e69871eb1a083fa5a3db211981d5959f549708bb578b0e0e9961467384d31d1"
 dependencies = [
  "anyhow",
  "bellperson",


### PR DESCRIPTION
This updates the proofs crates to lock the correct dependency versions.