### PR TITLE
ci: switch macos builds to apple silicon and upgrade xcode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,9 +93,9 @@ jobs:
 
   build_darwin_cgo_bindings:
     macos:
-      xcode: "12.5.1"
+      xcode: "13.4.1"
     working_directory: ~/go/src/github.com/filecoin-project/filecoin-ffi
-    resource_class: macos.x86.medium.gen2
+    resource_class: macos.m1.medium.gen1
     steps:
       - configure_environment_variables:
           linux: false
@@ -316,6 +316,7 @@ commands:
                 name: Add a few more environment variables
                 command: |
                   echo 'export PATH="${HOME}/.cargo/bin:${HOME}/.bin:${PATH}"' >> $BASH_ENV
+                  echo 'export LIBRARY_PATH=/opt/homebrew/lib' >> $BASH_ENV
   obtain_filecoin_parameters:
     steps:
       - run: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,6 @@ jobs:
           linux: false
           darwin: true
       - run: cd rust && cargo fetch
-      - run: cd rust && cargo install cargo-lipo
       - build_project
       - compile_tests
 
@@ -137,8 +136,8 @@ jobs:
       - publish_release
   publish_darwin_staticlib:
     macos:
-      xcode: "12.5.1"
-    resource_class: macos.x86.medium.gen2
+      xcode: "13.4.1"
+    resource_class: macos.m1.medium.gen1
     steps:
       - configure_environment_variables:
           linux: false
@@ -146,9 +145,8 @@ jobs:
       - prepare:
           linux: false
           darwin: true
-      - run: cd rust && rustup target add aarch64-apple-darwin
+      - run: cd rust && rustup target add x86_64-apple-darwin
       - run: cd rust && cargo fetch
-      - run: cd rust && cargo install cargo-lipo
       - publish_darwin_release
   rustfmt:
     docker:
@@ -283,7 +281,7 @@ commands:
             TARBALL_PATH="/tmp/${RELEASE_NAME}.tar.gz"
 
             # Note: the blst dependency uses the portable configuration for maximum compatibility
-            ./scripts/build-release.sh lipo --targets x86_64-apple-darwin,aarch64-apple-darwin --verbose --no-default-features --features multicore-sdr,opencl,blst-portable
+            ./scripts/build-release.sh lipo --verbose --no-default-features --features multicore-sdr,opencl,blst-portable
             ./scripts/package-release.sh $TARBALL_PATH
             ./scripts/publish-release.sh $TARBALL_PATH $RELEASE_NAME
   configure_environment_variables:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,7 +232,7 @@ commands:
             - run:
                 name: Install Go
                 command: |
-                  curl https://dl.google.com/go/go1.20.10.darwin-amd64.pkg -o /tmp/go.pkg && \
+                  curl https://dl.google.com/go/go1.20.10.darwin-arm64.pkg -o /tmp/go.pkg && \
                   sudo installer -pkg /tmp/go.pkg -target /
                   go version
             - run:

--- a/install-filcrypto
+++ b/install-filcrypto
@@ -158,17 +158,15 @@ build_from_source() {
 
     cargo --version
 
-    additional_flags=""
-    # For building on Darwin, we try to use cargo-lipo instead of cargo build.
-    # Note that the cross compile works on x86_64 for m1, but doesn't work on m1.
-    # For m1, we will build natively if building from source.
+    # In the past we were only able to build universal binaries on x86_64,
+    # for now we just keep that behaviour. This means that on aarch64 (e.g.
+    # Apple M1) it's a native, non-universal binary.
     if [ "$(uname -s)" = "Darwin" ] && [ "$(uname -m)" = "x86_64" ]; then
         # Rustup only installs the correct versions for the current
         # architecture you're on. As we cross-compile to aarch64, we need to
         # make sure that toolchain is installes as well.
         rustup target add aarch64-apple-darwin
         build="lipo"
-        additional_flags="--targets x86_64-apple-darwin,aarch64-apple-darwin "
     else
         build="build"
     fi
@@ -226,6 +224,7 @@ build_from_source() {
         use_fixed_rows_to_discard=",fixed-rows-to-discard"
     fi
 
+    additional_flags=""
     # Add feature specific rust flags as needed here.
     if [ "${FFI_USE_BLST_PORTABLE}" == "1" ]; then
         additional_flags="${additional_flags} --no-default-features --features ${use_multicore_sdr},blst-portable${gpu_flags}${use_fixed_rows_to_discard}"


### PR DESCRIPTION
This PR migrated the macos builds in the repo to Apple Silicon executors since the Apple Intel ones are getting deprecated by January 2024. See https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718.

FYI, the builds currently fail with:
```
# runtime/cgo
ld: warning: directory not found for option '-L/usr/lib/aarch64-linux-gnu/stubs'
# net
ld: warning: directory not found for option '-L/usr/lib/aarch64-linux-gnu/stubs'
# github.com/filecoin-project/filecoin-ffi/cgo
ld: warning: directory not found for option '-L/usr/lib/aarch64-linux-gnu/stubs'
ld: library not found for -lhwloc
clang: error: linker command failed with exit code 1 (use -v to see invocation)
FAIL    github.com/filecoin-project/filecoin-ffi [build failed]
```

I assume it's going to be easier to figure out for maintainers.