### PR TITLE
feat: add new fields to message trace for supporting new trace api

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1252,7 +1252,7 @@ dependencies = [
  "filepath",
  "fr32 7.0.0",
  "fvm 2.6.0",
- "fvm 3.6.0",
+ "fvm 3.7.0",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_shared 2.5.0",
@@ -1559,9 +1559,9 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c4c28467e3781fcfa97a47eedd1e05eb68fb0b2099a345a373e83cafe47a119"
+checksum = "a18c99b65d6210f87addf30511f677edd89200d93798f74bdb64fb14d94c335c"
 dependencies = [
  "anyhow",
  "blake2b_simd",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -33,7 +33,7 @@ anyhow = "1.0.23"
 serde_json = "1.0.46"
 rust-gpu-tools = { version = "0.7", optional = true, default-features = false }
 fr32 = { version = "~7.0", default-features = false }
-fvm3 = { package = "fvm", version = "~3.6.0", default-features = false, features = ["nv21-dev"] }
+fvm3 = { package = "fvm", version = "~3.7.0", default-features = false, features = ["nv21-dev"] }
 fvm3_shared = { package = "fvm_shared", version = "~3.5.0" }
 fvm2 = { package = "fvm", version = "~2.6", default-features = false }
 fvm2_shared = { package = "fvm_shared", version = "~2.5" }

--- a/rust/src/fvm/engine.rs
+++ b/rust/src/fvm/engine.rs
@@ -429,6 +429,8 @@ mod v2 {
                                 method,
                                 params: bytes_to_block(params),
                                 value: TokenAmount::from_atto(value.atto().clone()),
+                                gas_limit: msg.gas_limit,
+                                read_only: false,
                             }),
                             ExecutionEvent2::CallReturn(ret) => Some(ExecutionEvent::CallReturn(
                                 ExitCode::OK,

--- a/rust/src/fvm/machine.rs
+++ b/rust/src/fvm/machine.rs
@@ -395,6 +395,7 @@ pub struct TraceReturn {
     pub codec: u64,
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_lotus_trace(
     from: u64,
     to: Address,

--- a/rust/src/fvm/machine.rs
+++ b/rust/src/fvm/machine.rs
@@ -384,6 +384,7 @@ pub struct TraceMessage {
     pub codec: u64,
     pub gas_limit: u64,
     pub read_only: bool,
+    pub code_cid: Cid,
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple, Debug, PartialEq, Eq, Clone)]
@@ -415,6 +416,7 @@ fn build_lotus_trace(
             codec: params.codec,
             gas_limit,
             read_only,
+            code_cid: Cid::default(),
         },
         msg_ret: TraceReturn {
             exit_code: ExitCode::OK,
@@ -439,6 +441,9 @@ fn build_lotus_trace(
                 new_trace.subcalls.push(build_lotus_trace(
                     from, to, method, params, value, gas_limit, read_only, trace_iter,
                 )?);
+            }
+            ExecutionEvent::InvokeActor(cid) => {
+                new_trace.msg.code_cid = cid;
             }
             ExecutionEvent::CallReturn(exit_code, return_data) => {
                 let return_data = return_data.unwrap_or_default();


### PR DESCRIPTION
Related: https://github.com/filecoin-project/ref-fvm/issues/1793 and https://github.com/filecoin-project/fvm-pm/issues/613

Relevant PR in ref-fvm: https://github.com/filecoin-project/ref-fvm/pull/1823
Relevant PR in Lotus: https://github.com/filecoin-project/lotus/pull/11100

This PR updates the rust bindings to include the new fields introduced in https://github.com/filecoin-project/ref-fvm/pull/1823.

Will rebase and update PR once https://github.com/filecoin-project/ref-fvm/pull/1823 lands which should address CI errors.