### PR TITLE
ci: fix environment configuration on Ubuntu 24.04 arm64

### DIFF
--- a/.github/actions/configure-environment/action.yml
+++ b/.github/actions/configure-environment/action.yml
@@ -4,18 +4,32 @@ description: Configure environment variables for Filecoin FFI
 runs:
   using: 'composite'
   steps:
+    # The installation instructions can be found at https://developer.nvidia.com/cuda-downloads
     - if: runner.os == 'Linux' && runner.arch == 'ARM64'
       run: |
-        wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/sbsa/cuda-ubuntu2204.pin
-        sudo mv cuda-ubuntu2204.pin /etc/apt/preferences.d/cuda-repository-pin-600
-        wget -q https://developer.download.nvidia.com/compute/cuda/12.5.1/local_installers/cuda-repo-ubuntu2204-12-5-local_12.5.1-555.42.06-1_arm64.deb
-        sudo dpkg -i cuda-repo-ubuntu2204-12-5-local_12.5.1-555.42.06-1_arm64.deb
-        sudo cp /var/cuda-repo-ubuntu2204-12-5-local/cuda-*-keyring.gpg /usr/share/keyrings/
+        # Install the CUDA toolkit
+        wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/cuda-ubuntu2404.pin
+        sudo mv cuda-ubuntu2404.pin /etc/apt/preferences.d/cuda-repository-pin-600
+        wget -q https://developer.download.nvidia.com/compute/cuda/12.8.0/local_installers/cuda-repo-ubuntu2404-12-8-local_12.8.0-570.86.10-1_arm64.deb
+        sudo dpkg -i cuda-repo-ubuntu2404-12-8-local_12.8.0-570.86.10-1_arm64.deb
+        sudo cp /var/cuda-repo-ubuntu2404-12-8-local/cuda-*-keyring.gpg /usr/share/keyrings/
         sudo apt-get update
-        sudo apt-get -y install cuda-toolkit-12-5
+        sudo apt-get install --no-install-recommends -y cuda-toolkit-12-8
+        # Symlink the stubs
         sudo mkdir -p /usr/lib/aarch64-linux-gnu/stubs
-        sudo ln -s /usr/local/cuda-12.5/lib64/stubs/libcuda.so /usr/lib/aarch64-linux-gnu/stubs/libcuda.so.1
-        sudo ln -s /usr/local/cuda-12.5/lib64/stubs/libcuda.so /usr/lib/aarch64-linux-gnu/stubs/libcuda.so
+        sudo ln -s /usr/local/cuda-12.8/lib64/stubs/libcuda.so /usr/lib/aarch64-linux-gnu/stubs/libcuda.so.1
+        sudo ln -s /usr/local/cuda-12.8/lib64/stubs/libcuda.so /usr/lib/aarch64-linux-gnu/stubs/libcuda.so
+        # Add the the stubs to the environment
+        echo "LD_LIBRARY_PATH=/usr/lib/aarch64-linux-gnu/stubs:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
+        echo "LIBRARY_PATH=/usr/lib/aarch64-linux-gnu/stubs:${LIBRARY_PATH}" >> $GITHUB_ENV
+        # Add the nvcc to the path
+        echo "/usr/local/cuda-12.8/bin" >> $GITHUB_PATH
+      shell: bash
+    # The version in the default registry is outdated (12.0.1 as of 2025-02-02) but it is quicker to install
+    - if: runner.os == 'Linux' && runner.arch == 'X64'
+      run: |
+        sudo apt-get update
+        sudo apt-get install --no-install-recommends -y nvidia-cuda-toolkit
       shell: bash
     - run: |
         echo "FIL_PROOFS_PARAMETER_CACHE=${GITHUB_WORKSPACE}/filecoin-proof-parameters/" >> $GITHUB_ENV
@@ -30,11 +44,6 @@ runs:
         echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
         echo "${HOME}/.bin" >> $GITHUB_PATH
       shell: bash
-    - if: runner.os == 'Linux' && runner.arch == 'ARM64'
-      run: |
-        echo "LD_LIBRARY_PATH=/usr/lib/aarch64-linux-gnu/stubs:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
-        echo "LIBRARY_PATH=/usr/lib/aarch64-linux-gnu/stubs:${LIBRARY_PATH}" >> $GITHUB_ENV
-      shell: bash
     - if: runner.os == 'macOS'
       run: |
         echo "CPATH=$(brew --prefix)/include" >> $GITHUB_ENV
@@ -43,11 +52,7 @@ runs:
     - if: runner.os == 'Linux'
       run: |
         sudo apt-get update
-        sudo apt-get install --no-install-recommends -y valgrind ocl-icd-opencl-dev libssl-dev libhwloc-dev nvidia-cuda-toolkit g++-10 pkgconf
-        # Downgrade to GCC 10, as CUDA 11 doesn't play nice with GCC 11
-        sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-10 10
-        sudo update-alternatives --set c++ /usr/bin/g++-10
-        # Check if we need to install cuda-toolkit-12-5
+        sudo apt-get install --no-install-recommends -y valgrind ocl-icd-opencl-dev libssl-dev libhwloc-dev pkgconf
       shell: bash
     - if: runner.os == 'macOS'
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,10 @@ jobs:
   supraseal:
     name: Build with CUDA supraseal
     runs-on: ubuntu-latest
+    env:
+      CC: gcc-12
+      CXX: g++-12
+      NVCC_PREPEND_FLAGS: "-ccbin /usr/bin/g++-12"
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This fixes the environment configuration on Ubuntu 24.04 arm64 machines.

The context for the fix is that Ubuntu 24.04 comes with glibc 2.39 installed. Using older versions of nvcc with that glibc version results in the following errors - https://bugs.launchpad.net/ubuntu/+source/mumax3/+bug/2032624. This is specific to arm64 builds only.

On the plus side, we no longer have to downgrade gcc.

As a follow-up piece of work, we should consider installing the latest version of CUDA toolkit in the AMIs.

TODO (@galargh):
- [ ] upgrade 4xlarge self-hosted runners to Ubuntu 24.04