### PR TITLE
lotus may crash: avoid rust vec use memory allocated by CGO's C.Bytes()

### DIFF
--- a/cgo/blockstore.go
+++ b/cgo/blockstore.go
@@ -11,6 +11,7 @@ import (
 /*
 #include <stdint.h>
 typedef const uint8_t* buf_t;
+extern void rust_vec_extend_func(const uint8_t* data, int32_t len, void* vec);
 */
 import "C"
 
@@ -24,7 +25,7 @@ func toCid(k C.buf_t, kLen C.int32_t) cid.Cid {
 }
 
 //export cgo_blockstore_get
-func cgo_blockstore_get(handle C.uint64_t, k C.buf_t, kLen C.int32_t, block **C.uint8_t, size *C.int32_t) (res C.int32_t) {
+func cgo_blockstore_get(handle C.uint64_t, k C.buf_t, kLen C.int32_t, v* C.void) (res C.int32_t) {
 	defer func() {
 		if rerr := recover(); rerr != nil {
 			logPanic(rerr)
@@ -39,8 +40,7 @@ func cgo_blockstore_get(handle C.uint64_t, k C.buf_t, kLen C.int32_t, block **C.
 	}
 
 	err := externs.View(ctx, c, func(data []byte) error {
-		*block = (C.buf_t)(C.CBytes(data))
-		*size = C.int32_t(len(data))
+		C.rust_vec_extend_func((*C.uint8_t)(&data[0]), C.int32_t(len(data)), unsafe.Pointer(v))
 		return nil
 	})
 

--- a/rust/src/fvm/blockstore/cgo.rs
+++ b/rust/src/fvm/blockstore/cgo.rs
@@ -1,4 +1,4 @@
-use std::ptr;
+//use std::ptr;
 
 use anyhow::{anyhow, Result};
 use cid::Cid;
@@ -7,11 +7,23 @@ use fvm_shared::MAX_CID_LEN;
 
 use super::super::cgo::*;
 
+// for ffi_export marco
+use safer_ffi::prelude::*;
+
 /// The maximum amount of data to buffer in a batch before writing it to the underlying blockstore.
 const MAX_BUF_SIZE: usize = 4 << 20; // 4MiB
 /// The maximum number of blocks to buffer in a batch before before writing it to the underlying
 /// blockstore.
 const MAX_BLOCK_BATCH: usize = 1024;
+
+#[ffi_export]
+pub fn rust_vec_extend_func(d: *const u8, size: i32, vptr: *mut libc::c_void) {
+   unsafe {
+       let s = std::slice::from_raw_parts(d, size as usize);
+       let v = vptr as *mut Vec<u8>;
+       (*v).extend_from_slice(s);
+   }
+}
 
 pub struct CgoBlockstore {
     handle: u64,
@@ -50,16 +62,16 @@ impl Blockstore for CgoBlockstore {
     fn get(&self, k: &Cid) -> Result<Option<Vec<u8>>> {
         let k_bytes = k.to_bytes();
         unsafe {
-            let mut buf: *mut u8 = ptr::null_mut();
-            let mut size: i32 = 0;
+            let mut v = Vec::new();
+            let vptr: *mut Vec<u8>  = &mut v;
+            let vptr = vptr as *mut libc::c_void;
             match cgo_blockstore_get(
                 self.handle,
                 k_bytes.as_ptr(),
                 k_bytes.len() as i32,
-                &mut buf,
-                &mut size,
+                vptr,
             ) {
-                0 => Ok(Some(Vec::from_raw_parts(buf, size as usize, size as usize))),
+                0 => Ok(Some(v)),
                 r @ 1.. => panic!("invalid return value from get: {}", r),
                 x if x == FvmError::InvalidHandle as i32 => {
                     panic!("blockstore {} not registered", self.handle)

--- a/rust/src/fvm/cgo/externs.rs
+++ b/rust/src/fvm/cgo/externs.rs
@@ -5,8 +5,7 @@ extern "C" {
         store: u64,
         k: *const u8,
         k_len: i32,
-        block: *mut *mut u8,
-        size: *mut i32,
+        v: *mut libc::c_void,
     ) -> i32;
 
     pub fn cgo_blockstore_put(


### PR DESCRIPTION
Hi, every one, currently CgoBlockstore::get() return a rust vector who use a buffer that allocated by CGO 's C.Bytes(), and it will crash when rust drop that buffer.

When build with rust's default allocator, lotus run as expected, but when use mimalloc_rust as rust global allocator, lotus will crash at some fvm relative functions.

I try to fix:

avoid rust vec to use memory allocated by CGO C.Bytes
add callback to cgo_blockstore_get to avoid memory copy
now lotus work correctly when use mimalloc_rust as rust's global allocator.