### PR TITLE
Add aarch64 Linux build, test, and publish to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,25 @@ jobs:
       - run:
           command: make go-lint
 
+  build_and_test_aarch64_linux_cgo_bindings:
+    parameters:
+      run_leak_detector:
+        type: boolean
+        default: true
+    machine:
+      image: ubuntu-2004:current
+    resource_class: arm.large
+    working_directory: ~/go/src/github.com/filecoin-project/filecoin-ffi
+    steps:
+      - configure_environment_variables
+      - prepare
+      - build_project
+      - restore_parameter_cache
+      - obtain_filecoin_parameters
+      - save_parameter_cache
+      - run: cd rust && rustup target add wasm32-unknown-unknown
+      - run_tests
+
   build_and_test_linux_cgo_bindings:
     parameters:
       run_leak_detector:
@@ -68,8 +87,16 @@ jobs:
       - run: cd rust && cargo install cargo-lipo
       - build_project
       - compile_tests
-  publish_linux_staticlib:
+  publish_linux_x86_64_staticlib:
     executor: golang
+    steps:
+      - configure_environment_variables
+      - prepare
+      - publish_release
+  publish_linux_aarch64_staticlib:
+    machine:
+      image: ubuntu-2004:current
+    resource_class: arm.large
     steps:
       - configure_environment_variables
       - prepare
@@ -167,13 +194,21 @@ workflows:
       - go_lint
       - build_and_test_linux_cgo_bindings:
           run_leak_detector: false
-      - publish_linux_staticlib:
+      - build_and_test_aarch64_linux_cgo_bindings:
+          run_leak_detector: false
+      - build_darwin_cgo_bindings
+      - publish_linux_x86_64_staticlib:
           filters:
             tags:
               only: /^v.*/
             branches:
               ignore: /.*/
-      - build_darwin_cgo_bindings
+      - publish_linux_aarch64_staticlib:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
       - publish_darwin_staticlib:
           filters:
             tags:
@@ -231,8 +266,8 @@ commands:
           command: |
             cd rust
 
-            TARBALL_PATH="/tmp/${CIRCLE_PROJECT_REPONAME}-$(uname)-standard.tar.gz"
-            RELEASE_NAME="${CIRCLE_PROJECT_REPONAME}-$(uname)-standard"
+            TARBALL_PATH="/tmp/${CIRCLE_PROJECT_REPONAME}-$(uname)-$(uname -m)-standard.tar.gz"
+            RELEASE_NAME="${CIRCLE_PROJECT_REPONAME}-$(uname)-$(uname -m)-standard"
 
             # Note: the blst dependency uses the portable configuration for maximum compatibility
             ./scripts/build-release.sh filcrypto $(cat ./rust-toolchain) build --verbose --no-default-features --features multicore-sdr,opencl,blst-portable
@@ -243,7 +278,7 @@ commands:
           command: |
             cd rust
 
-            TARBALL_PATH="/tmp/${CIRCLE_PROJECT_REPONAME}-$(uname)-optimized.tar.gz"
+            TARBALL_PATH="/tmp/${CIRCLE_PROJECT_REPONAME}-$(uname)-$(uname -m)-optimized.tar.gz"
             RUSTFLAGS="-C target-feature=$(cat rustc-target-features-optimized.json | jq -r '.[].rustc_target_feature' | tr '\n' ',')"
 
             ./scripts/build-release.sh filcrypto $(cat ./rust-toolchain) build --verbose --no-default-features --features multicore-sdr,opencl

--- a/install-filcrypto
+++ b/install-filcrypto
@@ -92,7 +92,12 @@ download_release_tarball() {
     # names are constructed. Marginally less-bad would be to require that this
     # function's caller provide the release name.
     #
-    local __release_name="${__repo_name}-$(uname)-${release_flag_name}"
+    if [ "$(uname -s)" = "Darwin" ]; then
+        # For MacOS a universal library is used so naming convention is different
+        local __release_name="${__repo_name}-$(uname)-${release_flag_name}"
+    else
+        local __release_name="${__repo_name}-$(uname)-$(uname -m)-${release_flag_name}"
+    fi
 
     (>&2 echo "[download_release_tarball] acquiring release @ ${__release_tag}")
 


### PR DESCRIPTION
 - Rename circleci artifact tarbal names to differentiate x86_64 and aarch64

 - Add circleci build, test, and publish for aarch64