### PR TITLE
FVM: always create debug FVMs with tracing enabled

### DIFF
--- a/fvm.go
+++ b/fvm.go
@@ -83,7 +83,7 @@ func CreateFVM(opts *FVMOpts) (*FVM, error) {
 			uint64(opts.NetworkVersion),
 			cgo.AsSliceRefUint8(opts.StateBase.Bytes()),
 			cgo.AsSliceRefUint8(opts.ActorRedirect.Bytes()),
-			opts.Tracing,
+			true,
 			exHandle, exHandle,
 		)
 	}


### PR DESCRIPTION
As in the title.
