### PR TITLE
feat: add option to not require a t_aux file to be present

### DIFF
--- a/install-filcrypto
+++ b/install-filcrypto
@@ -208,11 +208,19 @@ build_from_source() {
         use_multicore_sdr=""
     fi
 
+    # By default the number or rows to discard of the TreeRLast can be set via
+    # `FIL_PROOFS_ROWS_TO_DISCARD`. When SupraSeal PC2 is used, then this
+    # number is fixed.
+    use_fixed_rows_to_discard=""
+    if [ "${FFI_USE_FIXED_ROWS_TO_DISCARD}" == "1" ]; then
+        use_fixed_rows_to_discard=",fixed-rows-to-discard"
+    fi
+
     # Add feature specific rust flags as needed here.
     if [ "${FFI_USE_BLST_PORTABLE}" == "1" ]; then
-        additional_flags="${additional_flags} --no-default-features --features ${use_multicore_sdr},blst-portable${gpu_flags}"
+        additional_flags="${additional_flags} --no-default-features --features ${use_multicore_sdr},blst-portable${gpu_flags}${use_fixed_rows_to_discard}"
     else
-        additional_flags="${additional_flags} --no-default-features --features ${use_multicore_sdr}${gpu_flags}"
+        additional_flags="${additional_flags} --no-default-features --features ${use_multicore_sdr}${gpu_flags}${use_fixed_rows_to_discard}"
     fi
 
     echo "Using additional build flags: ${additional_flags}"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1181,9 +1181,9 @@ dependencies = [
 
 [[package]]
 name = "filecoin-hashers"
-version = "11.0.0"
+version = "11.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb5ea33790e200a7d77b929e848fba8c3ee0d206dba6dc41e15286e433f62aa"
+checksum = "18a96fbc8232ba762026e6b4687dedf08ba1b3830148c919a158c21d7720fb62"
 dependencies = [
  "anyhow",
  "bellperson",
@@ -1201,9 +1201,9 @@ dependencies = [
 
 [[package]]
 name = "filecoin-proofs"
-version = "16.0.0"
+version = "16.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3840a583825e720be353549dca7e2cbd247bf2876adc9a79a8a1752eb95ab96"
+checksum = "7d5a4daf099aade347b0f23c1dd5b644aad340a223d5b65c37840faedda3092f"
 dependencies = [
  "anyhow",
  "bellperson",
@@ -1235,9 +1235,9 @@ dependencies = [
 
 [[package]]
 name = "filecoin-proofs-api"
-version = "16.0.0"
+version = "16.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61bdd3ba08899866a2b2c7f0fbe1fcb55cc6ad3c2f0b20026ef63263ac8ac50"
+checksum = "64cef9a819a3125ab92269da594daf2f742a3f6b1e03a2493c13a0bda4514b03"
 dependencies = [
  "anyhow",
  "bellperson",
@@ -1313,9 +1313,9 @@ dependencies = [
 
 [[package]]
 name = "fr32"
-version = "9.0.0"
+version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308ab8ad1457d722a3d247549c759ca0ce4a58796c633c956f6186f6923ea371"
+checksum = "fca9913cf6179723cdc69827661a36d9ac3fea4c6c8c0ee71536417e5b2cf5d6"
 dependencies = [
  "anyhow",
  "blstrs",
@@ -2964,9 +2964,9 @@ dependencies = [
 
 [[package]]
 name = "sha2raw"
-version = "11.0.0"
+version = "11.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b502b7bf556833b39551a1379b1ea715ce293016da621f18c3583fb13249a2ec"
+checksum = "b05310f1b1ceedfef5da1f80b6690342aec43713a79d1c303fa7b451f4e313de"
 dependencies = [
  "byteorder",
  "cpufeatures",
@@ -3044,9 +3044,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "storage-proofs-core"
-version = "16.0.0"
+version = "16.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "807382fd21c163e7666587a9f9142881c1caa00db33e14784dd31f7eb9982bee"
+checksum = "568106d9e94bd28082551873fe36e0295de24770e67cecdd25f345a1b39664f7"
 dependencies = [
  "aes",
  "anyhow",
@@ -3079,9 +3079,9 @@ dependencies = [
 
 [[package]]
 name = "storage-proofs-porep"
-version = "16.0.0"
+version = "16.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c9539ca32203ac4c7e888f967b6343defd29c935614d2defa4912a10148ff8"
+checksum = "e4d3d0dd1f03de0f4a3ea54ceed7d79c62e3c7963abe2014db0934e828514b54"
 dependencies = [
  "anyhow",
  "bellperson",
@@ -3097,6 +3097,7 @@ dependencies = [
  "filecoin-hashers",
  "fr32",
  "generic-array",
+ "glob",
  "hex",
  "hwloc",
  "lazy_static",
@@ -3121,9 +3122,9 @@ dependencies = [
 
 [[package]]
 name = "storage-proofs-post"
-version = "16.0.0"
+version = "16.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1780ccdd466460d78ac70290e289c4e7a20721272ffc9ac19736e9f34fcafbc"
+checksum = "c4817014940a69e7e84aa459afa3d7a0b81090a312d9918089f14810e988ac24"
 dependencies = [
  "anyhow",
  "bellperson",
@@ -3144,9 +3145,9 @@ dependencies = [
 
 [[package]]
 name = "storage-proofs-update"
-version = "16.0.0"
+version = "16.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a9c5760889cffd415961e6c1637c300aa40732e753646e8d4885baa4f48d72"
+checksum = "5374a6a435d62e23700a08e124a8b4756ddd937fd6152289346481bfdbac21f5"
 dependencies = [
  "anyhow",
  "bellperson",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -47,7 +47,7 @@ lazy_static = "1.4.0"
 serde = "1.0.117"
 serde_tuple = "0.5"
 safer-ffi = { version = "0.0.7", features = ["proc_macros"] }
-filecoin-proofs-api = { version = "16.0", default-features = false }
+filecoin-proofs-api = { version = "16.1", default-features = false }
 
 [dev-dependencies]
 memmap2 = "0.5"
@@ -61,3 +61,6 @@ cuda-supraseal = ["filecoin-proofs-api/cuda-supraseal", "rust-gpu-tools/cuda", "
 opencl = ["filecoin-proofs-api/opencl", "rust-gpu-tools/opencl", "fvm2/opencl", "fvm3/opencl", "fvm4/opencl"]
 multicore-sdr = ["filecoin-proofs-api/multicore-sdr"]
 c-headers = ["safer-ffi/headers"]
+# This feature enables a fixed number of discarded rows for TreeR. The `FIL_PROOFS_ROWS_TO_DISCARD`
+# setting is ignored, no `TemporaryAux` file will be written.
+fixed-rows-to-discard = ["filecoin-proofs-api/fixed-rows-to-discard"]


### PR DESCRIPTION
The `FFI_USE_FIXED_ROWS_TO_DISCARD` variable will make the proofs ignore the `FIL_PROOFS_ROWS_TO_DISCARD` setting, hence not relying on a `t_aux` file to be present. If enabled, then no `t_aux` file will be written by the proofs and a hard-coded value for `FIL_PROOFS_ROWS_TO_DISCARD` will be used.

---

I make this into draft mode as CI currently isn't passing due to https://github.com/filecoin-project/filecoin-ffi/issues/431.