### PR TITLE
Fix build error and remove extra build step for build_and_test_linux_cgo_bindings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,7 @@ jobs:
       - restore_parameter_cache
       - obtain_filecoin_parameters
       - save_parameter_cache
+      - run: cd rust && rustup target add wasm32-unknown-unknown
       - run_tests:
           run_leak_detector: << parameters.run_leak_detector >>
 
@@ -166,13 +167,6 @@ workflows:
       - go_lint
       - build_and_test_linux_cgo_bindings:
           run_leak_detector: false
-      - build_and_test_linux_cgo_bindings:
-          filters:
-            branches:
-              ignore:
-                - master
-          run_leak_detector: false
-
       - publish_linux_staticlib
       - build_darwin_cgo_bindings
       - publish_darwin_staticlib
@@ -291,9 +285,8 @@ commands:
       - run: |
           DIR=$(pwd)
           cd $(mktemp -d)
-          GOPATH=/tmp GO111MODULE=off go get github.com/filecoin-project/go-paramfetch/paramfetch
-          GOPATH=/tmp GO111MODULE=off go build -o go-paramfetch github.com/filecoin-project/go-paramfetch/paramfetch
-          ./go-paramfetch 2048 "${DIR}/parameters.json" "${DIR}/srs-inner-product.json"
+          go install github.com/filecoin-project/go-paramfetch/paramfetch@latest
+          $GOPATH/bin/paramfetch 2048 "${DIR}/parameters.json" "${DIR}/srs-inner-product.json"
 
   build_project:
     steps:


### PR DESCRIPTION
- Remove extra build step for build_and_test_linux_cgo_bindings

- Fix build failure in circleci/config.yml to use "go install" to get
paramfetch and install in default GOPATH.

- Add cargo_fetch as requirement to build_and_test_linux_cgo_bindings to
 fix intermittent build failure.

- Explicitly install wasm32-unknown-unknown for job build_and_test_linux_cgo_bindings in case that target has not been previously cached by a prior job. 