### PR TITLE
fix: install aarch64-apple-darwin toolchain on x86

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,6 @@ jobs:
       - prepare:
           linux: false
           darwin: true
-      - run: cd rust && rustup target add aarch64-apple-darwin
       - run: cd rust && cargo fetch
       - run: cd rust && cargo install cargo-lipo
       - build_project

--- a/install-filcrypto
+++ b/install-filcrypto
@@ -163,6 +163,10 @@ build_from_source() {
     # Note that the cross compile works on x86_64 for m1, but doesn't work on m1.
     # For m1, we will build natively if building from source.
     if [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "x86_64" ]; then
+        # Rustup only installs the correct versions for the current
+        # architecture you're on. As we cross-compile to aarch64, we need to
+        # make sure that toolchain is installes as well.
+        rustup target add aarch64-apple-darwin
         build="lipo"
         additional_flags="--targets x86_64-apple-darwin,aarch64-apple-darwin "
     else


### PR DESCRIPTION
We always create universal binaries when compiling on x86. This means that the aarch64-apple-darwin also needs to be installed. Install that toolchain automatically if it doesn't exist yet.

This change has also been tested for the case when the toolchain already exists. In that case it just reports:

    info: component 'rust-std' for target 'aarch64-apple-darwin' is up to date

Thanks @lanzafame for reporting this issue.