### PR TITLE
feat: download release tarball from named release

### DIFF
--- a/install-filcrypto
+++ b/install-filcrypto
@@ -81,8 +81,16 @@ download_release_tarball() {
     local __rust_sources_path=$2
     local __repo_name=$3
     local __release_flags=$4
-    local __release_sha1=$(git rev-parse HEAD)
-    local __release_tag="${__release_sha1:0:16}"
+    local __release_tags=$(git tag --points-at "$(git rev-parse HEAD)")
+    local __release_tag=$(echo "${__release_tags}" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-\w+)?$' | head -n 1)
+
+    # If we're building from a commit that doesn't have a tag, we need to
+    # compile from source.
+    if [ -z "${__release_tag}" ]; then
+        (>&2 echo "[download_release_tarball] failed to determine release tag")
+        return 1
+    fi
+
     local __release_tag_url="https://api.github.com/repos/filecoin-project/${__repo_name}/releases/tags/${__release_tag}"
 
     # Download the non-optimized standard release.


### PR DESCRIPTION
Avoid the need for using the commit hash to find the release.

Fixes: https://github.com/filecoin-project/filecoin-ffi/issues/491

See #491 for the question of whether we want to lock this behaviour in - release assets are only available for tags, not every commit on master as they used to be with CircleCI.