### PR TITLE
feat: FFI_PORTABLE to build a maximally portable binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ rm .install-filcrypto \
     ; FFI_BUILD_FROM_SOURCE=1 FFI_USE_BLST_PORTABLE=1 make
 ```
 
+Alternatively, to build a maximally portable binary without optimizing for the current CPU, set `FFI_PORTABLE=1`:
+
+```shell
+rm .install-filcrypto \
+    ; make clean \
+    ; FFI_BUILD_FROM_SOURCE=1 FFI_PORTABLE=1 make
+```
+
 By default, a 'gpu' option is used in the proofs library. This feature is also used in FFI unless explicitly disabled. To disable building with the 'gpu' dependency, set `FFI_USE_GPU=0`:
 
 ```shell
@@ -44,7 +52,7 @@ rm .install-filcrypto \
 
 #### GPU support
 
-CUDA for GPU support is now enabled by default in the proofs library. This feature can optionally be replaced by OpenCL by using `FFI_USE_OPENCL=1` set in the environment when building from source. Alternatively, if the CUDA toolkit (such as `nvcc`) cannot be located in the environment, OpenCL support is used instead. To disable GPU support entirely, set `FFI_USE_GPU=0` in the environment when building from source.
+CUDA for GPU support is now enabled by default in the proofs library. This feature can optionally be replaced by OpenCL by using `FFI_USE_OPENCL=1` set in the environment when building from source. Using `FFI_PORTABLE=1` will also enable OpenCL support. Alternatively, if the CUDA toolkit (such as `nvcc`) cannot be located in the environment, OpenCL support is used instead. To disable GPU support entirely, set `FFI_USE_GPU=0` in the environment when building from source.
 
 There is experimental support for faster C2 named "SupraSeal". To enable it, set `FFI_USE_CUDA_SUPRASEAL=1`. It's specific to CUDA and won't work with OpenCL.
 

--- a/install-filcrypto
+++ b/install-filcrypto
@@ -190,7 +190,7 @@ build_from_source() {
         if [ "${FFI_USE_GPU}" == "0" ]; then
             gpu_flags=""
         # Check if OpenCL support is specified or we're building on Darwin.
-        elif [ "${FFI_USE_OPENCL}" == "1" ] || [ "$(uname -s)" = "Darwin" ]; then
+        elif [ "${FFI_USE_OPENCL}" == "1" ] || [ "${FFI_PORTABLE}" == "1" ] || [ "$(uname -s)" = "Darwin" ]; then
             gpu_flags=",opencl"
         else
             # If GPUs are enabled and SupraSeal is not, default to CUDA support
@@ -226,7 +226,7 @@ build_from_source() {
 
     additional_flags=""
     # Add feature specific rust flags as needed here.
-    if [ "${FFI_USE_BLST_PORTABLE}" == "1" ]; then
+    if [ "${FFI_USE_BLST_PORTABLE}" == "1" ] || [ "${FFI_PORTABLE}" == "1" ]; then
         additional_flags="${additional_flags} --no-default-features --features ${use_multicore_sdr},blst-portable${gpu_flags}${use_fixed_rows_to_discard}"
     else
         additional_flags="${additional_flags} --no-default-features --features ${use_multicore_sdr}${gpu_flags}${use_fixed_rows_to_discard}"
@@ -243,6 +243,11 @@ build_from_source() {
 }
 
 get_release_flags() {
+    if [ "${FFI_PORTABLE}" == "1" ]; then
+        echo ""
+        return
+    fi
+
     local __features=""
 
     # determine where to look for CPU features


### PR DESCRIPTION
Ref: https://github.com/filecoin-project/lotus/pull/12423

Background: we're having trouble building from source in Lotus CI because we run tests two different machine types and only build FFI on one, caching the output and deploying it on the other machines. We have our own custom runners in AWS and also lean heavily on the default GHA runners which are in Azure and they obviously have different CPU types.

This change introduces `FFI_PORTABLE=1` which builds using the same flags as rust/scripts/build-release.sh does when called from CI to build the release bundle.

Comparison of some builds:

When run from CI, we get:

```
+ RUSTFLAGS='--print native-static-libs '
+ cargo build --release --locked --verbose --no-default-features --features multicore-sdr,opencl,blst-portable
```

When run from `FFI_BUILD_FROM_SOURCE=1 make` (on my machine), we get:

```
+ RUSTFLAGS='--print native-static-libs -C target-feature=+adx,+sha,+sse2,+avx2,+avx,+sse4.2,+sse4.1'
+ cargo build --release --locked --no-default-features --features multicore-sdr,cuda
```

`FFI_BUILD_FROM_SOURCE=1 FFI_USE_BLST_PORTABLE=1 make` gives:

```
+ RUSTFLAGS='--print native-static-libs -C target-feature=+adx,+sha,+sse2,+avx2,+avx,+sse4.2,+sse4.1'
+ cargo build --release --locked --no-default-features --features multicore-sdr,blst-portable,cuda
```

And this new option, `FFI_BUILD_FROM_SOURCE=1 FFI_PORTABLE=1 make`, gives:

```
+ RUSTFLAGS='--print native-static-libs '
+ cargo build --release --locked --no-default-features --features multicore-sdr,blst-portable,opencl
```

i.e. the same to the CI version except for `--verbose`.