### PR TITLE
feat: support flush_all_blocks, handle new ipld operations in traces

### DIFF
--- a/cgo/fvm.go
+++ b/cgo/fvm.go
@@ -90,3 +90,10 @@ func FvmMachineFlush(executor *FvmMachine) ([]byte, error) {
 	}
 	return (SliceBoxedUint8)(resp.value).copy(), nil
 }
+
+func FvmMachineDumpCache(executor *FvmMachine, blockstoreId uint64) error {
+	resp := C.fvm_machine_dump_cache(executor, C.uint64_t(blockstoreId))
+	defer resp.destroy()
+
+	return CheckErr(resp)
+}

--- a/cgo/fvm.go
+++ b/cgo/fvm.go
@@ -8,7 +8,7 @@ package cgo
 */
 import "C"
 
-func CreateFvmMachine(fvmVersion FvmRegisteredVersion, chainEpoch, chainTimestamp, chainId, baseFeeHi, baseFeeLo, baseCircSupplyHi, baseCircSupplyLo, networkVersion uint64, stateRoot SliceRefUint8, tracing bool, blockstoreId, externsId uint64) (*FvmMachine, error) {
+func CreateFvmMachine(fvmVersion FvmRegisteredVersion, chainEpoch, chainTimestamp, chainId, baseFeeHi, baseFeeLo, baseCircSupplyHi, baseCircSupplyLo, networkVersion uint64, stateRoot SliceRefUint8, tracing, flushAllBlocks bool, blockstoreId, externsId uint64) (*FvmMachine, error) {
 	resp := (*resultFvmMachine)(C.create_fvm_machine(
 		(C.FvmRegisteredVersion_t)(fvmVersion),
 		C.uint64_t(chainEpoch),
@@ -21,6 +21,7 @@ func CreateFvmMachine(fvmVersion FvmRegisteredVersion, chainEpoch, chainTimestam
 		C.uint32_t(networkVersion),
 		(C.slice_ref_uint8_t)(stateRoot),
 		C.bool(tracing),
+		C.bool(flushAllBlocks),
 		C.uint64_t(blockstoreId),
 		C.uint64_t(externsId),
 	))
@@ -36,7 +37,7 @@ func CreateFvmMachine(fvmVersion FvmRegisteredVersion, chainEpoch, chainTimestam
 	return executor, nil
 }
 
-func CreateFvmDebugMachine(fvmVersion FvmRegisteredVersion, chainEpoch, chainTimestamp, chainId, baseFeeHi, baseFeeLo, baseCircSupplyHi, baseCircSupplyLo, networkVersion uint64, stateRoot SliceRefUint8, actorRedirect SliceRefUint8, tracing bool, blockstoreId, externsId uint64) (*FvmMachine, error) {
+func CreateFvmDebugMachine(fvmVersion FvmRegisteredVersion, chainEpoch, chainTimestamp, chainId, baseFeeHi, baseFeeLo, baseCircSupplyHi, baseCircSupplyLo, networkVersion uint64, stateRoot SliceRefUint8, actorRedirect SliceRefUint8, tracing, flushAllBlocks bool, blockstoreId, externsId uint64) (*FvmMachine, error) {
 	resp := (*resultFvmMachine)(C.create_fvm_debug_machine(
 		(C.FvmRegisteredVersion_t)(fvmVersion),
 		C.uint64_t(chainEpoch),
@@ -50,6 +51,7 @@ func CreateFvmDebugMachine(fvmVersion FvmRegisteredVersion, chainEpoch, chainTim
 		(C.slice_ref_uint8_t)(stateRoot),
 		(C.slice_ref_uint8_t)(actorRedirect),
 		C.bool(tracing),
+		C.bool(flushAllBlocks),
 		C.uint64_t(blockstoreId),
 		C.uint64_t(externsId),
 	))
@@ -89,11 +91,4 @@ func FvmMachineFlush(executor *FvmMachine) ([]byte, error) {
 		return nil, err
 	}
 	return (SliceBoxedUint8)(resp.value).copy(), nil
-}
-
-func FvmMachineDumpCache(executor *FvmMachine, blockstoreId uint64) error {
-	resp := C.fvm_machine_dump_cache(executor, C.uint64_t(blockstoreId))
-	defer resp.destroy()
-
-	return CheckErr(resp)
 }

--- a/rust/src/fvm/engine.rs
+++ b/rust/src/fvm/engine.rs
@@ -16,7 +16,7 @@ use super::blockstore::CgoBlockstore;
 use super::externs::CgoExterns;
 use super::types::*;
 
-// Generic executor; uses the current (v3) engine types
+// Generic executor; uses the current engine types
 pub trait CgoExecutor: Send {
     fn execute_message(
         &mut self,
@@ -26,6 +26,8 @@ pub trait CgoExecutor: Send {
     ) -> anyhow::Result<ApplyRet>;
 
     fn flush(&mut self) -> anyhow::Result<Cid>;
+
+    fn dump_cache(&mut self, bs: CgoBlockstore) -> anyhow::Result<()>;
 }
 
 pub struct Config {
@@ -147,6 +149,11 @@ mod v4 {
 
         fn flush(&mut self) -> anyhow::Result<Cid> {
             fvm4::executor::Executor::flush(self)
+        }
+
+        fn dump_cache(&mut self, bs: CgoBlockstore) -> anyhow::Result<()> {
+            log::info!("CgoExecutor4::dump_cache");
+            fvm4::executor::Executor::dump_cache(self, bs)
         }
     }
 
@@ -420,6 +427,11 @@ mod v3 {
         fn flush(&mut self) -> anyhow::Result<Cid> {
             fvm3::executor::Executor::flush(self)
         }
+
+        // dump_cache is only implemented in v4
+        fn dump_cache(&mut self, _: CgoBlockstore) -> anyhow::Result<()> {
+            Err(anyhow::anyhow!("dump_cache not implemented for fvm v3"))
+        }
     }
 
     impl AbstractMultiEngine for MultiEngine3 {
@@ -680,6 +692,11 @@ mod v2 {
 
         fn flush(&mut self) -> anyhow::Result<Cid> {
             fvm2::executor::Executor::flush(self)
+        }
+
+        // dump_cache is only implemented in v4
+        fn dump_cache(&mut self, _: CgoBlockstore) -> anyhow::Result<()> {
+            Err(anyhow::anyhow!("dump_cache not implemented for fvm v2"))
         }
     }
 

--- a/rust/src/fvm/machine.rs
+++ b/rust/src/fvm/machine.rs
@@ -439,6 +439,13 @@ struct LotusGasCharge {
 }
 
 #[derive(Clone, Debug, Serialize_tuple, Deserialize_tuple)]
+struct TraceIpld {
+    pub op: u64,
+    pub cid: Cid,
+    pub size: usize,
+}
+
+#[derive(Clone, Debug, Serialize_tuple, Deserialize_tuple)]
 struct Trace {
     pub msg: TraceMessage,
     pub msg_ret: TraceReturn,
@@ -446,6 +453,7 @@ struct Trace {
     pub gas_charges: Vec<LotusGasCharge>,
     pub subcalls: Vec<Trace>,
     pub logs: Vec<String>,
+    pub ipld: Vec<TraceIpld>,
 }
 
 #[derive(Serialize_tuple, Deserialize_tuple, Debug, PartialEq, Eq, Clone)]
@@ -507,6 +515,7 @@ fn build_lotus_trace(
         gas_charges: vec![],
         subcalls: vec![],
         logs: vec![],
+        ipld: vec![],
     };
 
     while let Some(trace) = trace_iter.next() {
@@ -578,6 +587,13 @@ fn build_lotus_trace(
             }
             ExecutionEvent::Log(s) => {
                 new_trace.logs.push(s);
+            }
+            ExecutionEvent::Ipld { op, cid, size } => {
+                new_trace.ipld.push(TraceIpld {
+                    op: op as u64,
+                    cid,
+                    size,
+                });
             }
             _ => (), // ignore unknown events.
         };


### PR DESCRIPTION
Ref: https://github.com/filecoin-project/ref-fvm/pull/2101

This is a draft, but the `ExecutionEvent::Log` could probably be done separately since that's much more likely to actually make it in. I'll do that if I end up bailing on this.