### PR TITLE
ci: remove unecessary dependencies from macos

### DIFF
--- a/.github/actions/configure-environment/action.yml
+++ b/.github/actions/configure-environment/action.yml
@@ -51,7 +51,7 @@ runs:
       shell: bash
     - if: runner.os == 'macOS'
       run: |
-        HOMEBREW_NO_AUTO_UPDATE=1 brew install pkg-config md5sha1sum jq hwloc
+        HOMEBREW_NO_AUTO_UPDATE=1 brew install md5sha1sum hwloc
       shell: bash
     - uses: dtolnay/rust-toolchain@21dc36fb71dd22e3317045c0c31a3f4249868b17
       with:


### PR DESCRIPTION
This (pkg-config, specifically) was causing an error in CI due to a conflicting version already being available. It also turns out that `jq` is installed by default in this image as well.