### PR TITLE
fix: use Go 1.20 on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   golang:
     docker:
-      - image: cimg/go:1.18
+      - image: cimg/go:1.20
     resource_class: small
     environment:
       # Build the kernel only for the single architecture. This should reduce
@@ -56,7 +56,7 @@ jobs:
         type: boolean
         default: true
     machine:
-      image: ubuntu-2204:current
+      image: ubuntu-2204:2023.07.2
     resource_class: arm.large
     working_directory: ~/go/src/github.com/filecoin-project/filecoin-ffi
     steps:
@@ -234,7 +234,7 @@ commands:
             - run:
                 name: Install Go
                 command: |
-                  curl https://dl.google.com/go/go1.17.9.darwin-amd64.pkg -o /tmp/go.pkg && \
+                  curl https://dl.google.com/go/go1.20.10.darwin-amd64.pkg -o /tmp/go.pkg && \
                   sudo installer -pkg /tmp/go.pkg -target /
                   go version
             - run:

--- a/cgo/types.go
+++ b/cgo/types.go
@@ -91,7 +91,7 @@ type PoStProofGo struct {
 	Proof           []byte
 }
 
-/// FvmMachineExecuteResponse is a go allocated version of `FvmMachineExecuteResponse`.
+// FvmMachineExecuteResponse is a go allocated version of `FvmMachineExecuteResponse`.
 type FvmMachineExecuteResponseGo struct {
 	ExitCode             uint64
 	ReturnVal            []byte


### PR DESCRIPTION
As Lotus is now using Go 1.20 [1], also upgrade this CI to use 1.20.

This needs slight reformatting to make go fmt happy.

The CircleCI Ubuntu 22.04 image tagged 2023.07.2 is using Go 1.20.4 [2]. Later versions of that image use Go >= 1.21 [3].

[1]: https://github.com/filecoin-project/lotus/pull/11347
[2]: https://discuss.circleci.com/t/linux-machine-executor-2023-q3-update/48580
[3]: https://discuss.circleci.com/t/linux-machine-executor-2023-q4-update/49457