### PR TITLE
avoid lotus fvm crash

### DIFF
--- a/cgo/blockstore.go
+++ b/cgo/blockstore.go
@@ -11,6 +11,7 @@ import (
 /*
 #include <stdint.h>
 typedef const uint8_t* buf_t;
+extern void rust_vec_extend_func(const uint8_t* data, int32_t len, void* vec);
 */
 import "C"
 
@@ -24,7 +25,7 @@ func toCid(k C.buf_t, kLen C.int32_t) cid.Cid {
 }
 
 //export cgo_blockstore_get
-func cgo_blockstore_get(handle C.uint64_t, k C.buf_t, kLen C.int32_t, block **C.uint8_t, size *C.int32_t) (res C.int32_t) {
+func cgo_blockstore_get(handle C.uint64_t, k C.buf_t, kLen C.int32_t, v* C.void) (res C.int32_t) {
 	defer func() {
 		if rerr := recover(); rerr != nil {
 			logPanic(rerr)
@@ -39,8 +40,7 @@ func cgo_blockstore_get(handle C.uint64_t, k C.buf_t, kLen C.int32_t, block **C.
 	}
 
 	err := externs.View(ctx, c, func(data []byte) error {
-		*block = (C.buf_t)(C.CBytes(data))
-		*size = C.int32_t(len(data))
+		C.rust_vec_extend_func((*C.uint8_t)(&data[0]), C.int32_t(len(data)), unsafe.Pointer(v))
 		return nil
 	})
 

--- a/rust/src/fvm/cgo/externs.rs
+++ b/rust/src/fvm/cgo/externs.rs
@@ -5,8 +5,7 @@ extern "C" {
         store: u64,
         k: *const u8,
         k_len: i32,
-        block: *mut *mut u8,
-        size: *mut i32,
+        v: *mut libc::c_void,
     ) -> i32;
 
     pub fn cgo_blockstore_put(


### PR DESCRIPTION
Hi, every one, currently CgoBlockstore::get() return a rust vector who use a buffer that allocated by CGO 's  C.Bytes(), and it will crash when rust drop that buffer.

When build with rust's default allocator,  lotus run as expected, but when  use mimalloc_rust as rust global allocator, lotus will crash at some fvm relative functions.

I try to fix:
1. avoid rust vec to use memory allocated by CGO C.Bytes
2. add callback to cgo_blockstore_get to avoid memory copy

now lotus  work correctly when use mimalloc_rust as rust's global allocator.
