### PR TITLE
Enable CUDA as default GPU backend if available

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,6 +283,7 @@ commands:
             echo 'export PATH="/usr/local/go/bin:${HOME}/.cargo/bin:${PATH}:${HOME}/go/bin:${HOME}/.bin"' >> $BASH_ENV
             echo 'export RUST_LOG=info' >> $BASH_ENV
             echo 'export CIRCLE_ARTIFACTS="/tmp"' >> $BASH_ENV
+            echo 'export FFI_USE_OPENCL=1' >> $BASH_ENV
       - when:
           condition: << parameters.darwin >>
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -324,7 +324,7 @@ commands:
                 no_output_timeout: 90m
       - run:
           name: Run the Rust tests
-          command: cd rust && FIL_PROOFS_PARAMETER_CACHE="${HOME}/filecoin-proof-parameters/" RUST_LOG=info cargo test --all --release -- --test-threads 1&& cd ..
+          command: cd rust && FIL_PROOFS_PARAMETER_CACHE="${HOME}/filecoin-proof-parameters/" RUST_LOG=info cargo test --no-default-features --features multicore-sdr,opencl --all --release -- --test-threads 1&& cd ..
           no_output_timeout: 90m
       - run:
           name: Run the Go tests

--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ rm .install-filcrypto \
     ; FFI_BUILD_FROM_SOURCE=1 FFI_USE_GPU=0 make
 ```
 
-#### Experimental CUDA build support
+#### GPU support
 
-An experimental 'gpu' option using CUDA can be used in the proofs library.  This feature is disabled by default (opencl is the default, when `FFI_USE_GPU=1` is set.).  To enable building with the 'gpu' CUDA dependency, set `FFI_USE_CUDA=1` when building from source.
+CUDA for GPU support is now enabled by default in the proofs library.  This feature can optionally be replaced by OpenCL by using `FFI_USE_OPENCL=1` set in the environment when building from source.  Alternatively, if the CUDA toolkit (such as `nvcc`) cannot be located in the environment, OpenCL support is used instead.  To disable GPU support entirely, set `FFI_USE_GPU=0` in the environment when building from source.
 
 ```shell
 rm .install-filcrypto \
     ; make clean \
-    ; FFI_BUILD_FROM_SOURCE=1 FFI_USE_CUDA=1 make
+    ; FFI_BUILD_FROM_SOURCE=1 make
 ```
 
 By default, a 'multicore-sdr' option is used in the proofs library.  This feature is also used in FFI unless explicitly disabled.  To disable building with the 'multicore-sdr' dependency, set `FFI_USE_MULTICORE_SDR=0`:

--- a/install-filcrypto
+++ b/install-filcrypto
@@ -179,7 +179,7 @@ build_from_source() {
         if [ "${FFI_USE_OPENCL}" == "1" ] || [ "$(uname -s)" = "Darwin" ]; then
             gpu_flags=",opencl"
         else
-            if [ ! -v "nvcc" ]; then
+            if [ ! "$(command -v nvcc)" ]; then
                 echo "WARNING: Cannot find nvcc for CUDA support."
                 echo "WARNING: For CUDA support, please ensure that the CUDA toolkit is properly installed."
                 echo "WARNING: After installation, nvcc must be in the system path."

--- a/install-filcrypto
+++ b/install-filcrypto
@@ -179,7 +179,7 @@ build_from_source() {
         if [ "${FFI_USE_OPENCL}" == "1" ]; then
             gpu_flags=",opencl"
         else
-            if [ -z "$(which nvcc)" ]; then
+            if [ ! -v "nvcc" ]; then
                 echo "WARNING: Cannot find nvcc for CUDA support."
                 echo "WARNING: For CUDA support, please ensure that the CUDA toolkit is properly installed."
                 echo "WARNING: After installation, nvcc must be in the system path."

--- a/install-filcrypto
+++ b/install-filcrypto
@@ -165,25 +165,28 @@ build_from_source() {
         build="build"
     fi
 
-    # Default to use gpu flags, unless specified to disable
-    gpu_flags=",cuda"
-    if [ "${FFI_USE_OPENCL}" == "1" ]; then
-        gpu_flags=",opencl"
-    fi
-
+    # Check if GPU support is disabled.
     if [ "${FFI_USE_GPU}" == "0" ]; then
         gpu_flags=""
     else
+        # If not, default to CUDA support where possible.
         # First ensure that nvcc (as part of the CUDA toolkit) is
         # available -- if it's not warn that we are defaulting GPU to
         # OpenCL instead.
-        if [ -z "$(which nvcc)" ]; then
-            echo "WARNING: Cannot find nvcc for CUDA support."
-            echo "WARNING: For CUDA support, please ensure that the CUDA toolkit is properly installed."
-            echo "WARNING: After installation, nvcc must be in the system path."
-            echo ""
-            echo "WARNING: Defaulting to OpenCL GPU support(!!!)"
+        gpu_flags=",cuda"
+
+        # Unless OpenCL support is specified.
+        if [ "${FFI_USE_OPENCL}" == "1" ]; then
             gpu_flags=",opencl"
+        else
+            if [ -z "$(which nvcc)" ]; then
+                echo "WARNING: Cannot find nvcc for CUDA support."
+                echo "WARNING: For CUDA support, please ensure that the CUDA toolkit is properly installed."
+                echo "WARNING: After installation, nvcc must be in the system path."
+                echo ""
+                echo "WARNING: Defaulting to OpenCL GPU support(!!!)"
+                gpu_flags=",opencl"
+            fi
         fi
     fi
 

--- a/install-filcrypto
+++ b/install-filcrypto
@@ -175,8 +175,8 @@ build_from_source() {
         # OpenCL instead.
         gpu_flags=",cuda"
 
-        # Unless OpenCL support is specified.
-        if [ "${FFI_USE_OPENCL}" == "1" ]; then
+        # Unless OpenCL support is specified or we're building on Darwin.
+        if [ "${FFI_USE_OPENCL}" == "1" ] || [ "$(uname -s)" = "Darwin" ]; then
             gpu_flags=",opencl"
         else
             if [ ! -v "nvcc" ]; then

--- a/install-filcrypto
+++ b/install-filcrypto
@@ -166,12 +166,25 @@ build_from_source() {
     fi
 
     # Default to use gpu flags, unless specified to disable
-    gpu_flags=",opencl"
-    if [ "${FFI_USE_CUDA}" == "1" ]; then
-        gpu_flags=",cuda"
+    gpu_flags=",cuda"
+    if [ "${FFI_USE_OPENCL}" == "1" ]; then
+        gpu_flags=",opencl"
     fi
+
     if [ "${FFI_USE_GPU}" == "0" ]; then
         gpu_flags=""
+    else
+        # First ensure that nvcc (as part of the CUDA toolkit) is
+        # available -- if it's not warn that we are defaulting GPU to
+        # OpenCL instead.
+        if [ -z "$(which nvcc)" ]; then
+            echo "WARNING: Cannot find nvcc for CUDA support."
+            echo "WARNING: For CUDA support, please ensure that the CUDA toolkit is properly installed."
+            echo "WARNING: After installation, nvcc must be in the system path."
+            echo ""
+            echo "WARNING: Defaulting to OpenCL GPU support(!!!)"
+            gpu_flags=",opencl"
+        fi
     fi
 
     # Default to use multicore_sdr flags, unless specified to disable

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -57,9 +57,9 @@ memmap2 = "0.5"
 tempfile = "3.0.8"
 
 [features]
-default = ["opencl", "multicore-sdr" ]
+default = ["cuda", "multicore-sdr" ]
 blst-portable = ["bls-signatures/blst-portable", "blstrs/portable"]
-opencl = ["filecoin-proofs-api/opencl", "rust-gpu-tools/opencl", "fvm3/opencl", "fvm2/opencl"]
 cuda = ["filecoin-proofs-api/cuda", "rust-gpu-tools/cuda", "fvm3/cuda", "fvm2/cuda"]
+opencl = ["filecoin-proofs-api/opencl", "rust-gpu-tools/opencl", "fvm3/opencl", "fvm2/opencl"]
 multicore-sdr = ["filecoin-proofs-api/multicore-sdr"]
 c-headers = ["safer-ffi/headers"]

--- a/rust/scripts/build-release.sh
+++ b/rust/scripts/build-release.sh
@@ -66,7 +66,7 @@ main() {
 
     # generate filcrypto.h
     RUSTFLAGS="${__rust_flags}" HEADER_DIR="." \
-        cargo test --locked build_headers --features c-headers
+        cargo test --no-default-features --features multicore-sdr,opencl --locked build_headers --features c-headers
 
     # generate pkg-config
     #


### PR DESCRIPTION
If CUDA is found in the environment, it will be enabled unless `FFI_USE_OPENCL=1` is set.  If CUDA is not found by default or if building on Darwin, OpenCL will be used instead.  If `FFI_NO_GPU=1`, no GPU support will be used.