### PR TITLE
feat: increase default and max FVM concurrency

### DIFF
--- a/rust/src/fvm/engine.rs
+++ b/rust/src/fvm/engine.rs
@@ -66,7 +66,7 @@ pub struct MultiEngineContainer {
 }
 
 const LOTUS_FVM_CONCURRENCY_ENV_NAME: &str = "LOTUS_FVM_CONCURRENCY";
-const VALID_CONCURRENCY_RANGE: RangeInclusive<u32> = 1..=128;
+const VALID_CONCURRENCY_RANGE: RangeInclusive<u32> = 1..=4096;
 
 impl TryFrom<u32> for EngineVersion {
     type Error = anyhow::Error;
@@ -81,9 +81,9 @@ impl TryFrom<u32> for EngineVersion {
 }
 
 impl MultiEngineContainer {
-    /// Constructs a new multi-engine container with the default concurrency (4).
+    /// Constructs a new multi-engine container with the default concurrency (150).
     pub fn new() -> MultiEngineContainer {
-        Self::with_concurrency(4)
+        Self::with_concurrency(150)
     }
 
     /// Constructs a new multi-engine container with the concurrency specified in the


### PR DESCRIPTION
We used to allocate 1024 instances per "concurrency" but we now only allocate 1024 plus 20 per "concurrency". So, I'm increasing the default and maximum concurrency factors to take advantage of this. Importantly:

1. Max concurrency 128 -> 4096. `1024 + 4096*20 < 128 * 1024`.
2. Default concurrency 4 -> 150. `1024 + 150*20 < 4 * 1024`.

Motivation: I'm hoping that the default (150) is sufficient (more than the previous max...) so we can just get rid of this knob.

fixes https://github.com/filecoin-project/lotus/issues/11817

Alternatively, we could just remove the knob now? The default _is_ more than the previous max... On the other hand, the ability to decrease the max may be nice...