### PR TITLE
chore: update Rust version on CI to 1.73

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,7 +152,7 @@ jobs:
       - publish_darwin_release
   rustfmt:
     docker:
-      - image: cimg/rust:1.67
+      - image: cimg/rust:1.73
     resource_class: small
     steps:
       - checkout


### PR DESCRIPTION
Use the same rust version on CI as in the rust-toolchain.toml file.