### PR TITLE
chore: update fvm to 3.0.0-alpha.9

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1198,7 +1198,7 @@ dependencies = [
  "filepath",
  "fr32",
  "fvm 2.1.0",
- "fvm 3.0.0-alpha.8",
+ "fvm 3.0.0-alpha.9",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.2",
  "fvm_ipld_encoding 0.3.0",
@@ -1423,9 +1423,9 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "3.0.0-alpha.8"
+version = "3.0.0-alpha.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d558a9216545732649d0cc0d2d4c703b330103367f1f5353a27fa77309effb2f"
+checksum = "289d9b8bd8fefa72de124c59fb66136af5147696a5aa714a4ae6ed0674dfa663"
 dependencies = [
  "anyhow",
  "blake2b_simd",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -37,7 +37,7 @@ memmap = "0.7"
 rust-gpu-tools = { version = "0.5", optional = true, default-features = false }
 storage-proofs-porep = { version = "~12.0", default-features = false }
 fr32 = { version = "~5.0", default-features = false }
-fvm3 = { package = "fvm", version = "3.0.0-alpha.8", default-features = false, features = ["f4-as-account"] }
+fvm3 = { package = "fvm", version = "3.0.0-alpha.9", default-features = false, features = ["f4-as-account"] }
 fvm3_shared = { package = "fvm_shared", version = "3.0.0-alpha.11" }
 fvm3_ipld_encoding = { package = "fvm_ipld_encoding", version = "0.3.0" }
 fvm2 = { package = "fvm", version = "2.1.0", default-features = false }


### PR DESCRIPTION
Fixes a bug where flushing events would clear the blockstore's write buffer.