### PR TITLE
WIP Add par_scan and par bridge and bump Rayon to 1.5.0 

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -28,7 +28,7 @@ log = "0.4.7"
 fil_logger = "0.1.6"
 rand = "0.8"
 rand_chacha = "0.3.1"
-rayon = "1.2.1"
+rayon = "1.5.0"
 anyhow = "1.0.23"
 serde_json = "1.0.46"
 rust-gpu-tools = { version = "0.6", optional = true, default-features = false }

--- a/rust/src/bls/api.rs
+++ b/rust/src/bls/api.rs
@@ -167,7 +167,7 @@ pub fn hash_verify(
 
     // split the flattened message array into slices of individual messages to be hashed
     let messages: Vec<_> = message_sizes
-        .par_scan(0, |offset, chunk_size| {
+        .scan(0, |offset, chunk_size| {
             let slice = &flattened_messages[*offset..*offset + *chunk_size];
             *offset += *chunk_size;
             Some(slice)


### PR DESCRIPTION
Add par_scan and par bridge and bump Rayon to 1.5.0 as there is dependency to at least version 1.5.0. for the methods