### PR TITLE
feat: make the FVM concurrency configurable and set the default to 4

### DIFF
--- a/rust/src/fvm/machine.rs
+++ b/rust/src/fvm/machine.rs
@@ -26,7 +26,7 @@ use crate::destructor;
 use crate::util::types::{catch_panic_response, catch_panic_response_no_default, Result};
 
 lazy_static! {
-    static ref ENGINES: MultiEngineContainer = MultiEngineContainer::new();
+    static ref ENGINES: MultiEngineContainer = MultiEngineContainer::new_env();
 }
 
 #[allow(clippy::too_many_arguments)]


### PR DESCRIPTION
Previously, we were limited to 1 message at a time.