### PR TITLE
feat: use the new unsafe.Slice method instead of casting arrays

### DIFF
--- a/cgo/blockstore.go
+++ b/cgo/blockstore.go
@@ -93,14 +93,14 @@ func cgo_blockstore_put_many(handle C.uint64_t, lengths *C.int32_t, lengthsLen C
 		return ErrInvalidArgument
 	}
 
-	lengthsGo := (*[MAX_LEN]C.int32_t)(unsafe.Pointer(lengths))[:lengthsLen:lengthsLen]
+	lengthsGo := unsafe.Slice(lengths, lengthsLen)
 	blocksGo := make([]blocks.Block, 0, lengthsLen)
 	for _, length := range lengthsGo {
 		if length > MAX_LEN {
 			return ErrInvalidArgument
 		}
 		// get the next buffer. We could use C.GoBytes, but that copies.
-		buf := (*[MAX_LEN]byte)(unsafe.Pointer(blockBuf))[:length:length]
+		buf := unsafe.Slice((*byte)(unsafe.Pointer(blockBuf)), length)
 
 		// read the CID. This function will copy the CID internally.
 		cidLen, k, err := cid.CidFromBytes(buf)

--- a/cgo/extern.go
+++ b/cgo/extern.go
@@ -27,7 +27,7 @@ func cgo_extern_get_chain_randomness(
 		}
 	}()
 
-	out := (*[32]byte)(unsafe.Pointer(output))
+	out := unsafe.Slice((*byte)(unsafe.Pointer(output)), 32)
 	externs, ctx := Lookup(uint64(handle))
 	if externs == nil {
 		return ErrInvalidHandle
@@ -57,7 +57,7 @@ func cgo_extern_get_beacon_randomness(
 		}
 	}()
 
-	out := (*[32]byte)(unsafe.Pointer(output))
+	out := unsafe.Slice((*byte)(unsafe.Pointer(output)), 32)
 	externs, ctx := Lookup(uint64(handle))
 	if externs == nil {
 		return ErrInvalidHandle


### PR DESCRIPTION
Previously, in cgo, we had to rely on casting pointers to fixed-sized arrays then slicing. But upstream has added an `unsafe.Slice` method, so we can remove this hack.