### PR TITLE
chore: update fvm to 4.3.1

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -60,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "ambassador"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2362d85b9d773d0d6ec70d6cc8f27ddef81edd11b05bc4e18281e4993b6e6d6"
+checksum = "06baa18a48752d8177eca1bafa9970b2dc649a81b98d6dde9ae83bea1867030b"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
@@ -1282,12 +1282,12 @@ dependencies = [
  "filepath",
  "fvm 2.8.0",
  "fvm 3.10.0",
- "fvm 4.3.0",
+ "fvm 4.3.1",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_shared 2.7.0",
  "fvm_shared 3.10.0",
- "fvm_shared 4.3.0",
+ "fvm_shared 4.3.1",
  "group",
  "lazy_static",
  "libc",
@@ -1542,9 +1542,9 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "4.3.0"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b332a90abacf84345666bf4debc44c3d63392cd4c3add72ddf8624114af32e1f"
+checksum = "f5012b2afac90da5c32bde64b824d886d9dd46104dedecab1f2ec680daff07ac"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -1556,7 +1556,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_ipld_hamt 0.9.0",
- "fvm_shared 4.3.0",
+ "fvm_shared 4.3.1",
  "lazy_static",
  "log",
  "minstant",
@@ -1742,9 +1742,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "4.3.0"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31841282c98f3acd78c741f1e38ecebc97e72243c4ecb73a658f6529246a35a5"
+checksum = "6a907c935312f9a47a64fbe1d45f2cb7b2b0a5fbb989a90ecac395b40466069d"
 dependencies = [
  "anyhow",
  "bitflags 2.5.0",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -33,11 +33,8 @@ rayon = "1.2.1"
 anyhow = "1.0.23"
 serde_json = "1.0.46"
 rust-gpu-tools = { version = "0.7", optional = true, default-features = false }
-fvm4 = { package = "fvm", version = "~4.3.0", default-features = false, features = [
-  "nv23-dev",
-  "verify-signature",
-] }
-fvm4_shared = { package = "fvm_shared", version = "~4.3.0" }
+fvm4 = { package = "fvm", version = "~4.3.1", default-features = false, features = ["verify-signature"] }
+fvm4_shared = { package = "fvm_shared", version = "~4.3.1" }
 fvm3 = { package = "fvm", version = "~3.10.0", default-features = false }
 fvm3_shared = { package = "fvm_shared", version = "~3.10.0" }
 fvm2 = { package = "fvm", version = "~2.8", default-features = false }


### PR DESCRIPTION
Removes the nv23-dev feature, enabling support by default.