### PR TITLE
Ni-PoRep Go/cgo additions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -352,13 +352,13 @@ commands:
           no_output_timeout: 90m
       - run:
           name: Run the Go tests
-          command: GODEBUG=cgocheck=2 RUST_LOG=info go test -p 1 -timeout 60m
+          command: GOEXPERIMENT=cgocheck2 RUST_LOG=info go test -p 1 -timeout 60m
           no_output_timeout: 60m
   compile_tests:
     steps:
       - run:
           name: Build project and tests, but don't actually run the tests (used to verify that build/link works with Darwin)
-          command: GODEBUG=cgocheck=2 RUST_LOG=info go test -run=^$
+          command: GOEXPERIMENT=cgocheck2 RUST_LOG=info go test -run=^$
   restore_parameter_cache:
     steps:
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   golang:
     docker:
-      - image: cimg/go:1.20
+      - image: cimg/go:1.21
     resource_class: small
     environment:
       # Build the kernel only for the single architecture. This should reduce

--- a/cgo/const.go
+++ b/cgo/const.go
@@ -16,21 +16,26 @@ const (
 )
 
 const (
-	RegisteredSealProofStackedDrg2KiBV1                        = C.REGISTERED_SEAL_PROOF_STACKED_DRG2_KI_B_V1
-	RegisteredSealProofStackedDrg8MiBV1                        = C.REGISTERED_SEAL_PROOF_STACKED_DRG8_MI_B_V1
-	RegisteredSealProofStackedDrg512MiBV1                      = C.REGISTERED_SEAL_PROOF_STACKED_DRG512_MI_B_V1
-	RegisteredSealProofStackedDrg32GiBV1                       = C.REGISTERED_SEAL_PROOF_STACKED_DRG32_GI_B_V1
-	RegisteredSealProofStackedDrg64GiBV1                       = C.REGISTERED_SEAL_PROOF_STACKED_DRG64_GI_B_V1
-	RegisteredSealProofStackedDrg2KiBV11                       = C.REGISTERED_SEAL_PROOF_STACKED_DRG2_KI_B_V1_1
-	RegisteredSealProofStackedDrg8MiBV11                       = C.REGISTERED_SEAL_PROOF_STACKED_DRG8_MI_B_V1_1
-	RegisteredSealProofStackedDrg512MiBV11                     = C.REGISTERED_SEAL_PROOF_STACKED_DRG512_MI_B_V1_1
-	RegisteredSealProofStackedDrg32GiBV11                      = C.REGISTERED_SEAL_PROOF_STACKED_DRG32_GI_B_V1_1
-	RegisteredSealProofStackedDrg64GiBV11                      = C.REGISTERED_SEAL_PROOF_STACKED_DRG64_GI_B_V1_1
-	RegisteredSealProofStackedDrg2KiBV11_Feat_SyntheticPoRep   = C.REGISTERED_SEAL_PROOF_STACKED_DRG2_KI_B_V1_1__FEAT__SYNTHETIC_PO_REP
-	RegisteredSealProofStackedDrg8MiBV11_Feat_SyntheticPoRep   = C.REGISTERED_SEAL_PROOF_STACKED_DRG8_MI_B_V1_1__FEAT__SYNTHETIC_PO_REP
-	RegisteredSealProofStackedDrg512MiBV11_Feat_SyntheticPoRep = C.REGISTERED_SEAL_PROOF_STACKED_DRG512_MI_B_V1_1__FEAT__SYNTHETIC_PO_REP
-	RegisteredSealProofStackedDrg32GiBV11_Feat_SyntheticPoRep  = C.REGISTERED_SEAL_PROOF_STACKED_DRG32_GI_B_V1_1__FEAT__SYNTHETIC_PO_REP
-	RegisteredSealProofStackedDrg64GiBV11_Feat_SyntheticPoRep  = C.REGISTERED_SEAL_PROOF_STACKED_DRG64_GI_B_V1_1__FEAT__SYNTHETIC_PO_REP
+	RegisteredSealProofStackedDrg2KiBV1                              = C.REGISTERED_SEAL_PROOF_STACKED_DRG2_KI_B_V1
+	RegisteredSealProofStackedDrg8MiBV1                              = C.REGISTERED_SEAL_PROOF_STACKED_DRG8_MI_B_V1
+	RegisteredSealProofStackedDrg512MiBV1                            = C.REGISTERED_SEAL_PROOF_STACKED_DRG512_MI_B_V1
+	RegisteredSealProofStackedDrg32GiBV1                             = C.REGISTERED_SEAL_PROOF_STACKED_DRG32_GI_B_V1
+	RegisteredSealProofStackedDrg64GiBV1                             = C.REGISTERED_SEAL_PROOF_STACKED_DRG64_GI_B_V1
+	RegisteredSealProofStackedDrg2KiBV11                             = C.REGISTERED_SEAL_PROOF_STACKED_DRG2_KI_B_V1_1
+	RegisteredSealProofStackedDrg8MiBV11                             = C.REGISTERED_SEAL_PROOF_STACKED_DRG8_MI_B_V1_1
+	RegisteredSealProofStackedDrg512MiBV11                           = C.REGISTERED_SEAL_PROOF_STACKED_DRG512_MI_B_V1_1
+	RegisteredSealProofStackedDrg32GiBV11                            = C.REGISTERED_SEAL_PROOF_STACKED_DRG32_GI_B_V1_1
+	RegisteredSealProofStackedDrg64GiBV11                            = C.REGISTERED_SEAL_PROOF_STACKED_DRG64_GI_B_V1_1
+	RegisteredSealProofStackedDrg2KiBV11_Feat_SyntheticPoRep         = C.REGISTERED_SEAL_PROOF_STACKED_DRG2_KI_B_V1_1__FEAT__SYNTHETIC_PO_REP
+	RegisteredSealProofStackedDrg8MiBV11_Feat_SyntheticPoRep         = C.REGISTERED_SEAL_PROOF_STACKED_DRG8_MI_B_V1_1__FEAT__SYNTHETIC_PO_REP
+	RegisteredSealProofStackedDrg512MiBV11_Feat_SyntheticPoRep       = C.REGISTERED_SEAL_PROOF_STACKED_DRG512_MI_B_V1_1__FEAT__SYNTHETIC_PO_REP
+	RegisteredSealProofStackedDrg32GiBV11_Feat_SyntheticPoRep        = C.REGISTERED_SEAL_PROOF_STACKED_DRG32_GI_B_V1_1__FEAT__SYNTHETIC_PO_REP
+	RegisteredSealProofStackedDrg64GiBV11_Feat_SyntheticPoRep        = C.REGISTERED_SEAL_PROOF_STACKED_DRG64_GI_B_V1_1__FEAT__SYNTHETIC_PO_REP
+	RegisteredSealProofStackedDrg2KiBV1_2_Feat_NonInteractivePoRep   = C.REGISTERED_SEAL_PROOF_STACKED_DRG2_KI_B_V1_2__FEAT__NON_INTERACTIVE_PO_REP
+	RegisteredSealProofStackedDrg8MiBV1_2_Feat_NonInteractivePoRep   = C.REGISTERED_SEAL_PROOF_STACKED_DRG8_MI_B_V1_2__FEAT__NON_INTERACTIVE_PO_REP
+	RegisteredSealProofStackedDrg512MiBV1_2_Feat_NonInteractivePoRep = C.REGISTERED_SEAL_PROOF_STACKED_DRG512_MI_B_V1_2__FEAT__NON_INTERACTIVE_PO_REP
+	RegisteredSealProofStackedDrg32GiBV1_2_Feat_NonInteractivePoRep  = C.REGISTERED_SEAL_PROOF_STACKED_DRG32_GI_B_V1_2__FEAT__NON_INTERACTIVE_PO_REP
+	RegisteredSealProofStackedDrg64GiBV1_2_Feat_NonInteractivePoRep  = C.REGISTERED_SEAL_PROOF_STACKED_DRG64_GI_B_V1_2__FEAT__NON_INTERACTIVE_PO_REP
 )
 
 const (

--- a/cgo/proofs.go
+++ b/cgo/proofs.go
@@ -130,6 +130,15 @@ func SealCommitPhase2(sealCommitPhase1Output SliceRefUint8, sectorId uint64, pro
 	return resp.value.copy(), nil
 }
 
+func SealCommitPhase2CircuitProofs(sealCommitPhase1Output SliceRefUint8, sectorId uint64) ([]byte, error) {
+	resp := C.seal_commit_phase2_circuit_proofs(sealCommitPhase1Output, C.uint64_t(sectorId))
+	defer resp.destroy()
+	if err := CheckErr(resp); err != nil {
+		return nil, err
+	}
+	return resp.value.copy(), nil
+}
+
 func AggregateSealProofs(registeredProof RegisteredSealProof, registeredAggregation RegisteredAggregationProof, commRs SliceRefByteArray32, seeds SliceRefByteArray32, sealCommitResponses SliceRefSliceBoxedUint8) ([]byte, error) {
 	resp := C.aggregate_seal_proofs(registeredProof, registeredAggregation, commRs, seeds, sealCommitResponses)
 	defer resp.destroy()

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/filecoin-project/go-address v1.1.0
 	github.com/filecoin-project/go-fil-commcid v0.1.0
-	github.com/filecoin-project/go-state-types v0.13.1
+	github.com/filecoin-project/go-state-types v0.14.0-dev.0.20240611104512-19a29aa50e4a
 	github.com/ipfs/go-block-format v0.0.3
 	github.com/ipfs/go-cid v0.3.2
 	github.com/ipfs/go-ipfs-blockstore v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/filecoin-project/go-address v1.1.0
 	github.com/filecoin-project/go-fil-commcid v0.1.0
-	github.com/filecoin-project/go-state-types v0.14.0-dev.0.20240611104512-19a29aa50e4a
+	github.com/filecoin-project/go-state-types v0.14.0-rc1
 	github.com/ipfs/go-block-format v0.0.3
 	github.com/ipfs/go-cid v0.3.2
 	github.com/ipfs/go-ipfs-blockstore v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/filecoin-project/go-crypto v0.0.1 h1:AcvpSGGCgjaY8y1az6AMfKQWreF/pWO2
 github.com/filecoin-project/go-crypto v0.0.1/go.mod h1:+viYnvGtUTgJRdy6oaeF4MTFKAfatX071MPDPBL11EQ=
 github.com/filecoin-project/go-fil-commcid v0.1.0 h1:3R4ds1A9r6cr8mvZBfMYxTS88OqLYEo6roi+GiIeOh8=
 github.com/filecoin-project/go-fil-commcid v0.1.0/go.mod h1:Eaox7Hvus1JgPrL5+M3+h7aSPHc0cVqpSxA+TxIEpZQ=
-github.com/filecoin-project/go-state-types v0.14.0-dev.0.20240611104512-19a29aa50e4a h1:nMdbQ57jTYdJpygzRd/rfKt+unyUAmzK9DLgbOuUMwE=
-github.com/filecoin-project/go-state-types v0.14.0-dev.0.20240611104512-19a29aa50e4a/go.mod h1:cHpOPup9H1g2T29dKHAjC2sc7/Ef5ypjuW9A3I+e9yY=
+github.com/filecoin-project/go-state-types v0.14.0-rc1 h1:kWBGX/uqZmYotYMNmw+R/fIuot/k0KMcEtB7PKFy1SQ=
+github.com/filecoin-project/go-state-types v0.14.0-rc1/go.mod h1:cHpOPup9H1g2T29dKHAjC2sc7/Ef5ypjuW9A3I+e9yY=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/filecoin-project/go-crypto v0.0.1 h1:AcvpSGGCgjaY8y1az6AMfKQWreF/pWO2
 github.com/filecoin-project/go-crypto v0.0.1/go.mod h1:+viYnvGtUTgJRdy6oaeF4MTFKAfatX071MPDPBL11EQ=
 github.com/filecoin-project/go-fil-commcid v0.1.0 h1:3R4ds1A9r6cr8mvZBfMYxTS88OqLYEo6roi+GiIeOh8=
 github.com/filecoin-project/go-fil-commcid v0.1.0/go.mod h1:Eaox7Hvus1JgPrL5+M3+h7aSPHc0cVqpSxA+TxIEpZQ=
-github.com/filecoin-project/go-state-types v0.13.1 h1:4CivvlcHAIoAtFFVVlZtokynaMQu5XLXGoTKhQkfG1I=
-github.com/filecoin-project/go-state-types v0.13.1/go.mod h1:cHpOPup9H1g2T29dKHAjC2sc7/Ef5ypjuW9A3I+e9yY=
+github.com/filecoin-project/go-state-types v0.14.0-dev.0.20240611104512-19a29aa50e4a h1:nMdbQ57jTYdJpygzRd/rfKt+unyUAmzK9DLgbOuUMwE=
+github.com/filecoin-project/go-state-types v0.14.0-dev.0.20240611104512-19a29aa50e4a/go.mod h1:cHpOPup9H1g2T29dKHAjC2sc7/Ef5ypjuW9A3I+e9yY=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=

--- a/proofs.go
+++ b/proofs.go
@@ -414,6 +414,13 @@ func SealCommitPhase2(
 	return cgo.SealCommitPhase2(cgo.AsSliceRefUint8(phase1Output), uint64(sectorNum), &proverID)
 }
 
+// SealCommitPhase2CircuitProofs runs a non-interactive proof and returns the circuit proof bytes
+// rather than the aggregated proof bytes. This is used to aggregate multiple non-interactive
+// proofs as the aggregated single proof outputs can't further be aggregated.
+func SealCommitPhase2CircuitProofs(phase1Output []byte, sectorNum abi.SectorNumber) ([]byte, error) {
+	return cgo.SealCommitPhase2CircuitProofs(cgo.AsSliceRefUint8(phase1Output), uint64(sectorNum))
+}
+
 // TODO AggregateSealProofs it only needs InteractiveRandomness out of the aggregateInfo.Infos
 func AggregateSealProofs(aggregateInfo proof.AggregateSealVerifyProofAndInfos, proofs [][]byte) (out []byte, err error) {
 	sp, err := toFilRegisteredSealProof(aggregateInfo.SealProof)
@@ -1029,6 +1036,17 @@ func toFilRegisteredSealProof(p abi.RegisteredSealProof) (cgo.RegisteredSealProo
 		return cgo.RegisteredSealProofStackedDrg32GiBV11_Feat_SyntheticPoRep, nil
 	case abi.RegisteredSealProof_StackedDrg64GiBV1_1_Feat_SyntheticPoRep:
 		return cgo.RegisteredSealProofStackedDrg64GiBV11_Feat_SyntheticPoRep, nil
+
+	case abi.RegisteredSealProof_StackedDrg2KiBV1_2_Feat_NiPoRep:
+		return cgo.RegisteredSealProofStackedDrg2KiBV1_2_Feat_NonInteractivePoRep, nil
+	case abi.RegisteredSealProof_StackedDrg8MiBV1_2_Feat_NiPoRep:
+		return cgo.RegisteredSealProofStackedDrg8MiBV1_2_Feat_NonInteractivePoRep, nil
+	case abi.RegisteredSealProof_StackedDrg512MiBV1_2_Feat_NiPoRep:
+		return cgo.RegisteredSealProofStackedDrg512MiBV1_2_Feat_NonInteractivePoRep, nil
+	case abi.RegisteredSealProof_StackedDrg32GiBV1_2_Feat_NiPoRep:
+		return cgo.RegisteredSealProofStackedDrg32GiBV1_2_Feat_NonInteractivePoRep, nil
+	case abi.RegisteredSealProof_StackedDrg64GiBV1_2_Feat_NiPoRep:
+		return cgo.RegisteredSealProofStackedDrg64GiBV1_2_Feat_NonInteractivePoRep, nil
 
 	default:
 		return 0, errors.Errorf("no mapping to C.FFIRegisteredSealProof value available for: %v", p)

--- a/rust/src/proofs/api.rs
+++ b/rust/src/proofs/api.rs
@@ -294,6 +294,36 @@ fn seal_commit_phase2(
     })
 }
 
+/// This function generates a variant of the circuit proof for the second phase of the sealing
+/// process. It takes as input the output from the first phase of the sealing process
+/// [`seal_commit_phase1`] and a sector ID.
+///
+/// This variant of `seal_commit_phase2` is intended specifically for returning the circuit proofs
+/// of a NonInteractivePoRep proof, such that it can later be aggregated with other
+/// NonInteractivePoRep proofs.
+///
+/// # Arguments
+///
+/// * `seal_commit_phase1_output` - A reference to a slice of bytes representing the output from the
+///   first phase of the sealing process.
+/// * `sector_id` - A 64-bit integer representing the sector ID.
+///
+/// # Returns
+/// This function returns a `SealCommitPhase2Response` wrapped in a `repr_c::Box`. This response
+/// includes the proof generated in this phase of the sealing process.
+#[ffi_export]
+fn seal_commit_phase2_circuit_proofs(
+    seal_commit_phase1_output: c_slice::Ref<u8>,
+    sector_id: u64,
+) -> repr_c::Box<SealCommitPhase2Response> {
+    catch_panic_response("seal_commit_phase2_circuit_proofs", || {
+        let scp1o = serde_json::from_slice(&seal_commit_phase1_output)?;
+        let result = seal::seal_commit_phase2_circuit_proofs(scp1o, SectorId::from(sector_id))?;
+
+        Ok(result.proof.into_boxed_slice().into())
+    })
+}
+
 /// TODO: document
 #[ffi_export]
 fn generate_synth_proofs(


### PR DESCRIPTION
~Some additional changes on top of a rebased https://github.com/filecoin-project/filecoin-ffi/pull/453, while I try and wire things up for integration testing.~

~This has local linking for ref-fvm for https://github.com/filecoin-project/ref-fvm/pull/1999 on top of master for https://github.com/filecoin-project/ref-fvm/pull/2009.~

~It also has local linking for rust-filecoin-proofs-api for https://github.com/filecoin-project/rust-filecoin-proofs-api/pull/103~

--

Additions on top of https://github.com/filecoin-project/filecoin-ffi/pull/453, but this depends on https://github.com/filecoin-project/go-state-types/pull/269 being merged.

Note that his also includes `seal_commit_phase2_circuit_proofs` in `rust/src/proofs/api.rs`, that could go into #453.