### PR TITLE
ci: publish releases on tag (fixed)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -167,9 +167,19 @@ workflows:
       - go_lint
       - build_and_test_linux_cgo_bindings:
           run_leak_detector: false
-      - publish_linux_staticlib
+      - publish_linux_staticlib:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
       - build_darwin_cgo_bindings
-      - publish_darwin_staticlib
+      - publish_darwin_staticlib:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
 
 commands:
   prepare:

--- a/rust/scripts/publish-release.sh
+++ b/rust/scripts/publish-release.sh
@@ -18,15 +18,6 @@ main() {
     local __release_file=$1
     local __release_name=$2
     local __release_tag="${CIRCLE_SHA1:0:16}"
-    local __release_tag_name="${CIRCLE_TAG:-default}"
-
-    # Only publish if a release tag starting with 'v' was pushed
-    if [[ ! -z ${__release_tag_name} && ${__release_tag_name} =~ ^v.*$ ]]; then
-        echo "Publishing due to release tag: ${__release_tag_name}"
-    else
-        echo "NOT Publishing due to unsupported release tag: ${__release_tag_name}"
-        exit 0
-    fi
 
     # make sure we have a token set, api requests won't work otherwise
     if [ -z $GITHUB_TOKEN ]; then


### PR DESCRIPTION
This version relies on CircleCI's tag filter to only run the publish jobs on tags. The prior version didn't work because we were only running workflows on commits, not tags.

Everything was working fine for the release branch because the release branch was cut before that change was made.