### PR TITLE
chore: merge v1.20.0 release branch into master

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1220,12 +1220,12 @@ dependencies = [
  "filepath",
  "fr32",
  "fvm 2.2.0",
- "fvm 3.0.0-rc.1",
+ "fvm 3.0.0",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
  "fvm_ipld_encoding 0.3.3",
  "fvm_shared 2.0.0",
- "fvm_shared 3.0.0-alpha.20",
+ "fvm_shared 3.0.0",
  "group",
  "lazy_static",
  "libc",
@@ -1443,9 +1443,9 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "3.0.0-rc.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9efd2ca858542b73acd5f679bac84ab9de2af8ccb35a3528e414e08b85e55982"
+checksum = "6a3f6473e96a12c4d4856c013c9940e3b130ac1e6821b42f232b0c9a31d2f683"
 dependencies = [
  "anyhow",
  "blake2b_simd",
@@ -1460,7 +1460,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt 0.6.1",
- "fvm_shared 3.0.0-alpha.20",
+ "fvm_shared 3.0.0",
  "lazy_static",
  "log",
  "minstant",
@@ -1656,9 +1656,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "3.0.0-alpha.20"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b594b4d4c1393f03e3430f106c09874fcac565e68a560686de37ca2982a61d1a"
+checksum = "c99c06aa865e34198d9ca0da54e53e2fca14ae9ce5402f51b7c8e78175205861"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -34,8 +34,8 @@ serde_json = "1.0.46"
 memmap = "0.7"
 rust-gpu-tools = { version = "0.5", optional = true, default-features = false }
 fr32 = { version = "~5.0", default-features = false }
-fvm3 = { package = "fvm", version = "3.0.0-rc.1", default-features = false }
-fvm3_shared = { package = "fvm_shared", version = "3.0.0-alpha.20" }
+fvm3 = { package = "fvm", version = "3.0.0", default-features = false }
+fvm3_shared = { package = "fvm_shared", version = "3.0.0" }
 fvm3_ipld_encoding = { package = "fvm_ipld_encoding", version = "0.3.3" }
 fvm2 = { package = "fvm", version = "2.2.0", default-features = false }
 fvm2_shared = { package = "fvm_shared", version = "2.0.0" }


### PR DESCRIPTION
Just updates the crates to the FVM3 final crate, identical to the RC being used in master.

We should do a single merge-commit for this.