### PR TITLE
Update CircleCI Xcode image to fix MacOS Darwin Build, and add status badge to readme

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
 
   build_darwin_cgo_bindings:
     macos:
-      xcode: "12.5.0"
+      xcode: "12.5.1"
     working_directory: ~/go/src/github.com/filecoin-project/filecoin-ffi
     resource_class: large
     steps:
@@ -76,7 +76,7 @@ jobs:
       - publish_release
   publish_darwin_staticlib:
     macos:
-      xcode: "12.5.0"
+      xcode: "12.5.1"
     working_directory: ~/crate
     resource_class: large
     steps:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status][circleci-image]][circleci-link]
+
 # Filecoin FFI
 
 > C and CGO bindings for Filecoin's Rust libraries
@@ -99,3 +101,6 @@ Run it like so:
 MIT or Apache 2.0
 
 [1]: https://github.com/filecoin-project/rust-filecoin-proofs-api/commit/61fde0e581cc38abc4e13dbe96145c9ad2f1f0f5
+
+[circleci-image]: https://circleci.com/gh/filecoin-project/filecoin-ffi.svg?branch=master&style=shield
+[circleci-link]: https://app.circleci.com/pipelines/github/filecoin-project/filecoin-ffi?branch=master


### PR DESCRIPTION
Update Xcode docker image for CircleCI and add test badge

 - Update to patched CircleCI MacOS Docker image to fix Darwin build

 - Add CircleCI status badge and link to project README to link to build and test results