### PR TITLE
fix: remove ClearLayerData call

### DIFF
--- a/cgo/proofs.go
+++ b/cgo/proofs.go
@@ -229,11 +229,6 @@ func ClearSyntheticProofs(sectorSize uint64, cacheDirPath SliceRefUint8) error {
 	defer resp.destroy()
 	return CheckErr(resp)
 }
-func ClearLayerData(sectorSize uint64, cacheDirPath SliceRefUint8) error {
-	resp := C.clear_layer_data(C.uint64_t(sectorSize), cacheDirPath)
-	defer resp.destroy()
-	return CheckErr(resp)
-}
 
 func GenerateSynthProofs(
 	registered_proof RegisteredSealProof,

--- a/proofs.go
+++ b/proofs.go
@@ -666,10 +666,6 @@ func ClearSyntheticProofs(sectorSize uint64, cacheDirPath string) error {
 	return cgo.ClearSyntheticProofs(sectorSize, cgo.AsSliceRefUint8([]byte(cacheDirPath)))
 }
 
-func ClearLayerData(sectorSize abi.SectorSize, cacheDirPath string) error {
-	return cgo.ClearLayerData(uint64(sectorSize), cgo.AsSliceRefUint8([]byte(cacheDirPath)))
-}
-
 func GenerateSynthProofs(
 	proofType abi.RegisteredSealProof,
 	sealedCID, unsealedCID cid.Cid,

--- a/rust/src/proofs/api.rs
+++ b/rust/src/proofs/api.rs
@@ -1210,16 +1210,6 @@ fn clear_synthetic_proofs(
     })
 }
 
-#[ffi_export]
-fn clear_layer_data(
-    sector_size: u64,
-    cache_dir_path: c_slice::Ref<u8>,
-) -> repr_c::Box<ClearCacheResponse> {
-    catch_panic_response("clear_layer_data", || {
-        seal::clear_layer_data(sector_size, &as_path_buf(&cache_dir_path)?)
-    })
-}
-
 /// Returns the number of user bytes that will fit into a staged sector.
 #[ffi_export]
 fn get_max_user_bytes_per_staged_sector(registered_proof: RegisteredSealProof) -> u64 {
@@ -1846,7 +1836,7 @@ pub mod tests {
 
                 destroy_generate_synth_proofs_response(resp_p1);
 
-                let resp_clear = clear_layer_data(
+                let resp_clear = clear_cache(
                     api::RegisteredSealProof::from(registered_proof_seal)
                         .sector_size()
                         .0,
@@ -1854,7 +1844,7 @@ pub mod tests {
                 );
                 if resp_clear.status_code != FCPResponseStatus::NoError {
                     let msg = str::from_utf8(&resp_clear.error_msg).unwrap();
-                    panic!("clear_layer_data failed: {:?}", msg);
+                    panic!("clear_cache failed: {:?}", msg);
                 }
                 destroy_clear_cache_response(resp_clear);
             }


### PR DESCRIPTION
The `ClearLayerData` FFI call was accidentally introduced with the Synthetic PoRep. The call does under the hood exactly what `ClearCache` is doing. It was already removed from Lotus in [PR 11352], so that we can remove it here as well (and as a next steps from the Rust side). This reduces the API surface, which is generally a good idea.

[PR 11352]: https://github.com/filecoin-project/lotus/pull/11352