### PR TITLE
chore: deps: update to FVM 3.3.1 crates

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1136,7 +1136,7 @@ dependencies = [
  "filepath",
  "fr32 6.0.0",
  "fvm 2.3.0",
- "fvm 3.3.0",
+ "fvm 3.3.1",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.2.3",
  "fvm_ipld_encoding 0.3.3",
@@ -1442,9 +1442,9 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "3.3.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f7ba8142f9f44bf2318c1462c9d346d4391095b3ca0272f56ca8e5eb97cc0bb"
+checksum = "8002580816862be6681259cf5ad4217f47046edace1d4a339e11e8682aad241b"
 dependencies = [
  "anyhow",
  "byteorder",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -33,7 +33,7 @@ anyhow = "1.0.23"
 serde_json = "1.0.46"
 rust-gpu-tools = { version = "0.6", optional = true, default-features = false }
 fr32 = { version = "~6.0", default-features = false }
-fvm3 = { package = "fvm", version = "~3.3", default-features = false }
+fvm3 = { package = "fvm", version = "~3.3.1", default-features = false }
 fvm3_shared = { package = "fvm_shared", version = "~3.3" }
 fvm3_ipld_encoding = { package = "fvm_ipld_encoding", version = "0.3.3" }
 fvm2 = { package = "fvm", version = "~2.3", default-features = false }


### PR DESCRIPTION
This will be needed for users who wish to sync calibnet.