### PR TITLE
chore: attempt to read git commit id from environment variable

### DIFF
--- a/install-filcrypto
+++ b/install-filcrypto
@@ -133,7 +133,7 @@ build_from_source() {
     local __library_name=$1
     local __rust_sources_path=$2
     local __release_flags=$3
-    local __repo_sha1=$(git rev-parse HEAD)
+    local __repo_sha1=${FFI_GIT_COMMIT:-$(git rev-parse HEAD)}
     local __repo_sha1_truncated="${__repo_sha1:0:16}"
 
     (>&2 echo "building from source @ ${__repo_sha1_truncated}")


### PR DESCRIPTION
Reading git commit id from environment variable can be useful when building Docker images