### PR TITLE
chore: update fvm

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
  "filepath",
  "fr32",
  "fvm 2.2.0",
- "fvm 3.0.0-alpha.24",
+ "fvm 3.0.0-rc.1",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
  "fvm_ipld_encoding 0.3.3",
@@ -1443,9 +1443,9 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "3.0.0-alpha.24"
+version = "3.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "560201e145435e4a3741fe5e6f37b7854273af9f344ca13957232ccb58834a1f"
+checksum = "9efd2ca858542b73acd5f679bac84ab9de2af8ccb35a3528e414e08b85e55982"
 dependencies = [
  "anyhow",
  "blake2b_simd",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -34,7 +34,7 @@ serde_json = "1.0.46"
 memmap = "0.7"
 rust-gpu-tools = { version = "0.5", optional = true, default-features = false }
 fr32 = { version = "~5.0", default-features = false }
-fvm3 = { package = "fvm", version = "3.0.0-alpha.24", default-features = false }
+fvm3 = { package = "fvm", version = "3.0.0-rc.1", default-features = false }
 fvm3_shared = { package = "fvm_shared", version = "3.0.0-alpha.20" }
 fvm3_ipld_encoding = { package = "fvm_ipld_encoding", version = "0.3.3" }
 fvm2 = { package = "fvm", version = "2.2.0", default-features = false }


### PR DESCRIPTION
This removes a limit to event sizes that should never have been added.