### PR TITLE
chore: backport FVM update

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1154,12 +1154,12 @@ dependencies = [
  "fr32",
  "fvm 2.7.0",
  "fvm 3.8.0",
- "fvm 4.0.0-alpha.2",
+ "fvm 4.0.0-alpha.3",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_shared 2.6.0",
  "fvm_shared 3.6.0",
- "fvm_shared 4.0.0-alpha.2",
+ "fvm_shared 4.0.0-alpha.3",
  "group",
  "lazy_static",
  "libc",
@@ -1415,9 +1415,9 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6cb612a56eb37b1e36aa69de550b41f47cb7c482344af13a9aa7d54e1eb325f"
+checksum = "bda3c868d334b0615c62595e1260dc9481b82535eb6427d14434063d27eed965"
 dependencies = [
  "anyhow",
  "blake2b_simd",
@@ -1430,7 +1430,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
- "fvm_shared 4.0.0-alpha.2",
+ "fvm_shared 4.0.0-alpha.3",
  "lazy_static",
  "log",
  "minstant",
@@ -1598,9 +1598,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "4.0.0-alpha.2"
+version = "4.0.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dc4430d91e5269db5f32f8bb747810546e95485644c2d3ee432b7f6b15c7323"
+checksum = "e04c88cf61b42fd2492509f87d92e6757f60430cd7ee692f5fc0b9a94a14ae45"
 dependencies = [
  "anyhow",
  "bitflags 2.4.0",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1154,12 +1154,12 @@ dependencies = [
  "fr32",
  "fvm 2.7.0",
  "fvm 3.8.0",
- "fvm 4.0.0-alpha.3",
+ "fvm 4.0.0-alpha.4",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_shared 2.6.0",
  "fvm_shared 3.6.0",
- "fvm_shared 4.0.0-alpha.3",
+ "fvm_shared 4.0.0-alpha.4",
  "group",
  "lazy_static",
  "libc",
@@ -1415,9 +1415,9 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "4.0.0-alpha.3"
+version = "4.0.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda3c868d334b0615c62595e1260dc9481b82535eb6427d14434063d27eed965"
+checksum = "a71e2172d4454647217d0f2d31c0a5f72feb10b277520ea0a14643081fa74a7f"
 dependencies = [
  "anyhow",
  "blake2b_simd",
@@ -1430,7 +1430,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
- "fvm_shared 4.0.0-alpha.3",
+ "fvm_shared 4.0.0-alpha.4",
  "lazy_static",
  "log",
  "minstant",
@@ -1474,9 +1474,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_ipld_amt"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c0b0ee51ca8defa9717a72e1d35c8cbb85bd8320a835911410b63b9a63dffec"
+checksum = "5fea333475130094f27ce67809aae3f69eb5247541d835950b7c5da733dbbb34"
 dependencies = [
  "anyhow",
  "cid",
@@ -1598,9 +1598,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "4.0.0-alpha.3"
+version = "4.0.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04c88cf61b42fd2492509f87d92e6757f60430cd7ee692f5fc0b9a94a14ae45"
+checksum = "022bdee26d3a256905d6430b66099868ff7a439a8ceb22c0f351843aa7c5f394"
 dependencies = [
  "anyhow",
  "bitflags 2.4.0",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -33,8 +33,8 @@ anyhow = "1.0.23"
 serde_json = "1.0.46"
 rust-gpu-tools = { version = "0.7", optional = true, default-features = false }
 fr32 = { version = "9.0.0", default-features = false }
-fvm4 = { package = "fvm", version = "~4.0.0-alpha.2", default-features = false }
-fvm4_shared = { package = "fvm_shared", version = "~4.0.0-alpha.2" }
+fvm4 = { package = "fvm", version = "~4.0.0-alpha.3", default-features = false }
+fvm4_shared = { package = "fvm_shared", version = "~4.0.0-alpha.3" }
 fvm3 = { package = "fvm", version = "~3.8.0", default-features = false }
 fvm3_shared = { package = "fvm_shared", version = "~3.6.0" }
 fvm2 = { package = "fvm", version = "~2.7", default-features = false }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -33,8 +33,8 @@ anyhow = "1.0.23"
 serde_json = "1.0.46"
 rust-gpu-tools = { version = "0.7", optional = true, default-features = false }
 fr32 = { version = "9.0.0", default-features = false }
-fvm4 = { package = "fvm", version = "~4.0.0-alpha.3", default-features = false }
-fvm4_shared = { package = "fvm_shared", version = "~4.0.0-alpha.3" }
+fvm4 = { package = "fvm", version = "~4.0.0-alpha.4", default-features = false }
+fvm4_shared = { package = "fvm_shared", version = "~4.0.0-alpha.4" }
 fvm3 = { package = "fvm", version = "~3.8.0", default-features = false }
 fvm3_shared = { package = "fvm_shared", version = "~3.6.0" }
 fvm2 = { package = "fvm", version = "~2.7", default-features = false }

--- a/rust/src/fvm/engine.rs
+++ b/rust/src/fvm/engine.rs
@@ -268,7 +268,7 @@ mod v3 {
 
     use fvm4::call_manager::{backtrace::Backtrace, backtrace::Cause, backtrace::Frame};
     use fvm4::executor::{ApplyFailure, ApplyKind, ApplyRet};
-    use fvm4::gas::{Gas, GasCharge};
+    use fvm4::gas::{Gas, GasCharge, GasDuration};
     use fvm4::kernel::SyscallError;
 
     use fvm4::trace::ExecutionEvent;
@@ -389,9 +389,12 @@ mod v3 {
                                         charge.compute_gas.as_milligas(),
                                     ),
                                     other_gas: Gas::from_milligas(charge.other_gas.as_milligas()),
-                                    // TODO: There's no way to convert at the moment without a
-                                    // transmute.
-                                    elapsed: Default::default(),
+                                    elapsed: charge
+                                        .elapsed
+                                        .get()
+                                        .copied()
+                                        .map(GasDuration::from)
+                                        .unwrap_or_default(),
                                 }))
                             }
                             ExecutionEvent3::Call {


### PR DESCRIPTION
Bumps the 1.24.0 release branch to use FVM 4.0.0-alpha.4