### PR TITLE
feat: add FFI_USE_CUDA_SUPRASEAL env variable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,19 @@ jobs:
       - run: cd rust && cargo install cargo-lipo
       - build_project
       - compile_tests
+
+  # SupraSeal pulls in a C++ code base, make sure everything compiles properly.
+  build_linux_supraseal:
+    executor: golang
+    resource_class: medium
+    working_directory: ~/go/src/github.com/filecoin-project/filecoin-ffi
+    steps:
+      - configure_environment_variables
+      - prepare
+      - run:
+          name: Build project with `FFI_USE_CUDA_SUPRASEAL=1`
+          command: FFI_BUILD_FROM_SOURCE=1 FFI_USE_CUDA_SUPRASEAL=1 make
+
   publish_linux_x86_64_staticlib:
     executor: golang
     resource_class: medium
@@ -172,6 +185,7 @@ workflows:
       - build_and_test_aarch64_linux_cgo_bindings:
           run_leak_detector: false
       - build_darwin_cgo_bindings
+      - build_linux_supraseal
       - publish_linux_x86_64_staticlib:
           filters:
             tags:
@@ -208,7 +222,12 @@ commands:
           condition: << parameters.linux >>
           steps:
             - run: sudo apt-get update
-            - run: sudo apt-get install --no-install-recommends -y valgrind ocl-icd-opencl-dev libssl-dev libhwloc-dev nvidia-cuda-toolkit
+            - run: sudo apt-get install --no-install-recommends -y valgrind ocl-icd-opencl-dev libssl-dev libhwloc-dev nvidia-cuda-toolkit g++-10
+            - run:
+                name: Downgrade to GCC 10, as CUDA 11 doesn't play nice with GCC 11
+                command: |
+                  sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-10 10
+                  sudo update-alternatives --set c++ /usr/bin/g++-10
       - when:
           condition: << parameters.darwin >>
           steps:

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ rm .install-filcrypto \
 
 CUDA for GPU support is now enabled by default in the proofs library.  This feature can optionally be replaced by OpenCL by using `FFI_USE_OPENCL=1` set in the environment when building from source.  Alternatively, if the CUDA toolkit (such as `nvcc`) cannot be located in the environment, OpenCL support is used instead.  To disable GPU support entirely, set `FFI_USE_GPU=0` in the environment when building from source.
 
+There is experimental support for faster C2 named "SupraSeal". To enable it, set `FFI_USE_CUDA_SUPRASEAL=1`. It's specific to CUDA and won't work with OpenCL.
+
 ```shell
 rm .install-filcrypto \
     ; make clean \

--- a/install-filcrypto
+++ b/install-filcrypto
@@ -176,11 +176,15 @@ build_from_source() {
     # Check if GPU support is disabled.
     if [ "${FFI_USE_GPU}" == "0" ]; then
         gpu_flags=""
+    elif [ "${FFI_USE_CUDA_SUPRASEAL}" == "1" ]; then
+        # If SupraSeal is enabled, just use the `cuda-supraseal` eature and
+        # nothing else GPU related.
+        gpu_flags=",cuda-supraseal"
     else
-        # If not, default to CUDA support where possible.
-        # First ensure that nvcc (as part of the CUDA toolkit) is
-        # available -- if it's not warn that we are defaulting GPU to
-        # OpenCL instead.
+        # If GPUs are enabled and SupraSeal is not, default to CUDA support
+        # where possible.
+        # First ensure that nvcc (as part of the CUDA toolkit) is available --
+        # if it's not warn that we are defaulting GPU to OpenCL instead.
         gpu_flags=",cuda"
 
         # Unless OpenCL support is specified or we're building on Darwin.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -211,6 +211,7 @@ dependencies = [
  "rustversion",
  "serde",
  "sha2 0.10.7",
+ "supraseal-c2",
  "thiserror",
 ]
 
@@ -416,6 +417,7 @@ version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
+ "jobserver",
  "libc",
 ]
 
@@ -1939,6 +1941,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
+name = "jobserver"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3004,6 +3015,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sppark"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba7a6d98937866ea8917015cd4a72d56d6e7feee8979dbccf83fc0c870053c46"
+dependencies = [
+ "cc",
+ "which",
+]
+
+[[package]]
 name = "sptr"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3156,6 +3177,17 @@ name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
+name = "supraseal-c2"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd636fe8d238305b3022c399f9973c88f58d75212ef36d2ff1ebd51e20285d5b"
+dependencies = [
+ "blst",
+ "cc",
+ "sppark",
+]
 
 [[package]]
 name = "syn"
@@ -3667,6 +3699,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.37",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -57,6 +57,7 @@ tempfile = "3.0.8"
 default = ["cuda", "multicore-sdr" ]
 blst-portable = ["bls-signatures/blst-portable", "blstrs/portable"]
 cuda = ["filecoin-proofs-api/cuda", "rust-gpu-tools/cuda", "fvm3/cuda", "fvm2/cuda"]
+cuda-supraseal = ["filecoin-proofs-api/cuda-supraseal", "rust-gpu-tools/cuda", "fvm3/cuda-supraseal"]
 opencl = ["filecoin-proofs-api/opencl", "rust-gpu-tools/opencl", "fvm3/opencl", "fvm2/opencl"]
 multicore-sdr = ["filecoin-proofs-api/multicore-sdr"]
 c-headers = ["safer-ffi/headers"]


### PR DESCRIPTION
Make it possible to build the FFI with SupraSeal enabled, which should lead to better performance during C2.

This was accidentally removed from the PR at https://github.com/filecoin-project/filecoin-ffi/pull/418.