### PR TITLE
chore: use auth_header when trying to download release tarball

### DIFF
--- a/install-filcrypto
+++ b/install-filcrypto
@@ -123,7 +123,7 @@ download_release_tarball() {
         -w "%{url_effective}" \
         "${__release_url}")
 
-    if ! curl --retry 3 --output "${__tar_path}" "${__asset_url}"; then
+    if ! curl "${auth_header[@]}" --retry 3 --output "${__tar_path}" "${__asset_url}"; then
         (>&2 echo "[download_release_tarball] failed to download release asset (tag URL: ${__release_tag_url}, asset URL: ${__asset_url})")
         return 1
     fi


### PR DESCRIPTION
@rvagg noticed this call getting rate limited:
```
++ curl --retry 3 --location https://api.github.com/repos/filecoin-project/filecoin-ffi/releases/tags/5d00bb4365a97890
++ echo '{"message":"API rate limit exceeded for 208.83.5.75. (But here'\''s the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)","documentation_url":"https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}'
```

The error message suggests using an authenticated call might help with this.