### PR TITLE
multifvm

### DIFF
--- a/cgo/fvm.go
+++ b/cgo/fvm.go
@@ -8,10 +8,11 @@ package cgo
 */
 import "C"
 
-func CreateFvmMachine(fvmVersion FvmRegisteredVersion, chainEpoch, baseFeeHi, baseFeeLo, baseCircSupplyHi, baseCircSupplyLo, networkVersion uint64, stateRoot SliceRefUint8, manifestCid SliceRefUint8, tracing bool, blockstoreId, externsId uint64) (*FvmMachine, error) {
+func CreateFvmMachine(fvmVersion FvmRegisteredVersion, chainEpoch, chainTimestamp, baseFeeHi, baseFeeLo, baseCircSupplyHi, baseCircSupplyLo, networkVersion uint64, stateRoot SliceRefUint8, manifestCid SliceRefUint8, tracing bool, blockstoreId, externsId uint64) (*FvmMachine, error) {
 	resp := C.create_fvm_machine(
 		fvmVersion,
 		C.uint64_t(chainEpoch),
+		C.uint64_t(chainTimestamp),
 		C.uint64_t(baseFeeHi),
 		C.uint64_t(baseFeeLo),
 		C.uint64_t(baseCircSupplyHi),
@@ -35,10 +36,11 @@ func CreateFvmMachine(fvmVersion FvmRegisteredVersion, chainEpoch, baseFeeHi, ba
 	return executor, nil
 }
 
-func CreateFvmDebugMachine(fvmVersion FvmRegisteredVersion, chainEpoch, baseFeeHi, baseFeeLo, baseCircSupplyHi, baseCircSupplyLo, networkVersion uint64, stateRoot SliceRefUint8, actorRedirect SliceRefUint8, tracing bool, blockstoreId, externsId uint64) (*FvmMachine, error) {
+func CreateFvmDebugMachine(fvmVersion FvmRegisteredVersion, chainEpoch, chainTimestamp, baseFeeHi, baseFeeLo, baseCircSupplyHi, baseCircSupplyLo, networkVersion uint64, stateRoot SliceRefUint8, actorRedirect SliceRefUint8, tracing bool, blockstoreId, externsId uint64) (*FvmMachine, error) {
 	resp := C.create_fvm_debug_machine(
 		fvmVersion,
 		C.uint64_t(chainEpoch),
+		C.uint64_t(chainTimestamp),
 		C.uint64_t(baseFeeHi),
 		C.uint64_t(baseFeeLo),
 		C.uint64_t(baseCircSupplyHi),

--- a/fvm.go
+++ b/fvm.go
@@ -36,6 +36,7 @@ type FVMOpts struct {
 	Externs    cgo.Externs
 
 	Epoch          abi.ChainEpoch
+	Timestamp      uint64
 	BaseFee        abi.TokenAmount
 	BaseCircSupply abi.TokenAmount
 	NetworkVersion network.Version
@@ -63,6 +64,7 @@ func CreateFVM(opts *FVMOpts) (*FVM, error) {
 	if !opts.Debug {
 		executor, err = cgo.CreateFvmMachine(cgo.FvmRegisteredVersion(opts.FVMVersion),
 			uint64(opts.Epoch),
+			opts.Timestamp,
 			baseFeeHi,
 			baseFeeLo,
 			baseCircSupplyHi,
@@ -76,6 +78,7 @@ func CreateFVM(opts *FVMOpts) (*FVM, error) {
 	} else {
 		executor, err = cgo.CreateFvmDebugMachine(cgo.FvmRegisteredVersion(opts.FVMVersion),
 			uint64(opts.Epoch),
+			opts.Timestamp,
 			baseFeeHi,
 			baseFeeLo,
 			baseCircSupplyHi,

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -359,6 +359,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
+
+[[package]]
 name = "byte-slice-cast"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,19 +526,21 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.87.1"
+version = "0.88.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f91425bea5a5ac6d76b788477064944a7e21f0e240fd93f6f368a774a3efdd1"
+checksum = "44409ccf2d0f663920cab563d2b79fcd6b2e9a2bcc6e929fef76c8f82ad6c17a"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.87.1"
+version = "0.88.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b83b4bbf7bc96db77b7b5b5e41fafc4001536e9f0cbfd702ed7d4d8f848dc06"
+checksum = "98de2018ad96eb97f621f7d6b900a0cc661aec8d02ea4a50e56ecb48e5a2fcaf"
 dependencies = [
+ "arrayvec 0.7.2",
+ "bumpalo",
  "cranelift-bforest",
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
@@ -547,33 +555,33 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.87.1"
+version = "0.88.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da02e8fff048c381b313a3dfef4deb2343976fb6d7acc8e7d9c86d4c93e3fa06"
+checksum = "5287ce36e6c4758fbaf298bd1a8697ad97a4f2375a3d1b61142ea538db4877e5"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.87.1"
+version = "0.88.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9abc2a06e8fc29e36660ebbc9e2503e18a051057072acbb1e75e7f7cf19cb95e"
+checksum = "2855c24219e2f08827f3f4ffb2da92e134ae8d8ecc185b11ec8f9878cf5f588e"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.87.1"
+version = "0.88.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeced7874890fc25d85cacc5e626c4d67931c7c25aad1c2ad521684744c1ff5c"
+checksum = "0b65673279d75d34bf11af9660ae2dbd1c22e6d28f163f5c72f4e1dc56d56103"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.87.1"
+version = "0.88.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1d301ccad6fce05d9c9793d433d225fafdd57661b98d268d8d162e9291ff2e"
+checksum = "3ed2b3d7a4751163f6c4a349205ab1b7d9c00eecf19dcea48592ef1f7688eefc"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -583,15 +591,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.87.1"
+version = "0.88.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd7b100db19320848986b4df1da19501dbddeb706a799f502222f72f889b0fab"
+checksum = "3be64cecea9d90105fc6a2ba2d003e98c867c1d6c4c86cc878f97ad9fb916293"
 
 [[package]]
 name = "cranelift-native"
-version = "0.87.1"
+version = "0.88.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7be18d8b976cddc822e52343f328b7593d26dd2f1aeadd90da071596a210d524"
+checksum = "c4a03a6ac1b063e416ca4b93f6247978c991475e8271465340caa6f92f3c16a4"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -600,9 +608,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.87.1"
+version = "0.88.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f9e48bb632a2e189b38a9fa89fa5a6eea687a5a4c613bbef7c2b7522c3ad0e0"
+checksum = "c699873f7b30bc5f20dd03a796b4183e073a46616c91704792ec35e45d13f913"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1111,10 +1119,13 @@ dependencies = [
  "filecoin-proofs-api",
  "filepath",
  "fr32",
- "fvm",
+ "fvm 2.1.0",
+ "fvm 3.0.0-alpha.2",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
- "fvm_shared",
+ "fvm_ipld_encoding 0.2.2",
+ "fvm_ipld_encoding 0.3.0",
+ "fvm_shared 2.0.0",
+ "fvm_shared 3.0.0-alpha.5",
  "group",
  "lazy_static",
  "libc",
@@ -1297,9 +1308,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "fvm"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24e220455bb1b6ebebc0333a9876e8a57b7c1c0d8141c4fb70e810d15c0a5344"
+checksum = "78c00135badd76235a9665b116291bb5127599b42984281b250526bb15406c45"
 dependencies = [
  "anyhow",
  "blake2b_simd",
@@ -1310,11 +1321,48 @@ dependencies = [
  "derive_more",
  "filecoin-proofs-api",
  "fvm-wasm-instrument",
- "fvm_ipld_amt",
+ "fvm_ipld_amt 0.4.2",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
- "fvm_ipld_hamt",
- "fvm_shared",
+ "fvm_ipld_encoding 0.2.2",
+ "fvm_ipld_hamt 0.5.1",
+ "fvm_shared 2.0.0",
+ "lazy_static",
+ "log",
+ "multihash",
+ "num-derive",
+ "num-traits",
+ "num_cpus",
+ "rand",
+ "rayon",
+ "replace_with",
+ "serde",
+ "serde_repr",
+ "serde_tuple",
+ "thiserror",
+ "wasmtime",
+ "yastl",
+]
+
+[[package]]
+name = "fvm"
+version = "3.0.0-alpha.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e69a877b1c1b69cd9f9633ec4367f781d8cf3d80886ee15c6ed57fabf8ef9c"
+dependencies = [
+ "anyhow",
+ "blake2b_simd",
+ "byteorder",
+ "cid",
+ "derive-getters",
+ "derive_builder",
+ "derive_more",
+ "filecoin-proofs-api",
+ "fvm-wasm-instrument",
+ "fvm_ipld_amt 0.5.0",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding 0.3.0",
+ "fvm_ipld_hamt 0.6.0",
+ "fvm_shared 3.0.0-alpha.5",
  "lazy_static",
  "log",
  "multihash",
@@ -1350,7 +1398,23 @@ dependencies = [
  "anyhow",
  "cid",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
+ "fvm_ipld_encoding 0.2.2",
+ "itertools 0.10.4",
+ "once_cell",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "fvm_ipld_amt"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21efabb8ae696f1cfd90b176a3600176010bd6ad3fb9919b16a24b43ba866b3d"
+dependencies = [
+ "anyhow",
+ "cid",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding 0.3.0",
  "itertools 0.10.4",
  "once_cell",
  "serde",
@@ -1387,6 +1451,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "fvm_ipld_encoding"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf531c59e7c9a4c9044a34d1b44c9d544fab1eb0ba50aaa18121fe698d4fec35"
+dependencies = [
+ "anyhow",
+ "cid",
+ "fvm_ipld_blockstore",
+ "multihash",
+ "serde",
+ "serde_ipld_dagcbor",
+ "serde_repr",
+ "serde_tuple",
+ "thiserror",
+]
+
+[[package]]
 name = "fvm_ipld_hamt"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1398,8 +1479,28 @@ dependencies = [
  "cs_serde_bytes",
  "forest_hash_utils",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
- "libipld-core",
+ "fvm_ipld_encoding 0.2.2",
+ "libipld-core 0.13.1",
+ "multihash",
+ "once_cell",
+ "serde",
+ "sha2 0.10.6",
+ "thiserror",
+]
+
+[[package]]
+name = "fvm_ipld_hamt"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48ac0db0c676fe9663f34782d448320b0c71d5e0afb7df38914983ae4d46faa"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "cid",
+ "forest_hash_utils",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding 0.3.0",
+ "libipld-core 0.14.0",
  "multihash",
  "once_cell",
  "serde",
@@ -1423,7 +1524,38 @@ dependencies = [
  "data-encoding-macro",
  "filecoin-proofs-api",
  "fvm_ipld_blockstore",
- "fvm_ipld_encoding",
+ "fvm_ipld_encoding 0.2.2",
+ "lazy_static",
+ "libsecp256k1",
+ "log",
+ "multihash",
+ "num-bigint",
+ "num-derive",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "serde_repr",
+ "serde_tuple",
+ "thiserror",
+ "unsigned-varint",
+]
+
+[[package]]
+name = "fvm_shared"
+version = "3.0.0-alpha.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2a195a55012c943894f71f8ed505dd3efe73b13f2cab70fb9e4d335c63d0f3"
+dependencies = [
+ "anyhow",
+ "blake2b_simd",
+ "bls-signatures",
+ "byteorder",
+ "cid",
+ "data-encoding",
+ "data-encoding-macro",
+ "filecoin-proofs-api",
+ "fvm_ipld_blockstore",
+ "fvm_ipld_encoding 0.3.0",
  "lazy_static",
  "libsecp256k1",
  "log",
@@ -1701,6 +1833,21 @@ name = "libipld-core"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbdd758764f9680a818af33c31db733eb7c45224715d8816b9dcf0548c75f7c5"
+dependencies = [
+ "anyhow",
+ "cid",
+ "core2",
+ "multibase",
+ "multihash",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "libipld-core"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d44790246ec6b7314cba745992c23d479d018073e66d49ae40ae1b64e5dd8eb5"
 dependencies = [
  "anyhow",
  "cid",
@@ -3020,18 +3167,18 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasmparser"
-version = "0.88.0"
+version = "0.89.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb8cf7dd82407fe68161bedcd57fde15596f32ebf6e9b3bdbf3ae1da20e38e5e"
+checksum = "ab5d3e08b13876f96dd55608d03cd4883a0545884932d5adf11925876c96daef"
 dependencies = [
  "indexmap",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "0.40.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a020a3f6587fa7a7d98a021156177735ebb07212a6239a85ab5f14b2f728508f"
+checksum = "f1f511c4917c83d04da68333921107db75747c4e11a2f654a8e909cc5e0520dc"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3056,18 +3203,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "0.40.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed4ada1fdd4d9a2aa37be652abcc31ae3188ad0efcefb4571ef4f785be2d777"
+checksum = "39bf3debfe744bf19dd3732990ce6f8c0ced7439e2370ba4e1d8f5a3660a3178"
 dependencies = [
  "cfg-if 1.0.0",
 ]
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "0.40.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc59c28fe895112db09e262fb9c483f9e7b82c78a82a6ded69567ccc0e9795b"
+checksum = "058217e28644b012bdcdf0e445f58d496d78c2e0b6a6dd93558e701591dad705"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -3086,9 +3233,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "0.40.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11086e573d2635a45ac0d44697a8e4586e058cf1b190f76bea466ca2ec36c30a"
+checksum = "c7af06848df28b7661471d9a80d30a973e0f401f2e3ed5396ad7e225ed217047"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -3105,9 +3252,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "0.40.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5444a78b74144718633f8642eccd7c4858f4c6f0c98ae6a3668998adf177ba2"
+checksum = "9028fb63a54185b3c192b7500ef8039c7bb8d7f62bfc9e7c258483a33a3d13bb"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3129,18 +3276,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "0.40.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2bf6a667d2a29b2b0ed42bcf7564f00c595d92c24acb4d241c7c4d950b1910c"
+checksum = "25e82d4ef93296785de7efca92f7679dc67fe68a13b625a5ecc8d7503b377a37"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "wasmtime-runtime"
-version = "0.40.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee064ce7b563cc201cdf3bb1cc4b233f386d8c57a96e55f4c4afe6103f4bd6a1"
+checksum = "9f0e9bea7d517d114fe66b930b2124ee086516ee93eeebfd97f75f366c5b0553"
 dependencies = [
  "anyhow",
  "cc",
@@ -3162,9 +3309,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "0.40.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01e104bd9e625181d53ead85910bbc0863aa5f0c6ef96836fe9a5cc65da11b69"
+checksum = "69b83e93ed41b8fdc936244cfd5e455480cf1eca1fd60c78a0040038b4ce5075"
 dependencies = [
  "cranelift-entity",
  "serde",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -37,10 +37,10 @@ memmap = "0.7"
 rust-gpu-tools = { version = "0.5", optional = true, default-features = false }
 storage-proofs-porep = { version = "~12.0", default-features = false }
 fr32 = { version = "~5.0", default-features = false }
-fvm3 = { package = "fvm", version = "3.0.0-alpha.1", default-features = false, features = ["m2-native"] }
+fvm3 = { package = "fvm", version = "3.0.0-alpha.2", default-features = false, features = ["m2-native"] }
 fvm3_shared = { package = "fvm_shared", version = "3.0.0-alpha.5" }
 fvm3_ipld_encoding = { package = "fvm_ipld_encoding", version = "0.3.0" }
-fvm2 = { package = "fvm", version = "2.0.0", default-features = false }
+fvm2 = { package = "fvm", version = "2.1.0", default-features = false }
 fvm2_shared = { package = "fvm_shared", version = "2.0.0" }
 fvm2_ipld_encoding = { package = "fvm_ipld_encoding", version = "0.2.2" }
 fvm_ipld_blockstore = "0.1.1"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -40,8 +40,8 @@ fr32 = { version = "~5.0", default-features = false }
 fvm3 = { package = "fvm", version = "3.0.0-alpha.1", default-features = false, features = ["m2-native"] }
 fvm3_shared = { package = "fvm_shared", version = "3.0.0-alpha.5" }
 fvm3_ipld_encoding = { package = "fvm_ipld_encoding", version = "0.3.0" }
-fvm2 = { package = "fvm", version = "2.0.0-alpha.3", default-features = false }
-fvm2_shared = { package = "fvm_shared", version = "2.0.0-alpha.4" }
+fvm2 = { package = "fvm", version = "2.0.0", default-features = false }
+fvm2_shared = { package = "fvm_shared", version = "2.0.0" }
 fvm2_ipld_encoding = { package = "fvm_ipld_encoding", version = "0.2.2" }
 fvm_ipld_blockstore = "0.1.1"
 num-traits = "0.2.14"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -37,10 +37,13 @@ memmap = "0.7"
 rust-gpu-tools = { version = "0.5", optional = true, default-features = false }
 storage-proofs-porep = { version = "~12.0", default-features = false }
 fr32 = { version = "~5.0", default-features = false }
-fvm = { version = "2.0.0", default-features = false }
-fvm_shared = "2.0.0"
+fvm3 = { package = "fvm", version = "3.0.0-alpha.1", default-features = false, features = ["m2-native"] }
+fvm3_shared = { package = "fvm_shared", version = "3.0.0-alpha.5" }
+fvm3_ipld_encoding = { package = "fvm_ipld_encoding", version = "0.3.0" }
+fvm2 = { package = "fvm", version = "2.0.0-alpha.3", default-features = false }
+fvm2_shared = { package = "fvm_shared", version = "2.0.0-alpha.4" }
+fvm2_ipld_encoding = { package = "fvm_ipld_encoding", version = "0.2.2" }
 fvm_ipld_blockstore = "0.1.1"
-fvm_ipld_encoding = "0.2.2"
 num-traits = "0.2.14"
 num-bigint = "0.4"
 cid = { version = "0.8.5", features = ["serde-codec"] }
@@ -62,7 +65,7 @@ tempfile = "3.0.8"
 [features]
 default = ["opencl", "multicore-sdr" ]
 blst-portable = ["bls-signatures/blst-portable", "blstrs/portable"]
-opencl = ["filecoin-proofs-api/opencl", "bellperson/opencl", "storage-proofs-porep/opencl", "rust-gpu-tools/opencl", "fvm/opencl"]
-cuda = ["filecoin-proofs-api/cuda", "bellperson/cuda", "storage-proofs-porep/cuda", "rust-gpu-tools/cuda", "fvm/cuda"]
+opencl = ["filecoin-proofs-api/opencl", "bellperson/opencl", "storage-proofs-porep/opencl", "rust-gpu-tools/opencl", "fvm3/opencl", "fvm2/opencl"]
+cuda = ["filecoin-proofs-api/cuda", "bellperson/cuda", "storage-proofs-porep/cuda", "rust-gpu-tools/cuda", "fvm3/cuda", "fvm2/cuda"]
 multicore-sdr = ["storage-proofs-porep/multicore-sdr"]
 c-headers = ["safer-ffi/headers"]

--- a/rust/src/fvm/blockstore/cgo.rs
+++ b/rust/src/fvm/blockstore/cgo.rs
@@ -2,8 +2,8 @@ use std::ptr;
 
 use anyhow::{anyhow, Result};
 use cid::Cid;
+use fvm3_shared::MAX_CID_LEN;
 use fvm_ipld_blockstore::Blockstore;
-use fvm_shared::MAX_CID_LEN;
 
 use super::super::cgo::*;
 

--- a/rust/src/fvm/engine.rs
+++ b/rust/src/fvm/engine.rs
@@ -272,9 +272,7 @@ impl AbstractMultiEngine for MultiEngine2 {
         externs: CgoExterns,
     ) -> InnerFvmMachine {
         let cfg = NetworkConfig2 {
-            network_version: unsafe {
-                std::mem::transmute::<NetworkVersion, NetworkVersion2>(cfg.network_version)
-            },
+            network_version: NetworkVersion2::try_from(cfg.network_version as u32).unwrap(),
             max_call_depth: cfg.max_call_depth,
             max_wasm_stack: cfg.max_wasm_stack,
             builtin_actors_override: cfg.builtin_actors_override,

--- a/rust/src/fvm/engine.rs
+++ b/rust/src/fvm/engine.rs
@@ -71,6 +71,12 @@ impl MultiEngineContainer {
     }
 }
 
+impl Default for MultiEngineContainer {
+    fn default() -> MultiEngineContainer {
+        MultiEngineContainer::new()
+    }
+}
+
 // fvm v3 implementation
 mod v3 {
     use cid::Cid;

--- a/rust/src/fvm/engine.rs
+++ b/rust/src/fvm/engine.rs
@@ -4,19 +4,43 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::anyhow;
 use cid::Cid;
+
+use fvm2::call_manager::DefaultCallManager as DefaultCallManager2;
 use fvm3::call_manager::DefaultCallManager as DefaultCallManager3;
+
+use fvm2::executor::{
+    ApplyKind as ApplyKind2, ApplyRet as ApplyRet2, DefaultExecutor as DefaultExecutor2,
+    ThreadedExecutor as ThreadedExecutor2,
+};
 use fvm3::executor::{
-    ApplyKind as ApplyKind3, ApplyRet as ApplyRet3, DefaultExecutor as DefaultExecutor3,
-    ThreadedExecutor as ThreadedExecutor3,
+    ApplyKind, ApplyRet, DefaultExecutor as DefaultExecutor3, ThreadedExecutor as ThreadedExecutor3,
+};
+
+use fvm2::machine::{
+    DefaultMachine as DefaultMachine2, MachineContext as MachineContext2,
+    MultiEngine as MultiEngine2, NetworkConfig as NetworkConfig2,
 };
 use fvm3::machine::{
-    DefaultMachine as DefaultMachine3, MachineContext as MachineContext3,
-    MultiEngine as MultiEngine3, NetworkConfig as NetworkConfig3,
+    DefaultMachine as DefaultMachine3, MachineContext, MultiEngine as MultiEngine3, NetworkConfig,
 };
+
+use fvm2::DefaultKernel as DefaultKernel2;
 use fvm3::DefaultKernel as DefaultKernel3;
-use fvm3_shared::{
-    message::Message, version::NetworkVersion,
+
+use fvm2::gas::PriceList as PriceList2;
+use fvm3::gas::PriceList as PriceList3;
+
+use fvm3_shared::{econ::TokenAmount as TokenAmount3, message::Message, version::NetworkVersion};
+
+use fvm2_shared::{
+    econ::TokenAmount as TokenAmount2, message::Message as Message2,
+    version::NetworkVersion as NetworkVersion2,
 };
+
+use fvm2_shared::address::Address as Address2;
+
+use fvm2_ipld_encoding::RawBytes as RawBytes2;
+use fvm3_ipld_encoding::RawBytes as RawBytes3;
 
 use super::blockstore::{CgoBlockstore, OverlayBlockstore};
 use super::externs::CgoExterns;
@@ -24,20 +48,27 @@ use super::types::*;
 
 pub type CgoMachine3 = DefaultMachine3<OverlayBlockstore<CgoBlockstore>, CgoExterns>;
 pub type BaseExecutor3 = DefaultExecutor3<DefaultKernel3<DefaultCallManager3<CgoMachine3>>>;
-
 pub type CgoExecutor3 = ThreadedExecutor3<BaseExecutor3>;
+
+pub type CgoMachine2 = DefaultMachine2<OverlayBlockstore<CgoBlockstore>, CgoExterns>;
+pub type BaseExecutor2 = DefaultExecutor2<DefaultKernel2<DefaultCallManager2<CgoMachine2>>>;
+pub type CgoExecutor2 = ThreadedExecutor2<BaseExecutor2>;
 
 fn new_executor3(machine: CgoMachine3) -> CgoExecutor3 {
     ThreadedExecutor3(BaseExecutor3::new(machine))
+}
+
+fn new_executor2(machine: CgoMachine2) -> CgoExecutor2 {
+    ThreadedExecutor2(BaseExecutor2::new(machine))
 }
 
 pub trait CgoExecutor {
     fn execute_message(
         &mut self,
         msg: Message,
-        apply_kind: ApplyKind3,
+        apply_kind: ApplyKind,
         raw_length: usize,
-    ) -> anyhow::Result<ApplyRet3>;
+    ) -> anyhow::Result<ApplyRet>;
 
     fn flush(&mut self) -> anyhow::Result<Cid>;
 }
@@ -46,9 +77,9 @@ impl CgoExecutor for CgoExecutor3 {
     fn execute_message(
         &mut self,
         msg: Message,
-        apply_kind: ApplyKind3,
+        apply_kind: ApplyKind,
         raw_length: usize,
-    ) -> anyhow::Result<ApplyRet3> {
+    ) -> anyhow::Result<ApplyRet> {
         use fvm3::executor::Executor;
         self.0.execute_message(msg, apply_kind, raw_length)
     }
@@ -59,11 +90,51 @@ impl CgoExecutor for CgoExecutor3 {
     }
 }
 
+impl CgoExecutor for CgoExecutor2 {
+    fn execute_message(
+        &mut self,
+        msg: Message,
+        apply_kind: ApplyKind,
+        raw_length: usize,
+    ) -> anyhow::Result<ApplyRet> {
+        use fvm2::executor::Executor;
+        let res = self.0.execute_message(
+            Message2 {
+                version: msg.version,
+                from: Address2::from_bytes(&msg.from.to_bytes()).unwrap(),
+                to: Address2::from_bytes(&msg.to.to_bytes()).unwrap(),
+                sequence: msg.sequence,
+                value: unsafe { std::mem::transmute::<TokenAmount3, TokenAmount2>(msg.value) },
+                method_num: msg.method_num,
+                params: unsafe { std::mem::transmute::<RawBytes3, RawBytes2>(msg.params) },
+                gas_limit: msg.gas_limit,
+                gas_fee_cap: unsafe {
+                    std::mem::transmute::<TokenAmount3, TokenAmount2>(msg.gas_fee_cap)
+                },
+                gas_premium: unsafe {
+                    std::mem::transmute::<TokenAmount3, TokenAmount2>(msg.gas_premium)
+                },
+            },
+            unsafe { std::mem::transmute::<ApplyKind, ApplyKind2>(apply_kind) },
+            raw_length,
+        );
+        match res {
+            Ok(ret) => Ok(unsafe { std::mem::transmute::<ApplyRet2, ApplyRet>(ret) }),
+            Err(x) => Err(x),
+        }
+    }
+
+    fn flush(&mut self) -> anyhow::Result<Cid> {
+        use fvm2::executor::Executor;
+        self.0.flush()
+    }
+}
+
 pub trait AbstractMultiEngine: Send + Sync {
     fn new_executor(
         &self,
-        ncfg: NetworkConfig3,
-        mctx: MachineContext3,
+        ncfg: NetworkConfig,
+        mctx: MachineContext,
         blockstore: OverlayBlockstore<CgoBlockstore>,
         externs: CgoExterns,
     ) -> InnerFvmMachine;
@@ -72,8 +143,8 @@ pub trait AbstractMultiEngine: Send + Sync {
 impl AbstractMultiEngine for MultiEngine3 {
     fn new_executor(
         &self,
-        cfg: NetworkConfig3,
-        ctx: MachineContext3,
+        cfg: NetworkConfig,
+        ctx: MachineContext,
         blockstore: OverlayBlockstore<CgoBlockstore>,
         externs: CgoExterns,
     ) -> InnerFvmMachine {
@@ -89,6 +160,51 @@ impl AbstractMultiEngine for MultiEngine3 {
     }
 }
 
+impl AbstractMultiEngine for MultiEngine2 {
+    fn new_executor(
+        &self,
+        cfg: NetworkConfig,
+        ctx: MachineContext,
+        blockstore: OverlayBlockstore<CgoBlockstore>,
+        externs: CgoExterns,
+    ) -> InnerFvmMachine {
+        let cfg = NetworkConfig2 {
+            network_version: unsafe {
+                std::mem::transmute::<NetworkVersion, NetworkVersion2>(cfg.network_version)
+            },
+            max_call_depth: cfg.max_call_depth,
+            max_wasm_stack: cfg.max_wasm_stack,
+            builtin_actors_override: cfg.builtin_actors_override,
+            actor_debugging: cfg.actor_debugging,
+            price_list: unsafe { std::mem::transmute::<&PriceList3, &PriceList2>(cfg.price_list) },
+            actor_redirect: cfg.actor_redirect,
+        };
+
+        let engine = match self.get(&cfg) {
+            Ok(e) => e,
+            Err(err) => panic!("failed to create engine: {}", err),
+        };
+
+        let ctx = MachineContext2 {
+            network: cfg,
+            epoch: ctx.network_context.epoch,
+            initial_state_root: ctx.initial_state_root,
+            base_fee: unsafe {
+                std::mem::transmute::<TokenAmount3, TokenAmount2>(ctx.network_context.base_fee)
+            },
+            circ_supply: unsafe {
+                std::mem::transmute::<TokenAmount3, TokenAmount2>(ctx.circ_supply)
+            },
+            tracing: ctx.tracing,
+        };
+
+        let machine = CgoMachine2::new(&engine, &ctx, blockstore, externs).unwrap();
+        InnerFvmMachine {
+            machine: Some(Mutex::new(Box::new(new_executor2(machine)))),
+        }
+    }
+}
+
 pub struct MultiEngineContainer {
     engines: Mutex<HashMap<u32, Arc<dyn AbstractMultiEngine + 'static>>>,
 }
@@ -100,15 +216,18 @@ impl MultiEngineContainer {
         }
     }
 
-    pub fn get(&self, nv: NetworkVersion) -> anyhow::Result<Arc<dyn AbstractMultiEngine + 'static>> {
+    pub fn get(
+        &self,
+        nv: NetworkVersion,
+    ) -> anyhow::Result<Arc<dyn AbstractMultiEngine + 'static>> {
         let mut locked = self.engines.lock().unwrap();
         Ok(match locked.entry(nv as u32) {
             Entry::Occupied(v) => v.get().clone(),
             Entry::Vacant(v) => v
                 .insert(match nv {
-                    //NetworkVersion::V16 | NetworkVersion::V17 => {
-                    //    Arc::new(MultiEngine2::new()) as Arc<dyn AbstractMultiEngine + 'static>
-                    //}
+                    NetworkVersion::V16 | NetworkVersion::V17 => {
+                        Arc::new(MultiEngine2::new()) as Arc<dyn AbstractMultiEngine + 'static>
+                    }
                     NetworkVersion::V18 => {
                         Arc::new(MultiEngine3::new()) as Arc<dyn AbstractMultiEngine + 'static>
                     }

--- a/rust/src/fvm/engine.rs
+++ b/rust/src/fvm/engine.rs
@@ -110,7 +110,10 @@ impl CgoExecutor for CgoExecutor2 {
                 gas_fee_cap: TokenAmount2::from_atto(msg.gas_fee_cap.atto().clone()),
                 gas_premium: TokenAmount2::from_atto(msg.gas_premium.atto().clone()),
             },
-            unsafe { std::mem::transmute::<ApplyKind, ApplyKind2>(apply_kind) },
+            match apply_kind {
+                ApplyKind::Explicit => ApplyKind2::Explicit,
+                ApplyKind::Implicit => ApplyKind2::Implicit,
+            },
             raw_length,
         );
         match res {

--- a/rust/src/fvm/engine.rs
+++ b/rust/src/fvm/engine.rs
@@ -210,7 +210,7 @@ mod v2 {
                     sequence: msg.sequence,
                     value: TokenAmount2::from_atto(msg.value.atto().clone()),
                     method_num: msg.method_num,
-                    params: RawBytes2::from(msg.params.to_vec()),
+                    params: RawBytes2::new(msg.params.into()),
                     gas_limit: msg.gas_limit,
                     gas_fee_cap: TokenAmount2::from_atto(msg.gas_fee_cap.atto().clone()),
                     gas_premium: TokenAmount2::from_atto(msg.gas_premium.atto().clone()),
@@ -225,7 +225,7 @@ mod v2 {
                 Ok(ret) => Ok(ApplyRet {
                     msg_receipt: Receipt {
                         exit_code: ExitCode::new(ret.msg_receipt.exit_code.value()),
-                        return_data: RawBytes::from(ret.msg_receipt.return_data.to_vec()),
+                        return_data: RawBytes::new(ret.msg_receipt.return_data.into()),
                         gas_used: ret.msg_receipt.gas_used,
                     },
                     penalty: TokenAmount::from_atto(ret.penalty.atto().clone()),
@@ -242,12 +242,12 @@ mod v2 {
                             ApplyFailure::MessageBacktrace(Backtrace {
                                 frames: bt
                                     .frames
-                                    .iter()
+                                    .into_iter()
                                     .map(|f| Frame {
                                         source: f.source,
                                         method: f.method,
                                         code: ExitCode::new(f.code.value()),
-                                        message: f.message.clone(),
+                                        message: f.message,
                                     })
                                     .collect(),
                                 cause: bt.cause.map(|cause| match cause {
@@ -276,11 +276,11 @@ mod v2 {
                     }),
                     exec_trace: ret
                         .exec_trace
-                        .iter()
+                        .into_iter()
                         .filter_map(|tr| match tr {
                             ExecutionEvent2::GasCharge(charge) => {
                                 Some(ExecutionEvent::GasCharge(GasCharge {
-                                    name: charge.name.clone(),
+                                    name: charge.name,
                                     compute_gas: Gas::from_milligas(
                                         charge.compute_gas.as_milligas(),
                                     ),
@@ -296,24 +296,21 @@ mod v2 {
                                 params,
                                 value,
                             } => Some(ExecutionEvent::Call {
-                                from: *from,
+                                from,
                                 to: Address::from_bytes(&to.to_bytes()).unwrap(),
-                                method: *method,
-                                params: RawBytes::from(params.to_vec()),
+                                method,
+                                params: RawBytes::new(params.into()),
                                 value: TokenAmount::from_atto(value.atto().clone()),
                             }),
                             ExecutionEvent2::CallReturn(ret) => {
-                                Some(ExecutionEvent::CallReturn(RawBytes::from(ret.to_vec())))
+                                Some(ExecutionEvent::CallReturn(RawBytes::new(ret.into())))
                             }
                             ExecutionEvent2::CallAbort(ec) => {
                                 Some(ExecutionEvent::CallAbort(ExitCode::new(ec.value())))
                             }
-                            ExecutionEvent2::CallError(err) => {
-                                Some(ExecutionEvent::CallError(SyscallError(
-                                    err.0.clone(),
-                                    ErrorNumber::from_u32(err.1 as u32).unwrap(),
-                                )))
-                            }
+                            ExecutionEvent2::CallError(err) => Some(ExecutionEvent::CallError(
+                                SyscallError(err.0, ErrorNumber::from_u32(err.1 as u32).unwrap()),
+                            )),
                             _ => None,
                         })
                         .collect(),

--- a/rust/src/fvm/engine.rs
+++ b/rust/src/fvm/engine.rs
@@ -4,74 +4,17 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::anyhow;
 use cid::Cid;
-use num_traits::FromPrimitive;
 
-use fvm2::call_manager::{backtrace::Cause as Cause2, DefaultCallManager as DefaultCallManager2};
-use fvm3::call_manager::{
-    backtrace::Backtrace, backtrace::Cause, backtrace::Frame,
-    DefaultCallManager as DefaultCallManager3,
-};
-
-use fvm2::trace::ExecutionEvent as ExecutionEvent2;
-use fvm3::trace::ExecutionEvent;
-
-use fvm3::gas::{Gas, GasCharge};
-
-use fvm3::kernel::SyscallError;
-
-use fvm2::executor::{
-    ApplyFailure as ApplyFailure2, ApplyKind as ApplyKind2, DefaultExecutor as DefaultExecutor2,
-    ThreadedExecutor as ThreadedExecutor2,
-};
-use fvm3::executor::{
-    ApplyFailure, ApplyKind, ApplyRet, DefaultExecutor as DefaultExecutor3,
-    ThreadedExecutor as ThreadedExecutor3,
-};
-
-use fvm2::machine::{
-    DefaultMachine as DefaultMachine2, MachineContext as MachineContext2,
-    MultiEngine as MultiEngine2, NetworkConfig as NetworkConfig2,
-};
-use fvm3::machine::{
-    DefaultMachine as DefaultMachine3, MachineContext, MultiEngine as MultiEngine3, NetworkConfig,
-};
-
-use fvm2::DefaultKernel as DefaultKernel2;
-use fvm3::DefaultKernel as DefaultKernel3;
-
-use fvm3_shared::{
-    address::Address, econ::TokenAmount, error::ErrorNumber, error::ExitCode, message::Message,
-    receipt::Receipt, version::NetworkVersion,
-};
-
-use fvm2_shared::{
-    address::Address as Address2, econ::TokenAmount as TokenAmount2, message::Message as Message2,
-    version::NetworkVersion as NetworkVersion2,
-};
-
-use fvm2_ipld_encoding::RawBytes as RawBytes2;
-use fvm3_ipld_encoding::RawBytes;
+use fvm2::machine::MultiEngine as MultiEngine2;
+use fvm3::executor::{ApplyKind, ApplyRet};
+use fvm3::machine::{MachineContext, MultiEngine as MultiEngine3, NetworkConfig};
+use fvm3_shared::{message::Message, version::NetworkVersion};
 
 use super::blockstore::{CgoBlockstore, OverlayBlockstore};
 use super::externs::CgoExterns;
 use super::types::*;
 
-pub type CgoMachine3 = DefaultMachine3<OverlayBlockstore<CgoBlockstore>, CgoExterns>;
-pub type BaseExecutor3 = DefaultExecutor3<DefaultKernel3<DefaultCallManager3<CgoMachine3>>>;
-pub type CgoExecutor3 = ThreadedExecutor3<BaseExecutor3>;
-
-pub type CgoMachine2 = DefaultMachine2<OverlayBlockstore<CgoBlockstore>, CgoExterns>;
-pub type BaseExecutor2 = DefaultExecutor2<DefaultKernel2<DefaultCallManager2<CgoMachine2>>>;
-pub type CgoExecutor2 = ThreadedExecutor2<BaseExecutor2>;
-
-fn new_executor3(machine: CgoMachine3) -> CgoExecutor3 {
-    ThreadedExecutor3(BaseExecutor3::new(machine))
-}
-
-fn new_executor2(machine: CgoMachine2) -> CgoExecutor2 {
-    ThreadedExecutor2(BaseExecutor2::new(machine))
-}
-
+// Generic executor; uses the current (v3) engine types
 pub trait CgoExecutor {
     fn execute_message(
         &mut self,
@@ -83,153 +26,7 @@ pub trait CgoExecutor {
     fn flush(&mut self) -> anyhow::Result<Cid>;
 }
 
-impl CgoExecutor for CgoExecutor3 {
-    fn execute_message(
-        &mut self,
-        msg: Message,
-        apply_kind: ApplyKind,
-        raw_length: usize,
-    ) -> anyhow::Result<ApplyRet> {
-        use fvm3::executor::Executor;
-        self.0.execute_message(msg, apply_kind, raw_length)
-    }
-
-    fn flush(&mut self) -> anyhow::Result<Cid> {
-        use fvm3::executor::Executor;
-        self.0.flush()
-    }
-}
-
-impl CgoExecutor for CgoExecutor2 {
-    fn execute_message(
-        &mut self,
-        msg: Message,
-        apply_kind: ApplyKind,
-        raw_length: usize,
-    ) -> anyhow::Result<ApplyRet> {
-        use fvm2::executor::Executor;
-        let res = self.0.execute_message(
-            Message2 {
-                version: msg.version,
-                from: Address2::from_bytes(&msg.from.to_bytes()).unwrap(),
-                to: Address2::from_bytes(&msg.to.to_bytes()).unwrap(),
-                sequence: msg.sequence,
-                value: TokenAmount2::from_atto(msg.value.atto().clone()),
-                method_num: msg.method_num,
-                params: RawBytes2::from(msg.params.to_vec()),
-                gas_limit: msg.gas_limit,
-                gas_fee_cap: TokenAmount2::from_atto(msg.gas_fee_cap.atto().clone()),
-                gas_premium: TokenAmount2::from_atto(msg.gas_premium.atto().clone()),
-            },
-            match apply_kind {
-                ApplyKind::Explicit => ApplyKind2::Explicit,
-                ApplyKind::Implicit => ApplyKind2::Implicit,
-            },
-            raw_length,
-        );
-        match res {
-            Ok(ret) => Ok(ApplyRet {
-                msg_receipt: Receipt {
-                    exit_code: ExitCode::new(ret.msg_receipt.exit_code.value()),
-                    return_data: RawBytes::from(ret.msg_receipt.return_data.to_vec()),
-                    gas_used: ret.msg_receipt.gas_used,
-                },
-                penalty: TokenAmount::from_atto(ret.penalty.atto().clone()),
-                miner_tip: TokenAmount::from_atto(ret.miner_tip.atto().clone()),
-                base_fee_burn: TokenAmount::from_atto(ret.base_fee_burn.atto().clone()),
-                over_estimation_burn: TokenAmount::from_atto(
-                    ret.over_estimation_burn.atto().clone(),
-                ),
-                refund: TokenAmount::from_atto(ret.refund.atto().clone()),
-                gas_refund: ret.gas_refund,
-                gas_burned: ret.gas_burned,
-                failure_info: ret.failure_info.map(|failure| match failure {
-                    ApplyFailure2::MessageBacktrace(bt) => {
-                        ApplyFailure::MessageBacktrace(Backtrace {
-                            frames: bt
-                                .frames
-                                .iter()
-                                .map(|f| Frame {
-                                    source: f.source,
-                                    method: f.method,
-                                    code: ExitCode::new(f.code.value()),
-                                    message: f.message.clone(),
-                                })
-                                .collect(),
-                            cause: bt.cause.map(|cause| match cause {
-                                Cause2::Syscall {
-                                    module,
-                                    function,
-                                    error,
-                                    message,
-                                } => Cause::Syscall {
-                                    module,
-                                    function,
-                                    error: ErrorNumber::from_u32(error as u32).unwrap(),
-                                    message,
-                                },
-                                Cause2::Fatal {
-                                    error_msg,
-                                    backtrace,
-                                } => Cause::Fatal {
-                                    error_msg,
-                                    backtrace,
-                                },
-                            }),
-                        })
-                    }
-                    ApplyFailure2::PreValidation(s) => ApplyFailure::PreValidation(s),
-                }),
-                exec_trace: ret
-                    .exec_trace
-                    .iter()
-                    .filter_map(|tr| match tr {
-                        ExecutionEvent2::GasCharge(charge) => {
-                            Some(ExecutionEvent::GasCharge(GasCharge {
-                                name: charge.name.clone(),
-                                compute_gas: Gas::from_milligas(charge.compute_gas.as_milligas()),
-                                storage_gas: Gas::from_milligas(charge.storage_gas.as_milligas()),
-                            }))
-                        }
-                        ExecutionEvent2::Call {
-                            from,
-                            to,
-                            method,
-                            params,
-                            value,
-                        } => Some(ExecutionEvent::Call {
-                            from: *from,
-                            to: Address::from_bytes(&to.to_bytes()).unwrap(),
-                            method: *method,
-                            params: RawBytes::from(params.to_vec()),
-                            value: TokenAmount::from_atto(value.atto().clone()),
-                        }),
-                        ExecutionEvent2::CallReturn(ret) => {
-                            Some(ExecutionEvent::CallReturn(RawBytes::from(ret.to_vec())))
-                        }
-                        ExecutionEvent2::CallAbort(ec) => {
-                            Some(ExecutionEvent::CallAbort(ExitCode::new(ec.value())))
-                        }
-                        ExecutionEvent2::CallError(err) => {
-                            Some(ExecutionEvent::CallError(SyscallError(
-                                err.0.clone(),
-                                ErrorNumber::from_u32(err.1 as u32).unwrap(),
-                            )))
-                        }
-                        _ => None,
-                    })
-                    .collect(),
-            }),
-            Err(x) => Err(x),
-        }
-    }
-
-    fn flush(&mut self) -> anyhow::Result<Cid> {
-        use fvm2::executor::Executor;
-        self.0.flush()
-    }
-}
-
+// The generic engine interface
 pub trait AbstractMultiEngine: Send + Sync {
     fn new_executor(
         &self,
@@ -240,67 +37,7 @@ pub trait AbstractMultiEngine: Send + Sync {
     ) -> InnerFvmMachine;
 }
 
-impl AbstractMultiEngine for MultiEngine3 {
-    fn new_executor(
-        &self,
-        cfg: NetworkConfig,
-        ctx: MachineContext,
-        blockstore: OverlayBlockstore<CgoBlockstore>,
-        externs: CgoExterns,
-    ) -> InnerFvmMachine {
-        let engine = match self.get(&cfg) {
-            Ok(e) => e,
-            Err(err) => panic!("failed to create engine: {}", err),
-        };
-
-        let machine = CgoMachine3::new(&engine, &ctx, blockstore, externs).unwrap();
-        InnerFvmMachine {
-            machine: Some(Mutex::new(Box::new(new_executor3(machine)))),
-        }
-    }
-}
-
-impl AbstractMultiEngine for MultiEngine2 {
-    fn new_executor(
-        &self,
-        cfg: NetworkConfig,
-        ctx: MachineContext,
-        blockstore: OverlayBlockstore<CgoBlockstore>,
-        externs: CgoExterns,
-    ) -> InnerFvmMachine {
-        let ver = NetworkVersion2::try_from(cfg.network_version as u32).unwrap();
-        let cfg = NetworkConfig2 {
-            network_version: ver,
-            max_call_depth: cfg.max_call_depth,
-            max_wasm_stack: cfg.max_wasm_stack,
-            builtin_actors_override: cfg.builtin_actors_override,
-            actor_debugging: cfg.actor_debugging,
-            price_list: fvm2::gas::price_list_by_network_version(ver),
-            actor_redirect: cfg.actor_redirect,
-        };
-
-        let engine = match self.get(&cfg) {
-            Ok(e) => e,
-            Err(err) => panic!("failed to create engine: {}", err),
-        };
-
-        let ctx = MachineContext2 {
-            network: cfg,
-            epoch: ctx.network_context.epoch,
-            initial_state_root: ctx.initial_state_root,
-            base_fee: TokenAmount2::from_atto(ctx.network_context.base_fee.atto().clone()),
-            circ_supply: TokenAmount2::from_atto(ctx.circ_supply.atto().clone()),
-            tracing: ctx.tracing,
-        };
-
-        let machine = CgoMachine2::new(&engine, &ctx, blockstore, externs).unwrap();
-        InnerFvmMachine {
-            machine: Some(Mutex::new(Box::new(new_executor2(machine)))),
-        }
-    }
-}
-
-#[allow(clippy::new_without_default)]
+// The generic engine container
 pub struct MultiEngineContainer {
     engines: Mutex<HashMap<u32, Arc<dyn AbstractMultiEngine + 'static>>>,
 }
@@ -331,5 +68,297 @@ impl MultiEngineContainer {
                 })
                 .clone(),
         })
+    }
+}
+
+// fvm v3 implementation
+mod v3 {
+    use cid::Cid;
+    use std::sync::Mutex;
+
+    use fvm3::call_manager::DefaultCallManager as DefaultCallManager3;
+    use fvm3::executor::{
+        ApplyKind, ApplyRet, DefaultExecutor as DefaultExecutor3,
+        ThreadedExecutor as ThreadedExecutor3,
+    };
+    use fvm3::machine::{
+        DefaultMachine as DefaultMachine3, MachineContext, MultiEngine as MultiEngine3,
+        NetworkConfig,
+    };
+    use fvm3::DefaultKernel as DefaultKernel3;
+    use fvm3_shared::message::Message;
+
+    use crate::fvm::engine::{
+        AbstractMultiEngine, CgoBlockstore, CgoExecutor, CgoExterns, InnerFvmMachine,
+        OverlayBlockstore,
+    };
+
+    type CgoMachine3 = DefaultMachine3<OverlayBlockstore<CgoBlockstore>, CgoExterns>;
+    type BaseExecutor3 = DefaultExecutor3<DefaultKernel3<DefaultCallManager3<CgoMachine3>>>;
+    type CgoExecutor3 = ThreadedExecutor3<BaseExecutor3>;
+
+    fn new_executor(machine: CgoMachine3) -> CgoExecutor3 {
+        ThreadedExecutor3(BaseExecutor3::new(machine))
+    }
+
+    impl CgoExecutor for CgoExecutor3 {
+        fn execute_message(
+            &mut self,
+            msg: Message,
+            apply_kind: ApplyKind,
+            raw_length: usize,
+        ) -> anyhow::Result<ApplyRet> {
+            use fvm3::executor::Executor;
+            self.0.execute_message(msg, apply_kind, raw_length)
+        }
+
+        fn flush(&mut self) -> anyhow::Result<Cid> {
+            use fvm3::executor::Executor;
+            self.0.flush()
+        }
+    }
+
+    impl AbstractMultiEngine for MultiEngine3 {
+        fn new_executor(
+            &self,
+            cfg: NetworkConfig,
+            ctx: MachineContext,
+            blockstore: OverlayBlockstore<CgoBlockstore>,
+            externs: CgoExterns,
+        ) -> InnerFvmMachine {
+            let engine = match self.get(&cfg) {
+                Ok(e) => e,
+                Err(err) => panic!("failed to create engine: {}", err),
+            };
+
+            let machine = CgoMachine3::new(&engine, &ctx, blockstore, externs).unwrap();
+            InnerFvmMachine {
+                machine: Some(Mutex::new(Box::new(new_executor(machine)))),
+            }
+        }
+    }
+}
+
+// fvm v2 implementation
+mod v2 {
+    use cid::Cid;
+    use num_traits::FromPrimitive;
+    use std::sync::Mutex;
+
+    use fvm2::call_manager::{
+        backtrace::Cause as Cause2, DefaultCallManager as DefaultCallManager2,
+    };
+    use fvm2::executor::{
+        ApplyFailure as ApplyFailure2, ApplyKind as ApplyKind2,
+        DefaultExecutor as DefaultExecutor2, ThreadedExecutor as ThreadedExecutor2,
+    };
+    use fvm2::machine::{
+        DefaultMachine as DefaultMachine2, MachineContext as MachineContext2,
+        MultiEngine as MultiEngine2, NetworkConfig as NetworkConfig2,
+    };
+    use fvm2::trace::ExecutionEvent as ExecutionEvent2;
+    use fvm2::DefaultKernel as DefaultKernel2;
+    use fvm2_ipld_encoding::RawBytes as RawBytes2;
+    use fvm2_shared::{
+        address::Address as Address2, econ::TokenAmount as TokenAmount2,
+        message::Message as Message2, version::NetworkVersion as NetworkVersion2,
+    };
+    use fvm3::call_manager::{backtrace::Backtrace, backtrace::Cause, backtrace::Frame};
+    use fvm3::executor::{ApplyFailure, ApplyKind, ApplyRet};
+    use fvm3::gas::{Gas, GasCharge};
+    use fvm3::kernel::SyscallError;
+    use fvm3::machine::{MachineContext, NetworkConfig};
+    use fvm3::trace::ExecutionEvent;
+    use fvm3_ipld_encoding::RawBytes;
+    use fvm3_shared::{
+        address::Address, econ::TokenAmount, error::ErrorNumber, error::ExitCode, message::Message,
+        receipt::Receipt,
+    };
+
+    use crate::fvm::engine::{
+        AbstractMultiEngine, CgoBlockstore, CgoExecutor, CgoExterns, InnerFvmMachine,
+        OverlayBlockstore,
+    };
+
+    type CgoMachine2 = DefaultMachine2<OverlayBlockstore<CgoBlockstore>, CgoExterns>;
+    type BaseExecutor2 = DefaultExecutor2<DefaultKernel2<DefaultCallManager2<CgoMachine2>>>;
+    type CgoExecutor2 = ThreadedExecutor2<BaseExecutor2>;
+
+    fn new_executor(machine: CgoMachine2) -> CgoExecutor2 {
+        ThreadedExecutor2(BaseExecutor2::new(machine))
+    }
+
+    impl CgoExecutor for CgoExecutor2 {
+        fn execute_message(
+            &mut self,
+            msg: Message,
+            apply_kind: ApplyKind,
+            raw_length: usize,
+        ) -> anyhow::Result<ApplyRet> {
+            use fvm2::executor::Executor;
+            let res = self.0.execute_message(
+                Message2 {
+                    version: msg.version,
+                    from: Address2::from_bytes(&msg.from.to_bytes()).unwrap(),
+                    to: Address2::from_bytes(&msg.to.to_bytes()).unwrap(),
+                    sequence: msg.sequence,
+                    value: TokenAmount2::from_atto(msg.value.atto().clone()),
+                    method_num: msg.method_num,
+                    params: RawBytes2::from(msg.params.to_vec()),
+                    gas_limit: msg.gas_limit,
+                    gas_fee_cap: TokenAmount2::from_atto(msg.gas_fee_cap.atto().clone()),
+                    gas_premium: TokenAmount2::from_atto(msg.gas_premium.atto().clone()),
+                },
+                match apply_kind {
+                    ApplyKind::Explicit => ApplyKind2::Explicit,
+                    ApplyKind::Implicit => ApplyKind2::Implicit,
+                },
+                raw_length,
+            );
+            match res {
+                Ok(ret) => Ok(ApplyRet {
+                    msg_receipt: Receipt {
+                        exit_code: ExitCode::new(ret.msg_receipt.exit_code.value()),
+                        return_data: RawBytes::from(ret.msg_receipt.return_data.to_vec()),
+                        gas_used: ret.msg_receipt.gas_used,
+                    },
+                    penalty: TokenAmount::from_atto(ret.penalty.atto().clone()),
+                    miner_tip: TokenAmount::from_atto(ret.miner_tip.atto().clone()),
+                    base_fee_burn: TokenAmount::from_atto(ret.base_fee_burn.atto().clone()),
+                    over_estimation_burn: TokenAmount::from_atto(
+                        ret.over_estimation_burn.atto().clone(),
+                    ),
+                    refund: TokenAmount::from_atto(ret.refund.atto().clone()),
+                    gas_refund: ret.gas_refund,
+                    gas_burned: ret.gas_burned,
+                    failure_info: ret.failure_info.map(|failure| match failure {
+                        ApplyFailure2::MessageBacktrace(bt) => {
+                            ApplyFailure::MessageBacktrace(Backtrace {
+                                frames: bt
+                                    .frames
+                                    .iter()
+                                    .map(|f| Frame {
+                                        source: f.source,
+                                        method: f.method,
+                                        code: ExitCode::new(f.code.value()),
+                                        message: f.message.clone(),
+                                    })
+                                    .collect(),
+                                cause: bt.cause.map(|cause| match cause {
+                                    Cause2::Syscall {
+                                        module,
+                                        function,
+                                        error,
+                                        message,
+                                    } => Cause::Syscall {
+                                        module,
+                                        function,
+                                        error: ErrorNumber::from_u32(error as u32).unwrap(),
+                                        message,
+                                    },
+                                    Cause2::Fatal {
+                                        error_msg,
+                                        backtrace,
+                                    } => Cause::Fatal {
+                                        error_msg,
+                                        backtrace,
+                                    },
+                                }),
+                            })
+                        }
+                        ApplyFailure2::PreValidation(s) => ApplyFailure::PreValidation(s),
+                    }),
+                    exec_trace: ret
+                        .exec_trace
+                        .iter()
+                        .filter_map(|tr| match tr {
+                            ExecutionEvent2::GasCharge(charge) => {
+                                Some(ExecutionEvent::GasCharge(GasCharge {
+                                    name: charge.name.clone(),
+                                    compute_gas: Gas::from_milligas(
+                                        charge.compute_gas.as_milligas(),
+                                    ),
+                                    storage_gas: Gas::from_milligas(
+                                        charge.storage_gas.as_milligas(),
+                                    ),
+                                }))
+                            }
+                            ExecutionEvent2::Call {
+                                from,
+                                to,
+                                method,
+                                params,
+                                value,
+                            } => Some(ExecutionEvent::Call {
+                                from: *from,
+                                to: Address::from_bytes(&to.to_bytes()).unwrap(),
+                                method: *method,
+                                params: RawBytes::from(params.to_vec()),
+                                value: TokenAmount::from_atto(value.atto().clone()),
+                            }),
+                            ExecutionEvent2::CallReturn(ret) => {
+                                Some(ExecutionEvent::CallReturn(RawBytes::from(ret.to_vec())))
+                            }
+                            ExecutionEvent2::CallAbort(ec) => {
+                                Some(ExecutionEvent::CallAbort(ExitCode::new(ec.value())))
+                            }
+                            ExecutionEvent2::CallError(err) => {
+                                Some(ExecutionEvent::CallError(SyscallError(
+                                    err.0.clone(),
+                                    ErrorNumber::from_u32(err.1 as u32).unwrap(),
+                                )))
+                            }
+                            _ => None,
+                        })
+                        .collect(),
+                }),
+                Err(x) => Err(x),
+            }
+        }
+
+        fn flush(&mut self) -> anyhow::Result<Cid> {
+            use fvm2::executor::Executor;
+            self.0.flush()
+        }
+    }
+
+    impl AbstractMultiEngine for MultiEngine2 {
+        fn new_executor(
+            &self,
+            cfg: NetworkConfig,
+            ctx: MachineContext,
+            blockstore: OverlayBlockstore<CgoBlockstore>,
+            externs: CgoExterns,
+        ) -> InnerFvmMachine {
+            let ver = NetworkVersion2::try_from(cfg.network_version as u32).unwrap();
+            let cfg = NetworkConfig2 {
+                network_version: ver,
+                max_call_depth: cfg.max_call_depth,
+                max_wasm_stack: cfg.max_wasm_stack,
+                builtin_actors_override: cfg.builtin_actors_override,
+                actor_debugging: cfg.actor_debugging,
+                price_list: fvm2::gas::price_list_by_network_version(ver),
+                actor_redirect: cfg.actor_redirect,
+            };
+
+            let engine = match self.get(&cfg) {
+                Ok(e) => e,
+                Err(err) => panic!("failed to create engine: {}", err),
+            };
+
+            let ctx = MachineContext2 {
+                network: cfg,
+                epoch: ctx.network_context.epoch,
+                initial_state_root: ctx.initial_state_root,
+                base_fee: TokenAmount2::from_atto(ctx.network_context.base_fee.atto().clone()),
+                circ_supply: TokenAmount2::from_atto(ctx.circ_supply.atto().clone()),
+                tracing: ctx.tracing,
+            };
+
+            let machine = CgoMachine2::new(&engine, &ctx, blockstore, externs).unwrap();
+            InnerFvmMachine {
+                machine: Some(Mutex::new(Box::new(new_executor(machine)))),
+            }
+        }
     }
 }

--- a/rust/src/fvm/engine.rs
+++ b/rust/src/fvm/engine.rs
@@ -2,44 +2,30 @@ use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
-use num_traits::FromPrimitive;
 use anyhow::anyhow;
 use cid::Cid;
+use num_traits::FromPrimitive;
 
-use fvm2::call_manager::{
-    DefaultCallManager as DefaultCallManager2,
-    backtrace::Cause as Cause2,
-};
+use fvm2::call_manager::{backtrace::Cause as Cause2, DefaultCallManager as DefaultCallManager2};
 use fvm3::call_manager::{
+    backtrace::Backtrace, backtrace::Cause, backtrace::Frame,
     DefaultCallManager as DefaultCallManager3,
-    backtrace::Cause,
-    backtrace::Backtrace,
-    backtrace::Frame,
 };
 
-use fvm2::trace::{
-    ExecutionEvent as ExecutionEvent2,
-};
-use fvm3::trace::{
-    ExecutionEvent,
-};
+use fvm2::trace::ExecutionEvent as ExecutionEvent2;
+use fvm3::trace::ExecutionEvent;
 
-use fvm3::gas::{
-    Gas,
-    GasCharge,
-};
+use fvm3::gas::{Gas, GasCharge};
 
-use fvm3::kernel::{
-    SyscallError
-};
-
+use fvm3::kernel::SyscallError;
 
 use fvm2::executor::{
-    ApplyKind as ApplyKind2, ApplyFailure as ApplyFailure2, DefaultExecutor as DefaultExecutor2,
+    ApplyFailure as ApplyFailure2, ApplyKind as ApplyKind2, DefaultExecutor as DefaultExecutor2,
     ThreadedExecutor as ThreadedExecutor2,
 };
 use fvm3::executor::{
-    ApplyKind, ApplyRet, ApplyFailure, DefaultExecutor as DefaultExecutor3, ThreadedExecutor as ThreadedExecutor3,
+    ApplyFailure, ApplyKind, ApplyRet, DefaultExecutor as DefaultExecutor3,
+    ThreadedExecutor as ThreadedExecutor3,
 };
 
 use fvm2::machine::{
@@ -57,24 +43,17 @@ use fvm2::gas::PriceList as PriceList2;
 use fvm3::gas::PriceList as PriceList3;
 
 use fvm3_shared::{
-    message::Message,
-    receipt::Receipt,
-    version::NetworkVersion,
-    error::ExitCode,
-    error::ErrorNumber,
-    econ::TokenAmount,
-    address::Address,
+    address::Address, econ::TokenAmount, error::ErrorNumber, error::ExitCode, message::Message,
+    receipt::Receipt, version::NetworkVersion,
 };
 
 use fvm2_shared::{
-    econ::TokenAmount as TokenAmount2, message::Message as Message2,
+    address::Address as Address2, econ::TokenAmount as TokenAmount2, message::Message as Message2,
     version::NetworkVersion as NetworkVersion2,
-    address::Address as Address2,
 };
 
-
-use fvm3_ipld_encoding::RawBytes;
 use fvm2_ipld_encoding::RawBytes as RawBytes2;
+use fvm3_ipld_encoding::RawBytes;
 
 use super::blockstore::{CgoBlockstore, OverlayBlockstore};
 use super::externs::CgoExterns;
@@ -152,65 +131,98 @@ impl CgoExecutor for CgoExecutor2 {
             raw_length,
         );
         match res {
-            Ok(ret) => Ok(
-                ApplyRet {
-                    msg_receipt: Receipt {
-                        exit_code: ExitCode::new(ret.msg_receipt.exit_code.value()),
-                        return_data: RawBytes::from(ret.msg_receipt.return_data.to_vec()),
-                        gas_used: ret.msg_receipt.gas_used,
-                    },
-                    penalty: TokenAmount::from_atto(ret.penalty.atto().clone()),
-                    miner_tip: TokenAmount::from_atto(ret.miner_tip.atto().clone()),
-                    base_fee_burn: TokenAmount::from_atto(ret.base_fee_burn.atto().clone()),
-                    over_estimation_burn: TokenAmount::from_atto(ret.over_estimation_burn.atto().clone()),
-                    refund: TokenAmount::from_atto(ret.refund.atto().clone()),
-                    gas_refund: ret.gas_refund,
-                    gas_burned: ret.gas_burned,
-                    failure_info: ret.failure_info.map(|failure| {
-                        match failure {
-                            ApplyFailure2::MessageBacktrace(bt) => ApplyFailure::MessageBacktrace(
-                                Backtrace {
-                                    frames: bt.frames.iter().map(|f| Frame {
-                                        source: f.source,
-                                        method: f.method,
-                                        code: ExitCode::new(f.code.value()),
-                                        message: f.message.clone(),
-                                    }).collect(),
-                                    cause: bt.cause.map(|cause| {
-                                        match cause {
-                                            Cause2::Syscall { module, function, error,message } => Cause::Syscall { module, function, error: ErrorNumber::from_u32(error as u32).unwrap(),  message },
-                                            Cause2::Fatal { error_msg, backtrace } => Cause::Fatal { error_msg, backtrace },
-                                        }
-                                    }),
+            Ok(ret) => Ok(ApplyRet {
+                msg_receipt: Receipt {
+                    exit_code: ExitCode::new(ret.msg_receipt.exit_code.value()),
+                    return_data: RawBytes::from(ret.msg_receipt.return_data.to_vec()),
+                    gas_used: ret.msg_receipt.gas_used,
+                },
+                penalty: TokenAmount::from_atto(ret.penalty.atto().clone()),
+                miner_tip: TokenAmount::from_atto(ret.miner_tip.atto().clone()),
+                base_fee_burn: TokenAmount::from_atto(ret.base_fee_burn.atto().clone()),
+                over_estimation_burn: TokenAmount::from_atto(
+                    ret.over_estimation_burn.atto().clone(),
+                ),
+                refund: TokenAmount::from_atto(ret.refund.atto().clone()),
+                gas_refund: ret.gas_refund,
+                gas_burned: ret.gas_burned,
+                failure_info: ret.failure_info.map(|failure| match failure {
+                    ApplyFailure2::MessageBacktrace(bt) => {
+                        ApplyFailure::MessageBacktrace(Backtrace {
+                            frames: bt
+                                .frames
+                                .iter()
+                                .map(|f| Frame {
+                                    source: f.source,
+                                    method: f.method,
+                                    code: ExitCode::new(f.code.value()),
+                                    message: f.message.clone(),
+                                })
+                                .collect(),
+                            cause: bt.cause.map(|cause| match cause {
+                                Cause2::Syscall {
+                                    module,
+                                    function,
+                                    error,
+                                    message,
+                                } => Cause::Syscall {
+                                    module,
+                                    function,
+                                    error: ErrorNumber::from_u32(error as u32).unwrap(),
+                                    message,
                                 },
-                            ),
-                            ApplyFailure2::PreValidation(s) => ApplyFailure::PreValidation(s),
-                        }
-                    }),
-                    exec_trace: ret.exec_trace.iter().filter_map(|tr| match tr {
-                        ExecutionEvent2::GasCharge(charge) => Some(
-                            ExecutionEvent::GasCharge(GasCharge {
+                                Cause2::Fatal {
+                                    error_msg,
+                                    backtrace,
+                                } => Cause::Fatal {
+                                    error_msg,
+                                    backtrace,
+                                },
+                            }),
+                        })
+                    }
+                    ApplyFailure2::PreValidation(s) => ApplyFailure::PreValidation(s),
+                }),
+                exec_trace: ret
+                    .exec_trace
+                    .iter()
+                    .filter_map(|tr| match tr {
+                        ExecutionEvent2::GasCharge(charge) => {
+                            Some(ExecutionEvent::GasCharge(GasCharge {
                                 name: charge.name.clone(),
-                            compute_gas: Gas::from_milligas(charge.compute_gas.as_milligas()),
-                            storage_gas: Gas::from_milligas(charge.storage_gas.as_milligas()),
-                        })),
-                        ExecutionEvent2::Call{from, to, method, params, value} => Some(
-                            ExecutionEvent::Call {
+                                compute_gas: Gas::from_milligas(charge.compute_gas.as_milligas()),
+                                storage_gas: Gas::from_milligas(charge.storage_gas.as_milligas()),
+                            }))
+                        }
+                        ExecutionEvent2::Call {
+                            from,
+                            to,
+                            method,
+                            params,
+                            value,
+                        } => Some(ExecutionEvent::Call {
                             from: *from,
                             to: Address::from_bytes(&to.to_bytes()).unwrap(),
                             method: *method,
                             params: RawBytes::from(params.to_vec()),
                             value: TokenAmount::from_atto(value.atto().clone()),
-                            }),
-                        ExecutionEvent2::CallReturn(ret) => Some(
-                            ExecutionEvent::CallReturn(RawBytes::from(ret.to_vec()))),
-                        ExecutionEvent2::CallAbort(ec) => Some(
-                            ExecutionEvent::CallAbort(ExitCode::new(ec.value()))),
-                        ExecutionEvent2::CallError(err) => Some(
-                            ExecutionEvent::CallError(SyscallError(err.0.clone(), ErrorNumber::from_u32(err.1 as u32).unwrap()))),
+                        }),
+                        ExecutionEvent2::CallReturn(ret) => {
+                            Some(ExecutionEvent::CallReturn(RawBytes::from(ret.to_vec())))
+                        }
+                        ExecutionEvent2::CallAbort(ec) => {
+                            Some(ExecutionEvent::CallAbort(ExitCode::new(ec.value())))
+                        }
+                        ExecutionEvent2::CallError(err) => {
+                            Some(ExecutionEvent::CallError(SyscallError(
+                                err.0.clone(),
+                                ErrorNumber::from_u32(err.1 as u32).unwrap(),
+                            )))
+                        }
                         _ => None,
-                    }).collect(),
-                }),
+                    })
+                    .collect(),
+            }),
             Err(x) => Err(x),
         }
     }

--- a/rust/src/fvm/engine.rs
+++ b/rust/src/fvm/engine.rs
@@ -1,0 +1,120 @@
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use anyhow::anyhow;
+use cid::Cid;
+use fvm3::call_manager::DefaultCallManager as DefaultCallManager3;
+use fvm3::executor::{
+    ApplyKind as ApplyKind3, ApplyRet as ApplyRet3, DefaultExecutor as DefaultExecutor3,
+    ThreadedExecutor as ThreadedExecutor3,
+};
+use fvm3::machine::{
+    DefaultMachine as DefaultMachine3, MachineContext as MachineContext3,
+    MultiEngine as MultiEngine3, NetworkConfig as NetworkConfig3,
+};
+use fvm3::DefaultKernel as DefaultKernel3;
+use fvm3_shared::{
+    message::Message, version::NetworkVersion,
+};
+
+use super::blockstore::{CgoBlockstore, OverlayBlockstore};
+use super::externs::CgoExterns;
+use super::types::*;
+
+pub type CgoMachine3 = DefaultMachine3<OverlayBlockstore<CgoBlockstore>, CgoExterns>;
+pub type BaseExecutor3 = DefaultExecutor3<DefaultKernel3<DefaultCallManager3<CgoMachine3>>>;
+
+pub type CgoExecutor3 = ThreadedExecutor3<BaseExecutor3>;
+
+fn new_executor3(machine: CgoMachine3) -> CgoExecutor3 {
+    ThreadedExecutor3(BaseExecutor3::new(machine))
+}
+
+pub trait CgoExecutor {
+    fn execute_message(
+        &mut self,
+        msg: Message,
+        apply_kind: ApplyKind3,
+        raw_length: usize,
+    ) -> anyhow::Result<ApplyRet3>;
+
+    fn flush(&mut self) -> anyhow::Result<Cid>;
+}
+
+impl CgoExecutor for CgoExecutor3 {
+    fn execute_message(
+        &mut self,
+        msg: Message,
+        apply_kind: ApplyKind3,
+        raw_length: usize,
+    ) -> anyhow::Result<ApplyRet3> {
+        use fvm3::executor::Executor;
+        self.0.execute_message(msg, apply_kind, raw_length)
+    }
+
+    fn flush(&mut self) -> anyhow::Result<Cid> {
+        use fvm3::executor::Executor;
+        self.0.flush()
+    }
+}
+
+pub trait AbstractMultiEngine: Send + Sync {
+    fn new_executor(
+        &self,
+        ncfg: NetworkConfig3,
+        mctx: MachineContext3,
+        blockstore: OverlayBlockstore<CgoBlockstore>,
+        externs: CgoExterns,
+    ) -> InnerFvmMachine;
+}
+
+impl AbstractMultiEngine for MultiEngine3 {
+    fn new_executor(
+        &self,
+        cfg: NetworkConfig3,
+        ctx: MachineContext3,
+        blockstore: OverlayBlockstore<CgoBlockstore>,
+        externs: CgoExterns,
+    ) -> InnerFvmMachine {
+        let engine = match self.get(&cfg) {
+            Ok(e) => e,
+            Err(err) => panic!("failed to create engine: {}", err),
+        };
+
+        let machine = CgoMachine3::new(&engine, &ctx, blockstore, externs).unwrap();
+        InnerFvmMachine {
+            machine: Some(Mutex::new(Box::new(new_executor3(machine)))),
+        }
+    }
+}
+
+pub struct MultiEngineContainer {
+    engines: Mutex<HashMap<u32, Arc<dyn AbstractMultiEngine + 'static>>>,
+}
+
+impl MultiEngineContainer {
+    pub fn new() -> MultiEngineContainer {
+        MultiEngineContainer {
+            engines: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub fn get(&self, nv: NetworkVersion) -> anyhow::Result<Arc<dyn AbstractMultiEngine + 'static>> {
+        let mut locked = self.engines.lock().unwrap();
+        Ok(match locked.entry(nv as u32) {
+            Entry::Occupied(v) => v.get().clone(),
+            Entry::Vacant(v) => v
+                .insert(match nv {
+                    //NetworkVersion::V16 | NetworkVersion::V17 => {
+                    //    Arc::new(MultiEngine2::new()) as Arc<dyn AbstractMultiEngine + 'static>
+                    //}
+                    NetworkVersion::V18 => {
+                        Arc::new(MultiEngine3::new()) as Arc<dyn AbstractMultiEngine + 'static>
+                    }
+                    _ => return Err(anyhow!("network version not supported")),
+                })
+                .clone(),
+        })
+    }
+}

--- a/rust/src/fvm/engine.rs
+++ b/rust/src/fvm/engine.rs
@@ -30,7 +30,7 @@ use fvm3::DefaultKernel as DefaultKernel3;
 use fvm2::gas::PriceList as PriceList2;
 use fvm3::gas::PriceList as PriceList3;
 
-use fvm3_shared::{econ::TokenAmount as TokenAmount3, message::Message, version::NetworkVersion};
+use fvm3_shared::{message::Message, version::NetworkVersion};
 
 use fvm2_shared::{
     econ::TokenAmount as TokenAmount2, message::Message as Message2,
@@ -104,16 +104,12 @@ impl CgoExecutor for CgoExecutor2 {
                 from: Address2::from_bytes(&msg.from.to_bytes()).unwrap(),
                 to: Address2::from_bytes(&msg.to.to_bytes()).unwrap(),
                 sequence: msg.sequence,
-                value: unsafe { std::mem::transmute::<TokenAmount3, TokenAmount2>(msg.value) },
+                value: TokenAmount2::from_atto(msg.value.atto().clone()),
                 method_num: msg.method_num,
                 params: unsafe { std::mem::transmute::<RawBytes3, RawBytes2>(msg.params) },
                 gas_limit: msg.gas_limit,
-                gas_fee_cap: unsafe {
-                    std::mem::transmute::<TokenAmount3, TokenAmount2>(msg.gas_fee_cap)
-                },
-                gas_premium: unsafe {
-                    std::mem::transmute::<TokenAmount3, TokenAmount2>(msg.gas_premium)
-                },
+                gas_fee_cap: TokenAmount2::from_atto(msg.gas_fee_cap.atto().clone()),
+                gas_premium: TokenAmount2::from_atto(msg.gas_premium.atto().clone()),
             },
             unsafe { std::mem::transmute::<ApplyKind, ApplyKind2>(apply_kind) },
             raw_length,
@@ -189,12 +185,8 @@ impl AbstractMultiEngine for MultiEngine2 {
             network: cfg,
             epoch: ctx.network_context.epoch,
             initial_state_root: ctx.initial_state_root,
-            base_fee: unsafe {
-                std::mem::transmute::<TokenAmount3, TokenAmount2>(ctx.network_context.base_fee)
-            },
-            circ_supply: unsafe {
-                std::mem::transmute::<TokenAmount3, TokenAmount2>(ctx.circ_supply)
-            },
+            base_fee: TokenAmount2::from_atto(ctx.network_context.base_fee.atto().clone()),
+            circ_supply: TokenAmount2::from_atto(ctx.circ_supply.atto().clone()),
             tracing: ctx.tracing,
         };
 

--- a/rust/src/fvm/engine.rs
+++ b/rust/src/fvm/engine.rs
@@ -34,7 +34,7 @@ pub trait AbstractMultiEngine: Send + Sync {
         mctx: MachineContext,
         blockstore: OverlayBlockstore<CgoBlockstore>,
         externs: CgoExterns,
-    ) -> InnerFvmMachine;
+    ) -> anyhow::Result<InnerFvmMachine>;
 }
 
 // The generic engine container
@@ -131,22 +131,19 @@ mod v3 {
             ctx: MachineContext,
             blockstore: OverlayBlockstore<CgoBlockstore>,
             externs: CgoExterns,
-        ) -> InnerFvmMachine {
-            let engine = match self.get(&cfg) {
-                Ok(e) => e,
-                Err(err) => panic!("failed to create engine: {}", err),
-            };
-
-            let machine = CgoMachine3::new(&engine, &ctx, blockstore, externs).unwrap();
-            InnerFvmMachine {
+        ) -> anyhow::Result<InnerFvmMachine> {
+            let engine = self.get(&cfg)?;
+            let machine = CgoMachine3::new(&engine, &ctx, blockstore, externs)?;
+            Ok(InnerFvmMachine {
                 machine: Some(Mutex::new(Box::new(new_executor(machine)))),
-            }
+            })
         }
     }
 }
 
 // fvm v2 implementation
 mod v2 {
+    use anyhow::anyhow;
     use cid::Cid;
     use num_traits::FromPrimitive;
     use std::sync::Mutex;
@@ -259,7 +256,8 @@ mod v2 {
                                     } => Cause::Syscall {
                                         module,
                                         function,
-                                        error: ErrorNumber::from_u32(error as u32).unwrap(),
+                                        error: ErrorNumber::from_u32(error as u32)
+                                            .unwrap_or(ErrorNumber::AssertionFailed),
                                         message,
                                     },
                                     Cause2::Fatal {
@@ -308,9 +306,13 @@ mod v2 {
                             ExecutionEvent2::CallAbort(ec) => {
                                 Some(ExecutionEvent::CallAbort(ExitCode::new(ec.value())))
                             }
-                            ExecutionEvent2::CallError(err) => Some(ExecutionEvent::CallError(
-                                SyscallError(err.0, ErrorNumber::from_u32(err.1 as u32).unwrap()),
-                            )),
+                            ExecutionEvent2::CallError(err) => {
+                                Some(ExecutionEvent::CallError(SyscallError(
+                                    err.0,
+                                    ErrorNumber::from_u32(err.1 as u32)
+                                        .unwrap_or(ErrorNumber::AssertionFailed),
+                                )))
+                            }
                             _ => None,
                         })
                         .collect(),
@@ -332,8 +334,9 @@ mod v2 {
             ctx: MachineContext,
             blockstore: OverlayBlockstore<CgoBlockstore>,
             externs: CgoExterns,
-        ) -> InnerFvmMachine {
-            let ver = NetworkVersion2::try_from(cfg.network_version as u32).unwrap();
+        ) -> anyhow::Result<InnerFvmMachine> {
+            let ver = NetworkVersion2::try_from(cfg.network_version as u32)
+                .map_err(|nv| anyhow!("unsupported network version {nv}"))?;
             let cfg = NetworkConfig2 {
                 network_version: ver,
                 max_call_depth: cfg.max_call_depth,
@@ -344,10 +347,7 @@ mod v2 {
                 actor_redirect: cfg.actor_redirect,
             };
 
-            let engine = match self.get(&cfg) {
-                Ok(e) => e,
-                Err(err) => panic!("failed to create engine: {}", err),
-            };
+            let engine = self.get(&cfg)?;
 
             let ctx = MachineContext2 {
                 network: cfg,
@@ -358,10 +358,10 @@ mod v2 {
                 tracing: ctx.tracing,
             };
 
-            let machine = CgoMachine2::new(&engine, &ctx, blockstore, externs).unwrap();
-            InnerFvmMachine {
+            let machine = CgoMachine2::new(&engine, &ctx, blockstore, externs)?;
+            Ok(InnerFvmMachine {
                 machine: Some(Mutex::new(Box::new(new_executor(machine)))),
-            }
+            })
         }
     }
 }

--- a/rust/src/fvm/engine.rs
+++ b/rust/src/fvm/engine.rs
@@ -300,6 +300,7 @@ impl AbstractMultiEngine for MultiEngine2 {
     }
 }
 
+#[allow(clippy::new_without_default)]
 pub struct MultiEngineContainer {
     engines: Mutex<HashMap<u32, Arc<dyn AbstractMultiEngine + 'static>>>,
 }

--- a/rust/src/fvm/engine.rs
+++ b/rust/src/fvm/engine.rs
@@ -114,13 +114,11 @@ mod v3 {
             apply_kind: ApplyKind,
             raw_length: usize,
         ) -> anyhow::Result<ApplyRet> {
-            use fvm3::executor::Executor;
-            self.0.execute_message(msg, apply_kind, raw_length)
+            fvm3::executor::Executor::execute_message(self, msg, apply_kind, raw_length)
         }
 
         fn flush(&mut self) -> anyhow::Result<Cid> {
-            use fvm3::executor::Executor;
-            self.0.flush()
+            fvm3::executor::Executor::flush(self)
         }
     }
 
@@ -198,8 +196,8 @@ mod v2 {
             apply_kind: ApplyKind,
             raw_length: usize,
         ) -> anyhow::Result<ApplyRet> {
-            use fvm2::executor::Executor;
-            let res = self.0.execute_message(
+            let res = fvm2::executor::Executor::execute_message(
+                self,
                 Message2 {
                     version: msg.version,
                     from: Address2::from_bytes(&msg.from.to_bytes()).unwrap(),
@@ -322,8 +320,7 @@ mod v2 {
         }
 
         fn flush(&mut self) -> anyhow::Result<Cid> {
-            use fvm2::executor::Executor;
-            self.0.flush()
+            fvm2::executor::Executor::flush(self)
         }
     }
 

--- a/rust/src/fvm/engine.rs
+++ b/rust/src/fvm/engine.rs
@@ -40,7 +40,6 @@ use fvm2_shared::{
 use fvm2_shared::address::Address as Address2;
 
 use fvm2_ipld_encoding::RawBytes as RawBytes2;
-use fvm3_ipld_encoding::RawBytes as RawBytes3;
 
 use super::blockstore::{CgoBlockstore, OverlayBlockstore};
 use super::externs::CgoExterns;
@@ -106,7 +105,7 @@ impl CgoExecutor for CgoExecutor2 {
                 sequence: msg.sequence,
                 value: TokenAmount2::from_atto(msg.value.atto().clone()),
                 method_num: msg.method_num,
-                params: unsafe { std::mem::transmute::<RawBytes3, RawBytes2>(msg.params) },
+                params: RawBytes2::from(msg.params.to_vec()),
                 gas_limit: msg.gas_limit,
                 gas_fee_cap: TokenAmount2::from_atto(msg.gas_fee_cap.atto().clone()),
                 gas_premium: TokenAmount2::from_atto(msg.gas_premium.atto().clone()),

--- a/rust/src/fvm/engine.rs
+++ b/rust/src/fvm/engine.rs
@@ -39,9 +39,6 @@ use fvm3::machine::{
 use fvm2::DefaultKernel as DefaultKernel2;
 use fvm3::DefaultKernel as DefaultKernel3;
 
-use fvm2::gas::PriceList as PriceList2;
-use fvm3::gas::PriceList as PriceList3;
-
 use fvm3_shared::{
     address::Address, econ::TokenAmount, error::ErrorNumber, error::ExitCode, message::Message,
     receipt::Receipt, version::NetworkVersion,
@@ -271,13 +268,14 @@ impl AbstractMultiEngine for MultiEngine2 {
         blockstore: OverlayBlockstore<CgoBlockstore>,
         externs: CgoExterns,
     ) -> InnerFvmMachine {
+        let ver = NetworkVersion2::try_from(cfg.network_version as u32).unwrap();
         let cfg = NetworkConfig2 {
-            network_version: NetworkVersion2::try_from(cfg.network_version as u32).unwrap(),
+            network_version: ver,
             max_call_depth: cfg.max_call_depth,
             max_wasm_stack: cfg.max_wasm_stack,
             builtin_actors_override: cfg.builtin_actors_override,
             actor_debugging: cfg.actor_debugging,
-            price_list: unsafe { std::mem::transmute::<&PriceList3, &PriceList2>(cfg.price_list) },
+            price_list: fvm2::gas::price_list_by_network_version(ver),
             actor_redirect: cfg.actor_redirect,
         };
 

--- a/rust/src/fvm/externs.rs
+++ b/rust/src/fvm/externs.rs
@@ -12,7 +12,7 @@ use fvm2_shared::consensus::{
     ConsensusFault as ConsensusFault2, ConsensusFaultType as ConsensusFaultType2,
 };
 use fvm3_shared::consensus::{
-    ConsensusFault as ConsensusFault3, ConsensusFaultType as ConsensusFaultType3,
+    ConsensusFault as ConsensusFault3
 };
 
 use num_traits::FromPrimitive;
@@ -178,11 +178,7 @@ impl Consensus2 for CgoExterns {
                 Some(ConsensusFault2 {
                     target: Address2::from_bytes(&res.target.to_bytes()).unwrap(),
                     epoch: res.epoch,
-                    fault_type: unsafe {
-                        std::mem::transmute::<ConsensusFaultType3, ConsensusFaultType2>(
-                            res.fault_type,
-                        )
-                    },
+                    fault_type: ConsensusFaultType2::from_u8(res.fault_type as u8).unwrap(),
                 }),
                 x,
             )),

--- a/rust/src/fvm/externs.rs
+++ b/rust/src/fvm/externs.rs
@@ -109,7 +109,7 @@ impl Rand2 for CgoExterns {
         round: ChainEpoch,
         entropy: &[u8],
     ) -> anyhow::Result<[u8; 32]> {
-        Rand3::get_chain_randomness(self, pers, round, entropy)
+        Rand3::get_beacon_randomness(self, pers, round, entropy)
     }
 }
 

--- a/rust/src/fvm/externs.rs
+++ b/rust/src/fvm/externs.rs
@@ -1,8 +1,20 @@
 use anyhow::{anyhow, Context};
-use fvm3::externs::{Consensus, Externs, Rand};
+
+use fvm2::externs::{Consensus as Consensus2, Externs as Externs2, Rand as Rand2};
+use fvm3::externs::{Consensus as Consensus3, Externs as Externs3, Rand as Rand3};
+
+use fvm2_shared::address::Address as Address2;
 use fvm3_shared::address::Address;
+
 use fvm3_shared::clock::ChainEpoch;
-use fvm3_shared::consensus::ConsensusFault;
+
+use fvm2_shared::consensus::{
+    ConsensusFault as ConsensusFault2, ConsensusFaultType as ConsensusFaultType2,
+};
+use fvm3_shared::consensus::{
+    ConsensusFault as ConsensusFault3, ConsensusFaultType as ConsensusFaultType3,
+};
+
 use num_traits::FromPrimitive;
 
 use super::cgo::*;
@@ -23,7 +35,7 @@ impl CgoExterns {
     }
 }
 
-impl Rand for CgoExterns {
+impl Rand3 for CgoExterns {
     fn get_chain_randomness(
         &self,
         pers: i64,
@@ -83,13 +95,33 @@ impl Rand for CgoExterns {
     }
 }
 
-impl Consensus for CgoExterns {
+impl Rand2 for CgoExterns {
+    fn get_chain_randomness(
+        &self,
+        pers: i64,
+        round: ChainEpoch,
+        entropy: &[u8],
+    ) -> anyhow::Result<[u8; 32]> {
+        Rand3::get_chain_randomness(self, pers, round, entropy)
+    }
+
+    fn get_beacon_randomness(
+        &self,
+        pers: i64,
+        round: ChainEpoch,
+        entropy: &[u8],
+    ) -> anyhow::Result<[u8; 32]> {
+        Rand3::get_chain_randomness(self, pers, round, entropy)
+    }
+}
+
+impl Consensus3 for CgoExterns {
     fn verify_consensus_fault(
         &self,
         h1: &[u8],
         h2: &[u8],
         extra: &[u8],
-    ) -> anyhow::Result<(Option<ConsensusFault>, i64)> {
+    ) -> anyhow::Result<(Option<ConsensusFault3>, i64)> {
         unsafe {
             let mut miner_id: u64 = 0;
             let mut epoch: i64 = 0;
@@ -111,7 +143,7 @@ impl Consensus for CgoExterns {
                 0 => Ok((
                     match fault_type {
                         0 => None,
-                        _ => Some(ConsensusFault {
+                        _ => Some(ConsensusFault3 {
                             target: Address::new_id(miner_id),
                             epoch,
                             fault_type: FromPrimitive::from_i64(fault_type)
@@ -133,4 +165,32 @@ impl Consensus for CgoExterns {
     }
 }
 
-impl Externs for CgoExterns {}
+impl Consensus2 for CgoExterns {
+    fn verify_consensus_fault(
+        &self,
+        h1: &[u8],
+        h2: &[u8],
+        extra: &[u8],
+    ) -> anyhow::Result<(Option<ConsensusFault2>, i64)> {
+        let res = Consensus3::verify_consensus_fault(self, h1, h2, extra);
+        match res {
+            Ok((Some(res), x)) => Ok((
+                Some(ConsensusFault2 {
+                    target: Address2::from_bytes(&res.target.to_bytes()).unwrap(),
+                    epoch: res.epoch,
+                    fault_type: unsafe {
+                        std::mem::transmute::<ConsensusFaultType3, ConsensusFaultType2>(
+                            res.fault_type,
+                        )
+                    },
+                }),
+                x,
+            )),
+            Ok((None, x)) => Ok((None, x)),
+            Err(x) => Err(x),
+        }
+    }
+}
+
+impl Externs3 for CgoExterns {}
+impl Externs2 for CgoExterns {}

--- a/rust/src/fvm/externs.rs
+++ b/rust/src/fvm/externs.rs
@@ -1,8 +1,8 @@
 use anyhow::{anyhow, Context};
-use fvm::externs::{Consensus, Externs, Rand};
-use fvm_shared::address::Address;
-use fvm_shared::clock::ChainEpoch;
-use fvm_shared::consensus::ConsensusFault;
+use fvm3::externs::{Consensus, Externs, Rand};
+use fvm3_shared::address::Address;
+use fvm3_shared::clock::ChainEpoch;
+use fvm3_shared::consensus::ConsensusFault;
 use num_traits::FromPrimitive;
 
 use super::cgo::*;

--- a/rust/src/fvm/externs.rs
+++ b/rust/src/fvm/externs.rs
@@ -11,9 +11,7 @@ use fvm3_shared::clock::ChainEpoch;
 use fvm2_shared::consensus::{
     ConsensusFault as ConsensusFault2, ConsensusFaultType as ConsensusFaultType2,
 };
-use fvm3_shared::consensus::{
-    ConsensusFault as ConsensusFault3
-};
+use fvm3_shared::consensus::ConsensusFault as ConsensusFault3;
 
 use num_traits::FromPrimitive;
 

--- a/rust/src/fvm/machine.rs
+++ b/rust/src/fvm/machine.rs
@@ -19,11 +19,11 @@ use log::info;
 use safer_ffi::prelude::*;
 
 use super::blockstore::{CgoBlockstore, FakeBlockstore};
+use super::engine::*;
 use super::externs::CgoExterns;
 use super::types::*;
 use crate::destructor;
 use crate::util::types::{catch_panic_response, catch_panic_response_no_default, Result};
-use super::engine::*;
 
 lazy_static! {
     static ref ENGINES: MultiEngineContainer = MultiEngineContainer::new();
@@ -450,11 +450,11 @@ mod test {
     use crate::fvm3::machine::build_lotus_trace;
     use fvm3::kernel::SyscallError;
     use fvm3::trace::ExecutionEvent;
+    use fvm3_ipld_encoding::RawBytes;
     use fvm3_shared::address::Address;
     use fvm3_shared::econ::TokenAmount;
     use fvm3_shared::error::ErrorNumber::IllegalArgument;
     use fvm3_shared::ActorID;
-    use fvm_ipld_encoding::RawBytes;
 
     #[test]
     fn test_lotus_trace() {

--- a/rust/src/fvm/machine.rs
+++ b/rust/src/fvm/machine.rs
@@ -1,23 +1,11 @@
 use std::borrow::Cow;
-use std::collections::hash_map::Entry;
-use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
-use std::sync::{Arc, Mutex};
 
 use anyhow::{anyhow, bail, Context};
 use cid::Cid;
-use fvm3::call_manager::DefaultCallManager as DefaultCallManager3;
-use fvm3::executor::{
-    ApplyKind as ApplyKind3, ApplyRet as ApplyRet3, DefaultExecutor as DefaultExecutor3,
-    ThreadedExecutor as ThreadedExecutor3,
-};
+use fvm3::executor::ApplyKind as ApplyKind3;
 use fvm3::gas::GasCharge;
-use fvm3::machine::{
-    DefaultMachine as DefaultMachine3, MachineContext as MachineContext3,
-    MultiEngine as MultiEngine3, NetworkConfig as NetworkConfig3,
-};
 use fvm3::trace::ExecutionEvent;
-use fvm3::DefaultKernel as DefaultKernel3;
 use fvm3_ipld_encoding::tuple::{Deserialize_tuple, Serialize_tuple};
 use fvm3_ipld_encoding::{to_vec, CborStore, RawBytes};
 use fvm3_shared::address::Address;
@@ -30,108 +18,12 @@ use lazy_static::lazy_static;
 use log::info;
 use safer_ffi::prelude::*;
 
-use super::blockstore::{CgoBlockstore, FakeBlockstore, OverlayBlockstore};
+use super::blockstore::{CgoBlockstore, FakeBlockstore};
 use super::externs::CgoExterns;
 use super::types::*;
 use crate::destructor;
 use crate::util::types::{catch_panic_response, catch_panic_response_no_default, Result};
-
-type CgoMachine3 = DefaultMachine3<OverlayBlockstore<CgoBlockstore>, CgoExterns>;
-type BaseExecutor3 = DefaultExecutor3<DefaultKernel3<DefaultCallManager3<CgoMachine3>>>;
-
-pub type CgoExecutor3 = ThreadedExecutor3<BaseExecutor3>;
-
-fn new_executor3(machine: CgoMachine3) -> CgoExecutor3 {
-    ThreadedExecutor3(BaseExecutor3::new(machine))
-}
-
-pub trait CgoExecutor {
-    fn execute_message(
-        &mut self,
-        msg: Message,
-        apply_kind: ApplyKind3,
-        raw_length: usize,
-    ) -> anyhow::Result<ApplyRet3>;
-
-    fn flush(&mut self) -> anyhow::Result<Cid>;
-}
-
-impl CgoExecutor for CgoExecutor3 {
-    fn execute_message(
-        &mut self,
-        msg: Message,
-        apply_kind: ApplyKind3,
-        raw_length: usize,
-    ) -> anyhow::Result<ApplyRet3> {
-        use fvm3::executor::Executor;
-        self.0.execute_message(msg, apply_kind, raw_length)
-    }
-
-    fn flush(&mut self) -> anyhow::Result<Cid> {
-        use fvm3::executor::Executor;
-        self.0.flush()
-    }
-}
-
-trait AbstractMultiEngine: Send + Sync {
-    fn new_executor(
-        &self,
-        ncfg: NetworkConfig3,
-        mctx: MachineContext3,
-        blockstore: OverlayBlockstore<CgoBlockstore>,
-        externs: CgoExterns,
-    ) -> InnerFvmMachine;
-}
-
-impl AbstractMultiEngine for MultiEngine3 {
-    fn new_executor(
-        &self,
-        cfg: NetworkConfig3,
-        ctx: MachineContext3,
-        blockstore: OverlayBlockstore<CgoBlockstore>,
-        externs: CgoExterns,
-    ) -> InnerFvmMachine {
-        let engine = match self.get(&cfg) {
-            Ok(e) => e,
-            Err(err) => panic!("failed to create engine: {}", err),
-        };
-
-        let machine = CgoMachine3::new(&engine, &ctx, blockstore, externs).unwrap();
-        InnerFvmMachine {
-            machine: Some(Mutex::new(Box::new(new_executor3(machine)))),
-        }
-    }
-}
-
-struct MultiEngineContainer {
-    engines: Mutex<HashMap<u32, Arc<dyn AbstractMultiEngine + 'static>>>,
-}
-
-impl MultiEngineContainer {
-    fn new() -> MultiEngineContainer {
-        MultiEngineContainer {
-            engines: Mutex::new(HashMap::new()),
-        }
-    }
-
-    fn get(&self, nv: NetworkVersion) -> anyhow::Result<Arc<dyn AbstractMultiEngine + 'static>> {
-        let mut locked = self.engines.lock().unwrap();
-        Ok(match locked.entry(nv as u32) {
-            Entry::Occupied(v) => v.get().clone(),
-            Entry::Vacant(v) => v
-                .insert(match nv {
-                    //NetworkVersion::V16 | NetworkVersion::V17 => {
-                    //    Arc::new(MultiEngine2::new()) as Arc<dyn AbstractMultiEngine + 'static>
-                    //}
-                    NetworkVersion::V18 => {
-                        Arc::new(MultiEngine3::new()) as Arc<dyn AbstractMultiEngine + 'static>
-                    }
-                    _ => return Err(anyhow!("network version not supported")),
-                })
-                .clone(),
-        })
-    }
-}
+use super::engine::*;
 
 lazy_static! {
     static ref ENGINES: MultiEngineContainer = MultiEngineContainer::new();

--- a/rust/src/fvm/machine.rs
+++ b/rust/src/fvm/machine.rs
@@ -447,7 +447,7 @@ fn build_lotus_trace(
 
 #[cfg(test)]
 mod test {
-    use crate::fvm3::machine::build_lotus_trace;
+    use crate::fvm::machine::build_lotus_trace;
     use fvm3::kernel::SyscallError;
     use fvm3::trace::ExecutionEvent;
     use fvm3_ipld_encoding::RawBytes;

--- a/rust/src/fvm/machine.rs
+++ b/rust/src/fvm/machine.rs
@@ -127,7 +127,7 @@ fn create_fvm_machine_generic(
                 machine_context,
                 blockstore,
                 externs,
-            ))))
+            )?)))
         })
     }
 }

--- a/rust/src/fvm/mod.rs
+++ b/rust/src/fvm/mod.rs
@@ -2,8 +2,8 @@ mod blockstore;
 mod cgo;
 mod externs;
 
+pub mod engine;
 pub mod machine;
 pub mod types;
-pub mod engine;
 
 pub use cgo::FvmError;

--- a/rust/src/fvm/mod.rs
+++ b/rust/src/fvm/mod.rs
@@ -4,5 +4,6 @@ mod externs;
 
 pub mod machine;
 pub mod types;
+pub mod engine;
 
 pub use cgo::FvmError;

--- a/rust/src/fvm/types.rs
+++ b/rust/src/fvm/types.rs
@@ -2,7 +2,7 @@ use std::sync::Mutex;
 
 use safer_ffi::prelude::*;
 
-use super::machine::CgoExecutor;
+use super::engine::CgoExecutor;
 
 #[derive_ReprC]
 #[repr(u8)]

--- a/rust/src/fvm/types.rs
+++ b/rust/src/fvm/types.rs
@@ -15,7 +15,7 @@ pub enum FvmRegisteredVersion {
 #[ReprC::opaque]
 #[derive(Default)]
 pub struct InnerFvmMachine {
-    pub(crate) machine: Option<Mutex<CgoExecutor>>,
+    pub(crate) machine: Option<Mutex<Box<dyn CgoExecutor>>>,
 }
 
 pub type FvmMachine = Option<repr_c::Box<InnerFvmMachine>>;


### PR DESCRIPTION
This adds support for multiple fvm versions behind the same facade to the client, with dispatch based on the network version.
It allows us to host multiple network versions in the same client, including in development things, without blocking ourselves on backwards compatibility.