### PR TITLE
chore: Fix build with Go 1.20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,12 @@ all: $(DEPS)
 $(DEPS): .install-filcrypto  ;
 
 .install-filcrypto: rust
-	go clean -cache -testcache .
+	go clean -cache -testcache
 	./install-filcrypto
 	@touch $@
 
 clean:
-	go clean -cache -testcache .
+	go clean -cache -testcache
 	rm -rf $(DEPS) .install-filcrypto
 	rm -f ./runner
 	cd rust && cargo clean && cd ..


### PR DESCRIPTION
Go 1.20 changed how `go clean` works

```
$ go clean -cache -testcache .
go: clean -cache cannot be used with package arguments
```