### PR TITLE
Fix receivers defined on cgo type aliases

### DIFF
--- a/cgo/bls.go
+++ b/cgo/bls.go
@@ -9,13 +9,13 @@ package cgo
 import "C"
 
 func Hash(message SliceRefUint8) *[96]byte {
-	resp := C.hash(message)
+	resp := ByteArray96{delegate: C.hash(message)}
 	defer resp.destroy()
 	return resp.copyAsArray()
 }
 
 func Aggregate(flattenedSignatures SliceRefUint8) *[96]byte {
-	resp := C.aggregate(flattenedSignatures)
+	resp := ByteArray96{delegate: C.aggregate(flattenedSignatures)}
 	defer resp.destroy()
 	return resp.copyAsArray()
 }
@@ -31,31 +31,31 @@ func HashVerify(signature SliceRefUint8, flattenedMessages SliceRefUint8, messag
 }
 
 func PrivateKeyGenerate() *[32]byte {
-	resp := C.private_key_generate()
+	resp := ByteArray32{delegate: C.private_key_generate()}
 	defer resp.destroy()
 	return resp.copyAsArray()
 }
 
 func PrivateKeyGenerateWithSeed(rawSeed *ByteArray32) *[32]byte {
-	resp := C.private_key_generate_with_seed(rawSeed)
+	resp := ByteArray32{delegate: C.private_key_generate_with_seed(rawSeed.delegate)}
 	defer resp.destroy()
 	return resp.copyAsArray()
 }
 
 func PrivateKeySign(rawPrivateKey SliceRefUint8, message SliceRefUint8) *[96]byte {
-	resp := C.private_key_sign(rawPrivateKey, message)
+	resp := ByteArray96{delegate: C.private_key_sign(rawPrivateKey, message)}
 	defer resp.destroy()
 	return resp.copyAsArray()
 }
 
 func PrivateKeyPublicKey(rawPrivateKey SliceRefUint8) *[48]byte {
-	resp := C.private_key_public_key(rawPrivateKey)
+	resp := ByteArray48{delegate: C.private_key_public_key(rawPrivateKey)}
 	defer resp.destroy()
 	return resp.copyAsArray()
 }
 
 func CreateZeroSignature() *[96]byte {
-	resp := C.create_zero_signature()
+	resp := ByteArray96{delegate: C.create_zero_signature()}
 	defer resp.destroy()
 	return resp.copyAsArray()
 }

--- a/cgo/fvm.go
+++ b/cgo/fvm.go
@@ -9,84 +9,91 @@ package cgo
 import "C"
 
 func CreateFvmMachine(fvmVersion FvmRegisteredVersion, chainEpoch, chainTimestamp, chainId, baseFeeHi, baseFeeLo, baseCircSupplyHi, baseCircSupplyLo, networkVersion uint64, stateRoot SliceRefUint8, tracing bool, blockstoreId, externsId uint64) (*FvmMachine, error) {
-	resp := C.create_fvm_machine(
-		fvmVersion,
-		C.uint64_t(chainEpoch),
-		C.uint64_t(chainTimestamp),
-		C.uint64_t(chainId),
-		C.uint64_t(baseFeeHi),
-		C.uint64_t(baseFeeLo),
-		C.uint64_t(baseCircSupplyHi),
-		C.uint64_t(baseCircSupplyLo),
-		C.uint32_t(networkVersion),
-		stateRoot,
-		C.bool(tracing),
-		C.uint64_t(blockstoreId),
-		C.uint64_t(externsId),
-	)
+	resp := &resultFvmMachine{
+		delegate: C.create_fvm_machine(
+			fvmVersion,
+			C.uint64_t(chainEpoch),
+			C.uint64_t(chainTimestamp),
+			C.uint64_t(chainId),
+			C.uint64_t(baseFeeHi),
+			C.uint64_t(baseFeeLo),
+			C.uint64_t(baseCircSupplyHi),
+			C.uint64_t(baseCircSupplyLo),
+			C.uint32_t(networkVersion),
+			stateRoot,
+			C.bool(tracing),
+			C.uint64_t(blockstoreId),
+			C.uint64_t(externsId),
+		),
+	}
 	// take out the pointer from the result to ensure it doesn't get freed
-	executor := resp.value
-	resp.value = nil
+	executor := resp.delegate.value
+	resp.delegate.value = nil
 	defer resp.destroy()
 
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
 
-	return executor, nil
+	return &FvmMachine{delegate: executor}, nil
 }
 
 func CreateFvmDebugMachine(fvmVersion FvmRegisteredVersion, chainEpoch, chainTimestamp, chainId, baseFeeHi, baseFeeLo, baseCircSupplyHi, baseCircSupplyLo, networkVersion uint64, stateRoot SliceRefUint8, actorRedirect SliceRefUint8, tracing bool, blockstoreId, externsId uint64) (*FvmMachine, error) {
-	resp := C.create_fvm_debug_machine(
-		fvmVersion,
-		C.uint64_t(chainEpoch),
-		C.uint64_t(chainTimestamp),
-		C.uint64_t(chainId),
-		C.uint64_t(baseFeeHi),
-		C.uint64_t(baseFeeLo),
-		C.uint64_t(baseCircSupplyHi),
-		C.uint64_t(baseCircSupplyLo),
-		C.uint32_t(networkVersion),
-		stateRoot,
-		actorRedirect,
-		C.bool(tracing),
-		C.uint64_t(blockstoreId),
-		C.uint64_t(externsId),
-	)
+	resp := &resultFvmMachine{
+		delegate: C.create_fvm_debug_machine(
+			fvmVersion,
+			C.uint64_t(chainEpoch),
+			C.uint64_t(chainTimestamp),
+			C.uint64_t(chainId),
+			C.uint64_t(baseFeeHi),
+			C.uint64_t(baseFeeLo),
+			C.uint64_t(baseCircSupplyHi),
+			C.uint64_t(baseCircSupplyLo),
+			C.uint32_t(networkVersion),
+			stateRoot,
+			actorRedirect,
+			C.bool(tracing),
+			C.uint64_t(blockstoreId),
+			C.uint64_t(externsId),
+		),
+	}
 	// take out the pointer from the result to ensure it doesn't get freed
-	executor := resp.value
-	resp.value = nil
+	executor := resp.delegate.value
+	resp.delegate.value = nil
 	defer resp.destroy()
 
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
 
-	return executor, nil
+	return &FvmMachine{delegate: executor}, nil
 }
 
 func FvmMachineExecuteMessage(executor *FvmMachine, message SliceRefUint8, chainLen, applyKind uint64) (FvmMachineExecuteResponseGo, error) {
-	resp := C.fvm_machine_execute_message(
-		executor,
-		message,
-		C.uint64_t(chainLen),
-		C.uint64_t(applyKind),
-	)
+	resp := &resultFvmMachineExecuteResponse{
+		delegate: C.fvm_machine_execute_message(
+			executor.delegate,
+			message,
+			C.uint64_t(chainLen),
+			C.uint64_t(applyKind),
+		),
+	}
 	defer resp.destroy()
 
 	if err := CheckErr(resp); err != nil {
 		return FvmMachineExecuteResponseGo{}, err
 	}
 
-	return resp.value.copy(), nil
+	response := &FvmMachineExecuteResponse{delegate: &resp.delegate.value}
+	return response.copy(), nil
 }
 
 func FvmMachineFlush(executor *FvmMachine) ([]byte, error) {
-	resp := C.fvm_machine_flush(executor)
+	resp := &resultSliceBoxedUint8{delegate: C.fvm_machine_flush(executor.delegate)}
 	defer resp.destroy()
 
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
-	return resp.value.copy(), nil
+	return SliceBoxedUint8{delegate: resp.delegate.value}.copy(), nil
 }

--- a/cgo/proofs.go
+++ b/cgo/proofs.go
@@ -9,232 +9,236 @@ package cgo
 import "C"
 
 func VerifySeal(registeredProof RegisteredSealProof, commR *ByteArray32, commD *ByteArray32, proverId *ByteArray32, ticket *ByteArray32, seed *ByteArray32, sectorId uint64, proof SliceRefUint8) (bool, error) {
-	resp := C.verify_seal(registeredProof, commR, commD, proverId, ticket, seed, C.uint64_t(sectorId), proof)
+	resp := &resultBool{delegate: C.verify_seal(registeredProof, commR.delegate, commD.delegate, proverId.delegate, ticket.delegate, seed.delegate, C.uint64_t(sectorId), proof)}
 	defer resp.destroy()
 
 	if err := CheckErr(resp); err != nil {
 		return false, err
 	}
 
-	return bool(resp.value), nil
+	return bool(resp.delegate.value), nil
 }
 
 func VerifyAggregateSealProof(registeredProof RegisteredSealProof, registeredAggregation RegisteredAggregationProof, proverId *ByteArray32, proof SliceRefUint8, commitInputs SliceRefAggregationInputs) (bool, error) {
-	resp := C.verify_aggregate_seal_proof(registeredProof, registeredAggregation, proverId, proof, commitInputs)
+	resp := &resultBool{delegate: C.verify_aggregate_seal_proof(registeredProof, registeredAggregation, proverId.delegate, proof, commitInputs)}
 	defer resp.destroy()
 
 	if err := CheckErr(resp); err != nil {
 		return false, err
 	}
-	return bool(resp.value), nil
+	return bool(resp.delegate.value), nil
 }
 
 func VerifyWinningPoSt(randomness *ByteArray32, replicas SliceRefPublicReplicaInfo, proofs SliceRefPoStProof, proverId *ByteArray32) (bool, error) {
-	resp := C.verify_winning_post(randomness, replicas, proofs, proverId)
+	resp := &resultBool{delegate: C.verify_winning_post(randomness.delegate, replicas, proofs, proverId.delegate)}
 	defer resp.destroy()
 
 	if err := CheckErr(resp); err != nil {
 		return false, err
 	}
 
-	return bool(resp.value), nil
+	return bool(resp.delegate.value), nil
 }
 
 func VerifyWindowPoSt(randomness *ByteArray32, replicas SliceRefPublicReplicaInfo, proofs SliceRefPoStProof, proverId *ByteArray32) (bool, error) {
-	resp := C.verify_window_post(randomness, replicas, proofs, proverId)
+	resp := &resultBool{delegate: C.verify_window_post(randomness.delegate, replicas, proofs, proverId.delegate)}
 	defer resp.destroy()
 
 	if err := CheckErr(resp); err != nil {
 		return false, err
 	}
 
-	return bool(resp.value), nil
+	return bool(resp.delegate.value), nil
 }
 
 func GeneratePieceCommitment(registeredProof RegisteredSealProof, pieceFdRaw int32, unpaddedPieceSize uint64) ([]byte, error) {
-	resp := C.generate_piece_commitment(registeredProof, C.int32_t(pieceFdRaw), C.uint64_t(unpaddedPieceSize))
+	resp := &resultGeneratePieceCommitment{delegate: C.generate_piece_commitment(registeredProof, C.int32_t(pieceFdRaw), C.uint64_t(unpaddedPieceSize))}
 	defer resp.destroy()
 
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
 
-	return resp.value.comm_p.copy(), nil
+	commp := ByteArray32{delegate: &resp.delegate.value.comm_p}
+	return commp.copy(), nil
 }
 
 func GenerateDataCommitment(registeredProof RegisteredSealProof, pieces SliceRefPublicPieceInfo) ([]byte, error) {
-	resp := C.generate_data_commitment(registeredProof, pieces)
+	resp := &resultByteArray32{delegate: C.generate_data_commitment(registeredProof, pieces)}
 	defer resp.destroy()
 
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
 
-	return resp.value.copy(), nil
+	value := ByteArray32{delegate: &resp.delegate.value}
+	return value.copy(), nil
 }
 
 func WriteWithAlignment(registeredProof RegisteredSealProof, srcFd int32, srcSize uint64, dstFd int32, existingPieceSizes SliceRefUint64) (uint64, uint64, []byte, error) {
-	resp := C.write_with_alignment(registeredProof, C.int32_t(srcFd), C.uint64_t(srcSize), C.int32_t(dstFd), existingPieceSizes)
+	resp := &resultWriteWithAlignment{delegate: C.write_with_alignment(registeredProof, C.int32_t(srcFd), C.uint64_t(srcSize), C.int32_t(dstFd), existingPieceSizes)}
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return 0, 0, nil, err
 	}
 
-	return uint64(resp.value.left_alignment_unpadded), uint64(resp.value.total_write_unpadded), resp.value.comm_p.copy(), nil
+	commp := ByteArray32{delegate: &resp.delegate.value.comm_p}
+	return uint64(resp.delegate.value.left_alignment_unpadded), uint64(resp.delegate.value.total_write_unpadded), commp.copy(), nil
 }
 
 func WriteWithoutAlignment(registeredProof RegisteredSealProof, srcFd int32, srcSize uint64, dstFd int32) (uint64, []byte, error) {
-	resp := C.write_without_alignment(registeredProof, C.int32_t(srcFd), C.uint64_t(srcSize), C.int32_t(dstFd))
+	resp := &resultWriteWithoutAlignment{delegate: C.write_without_alignment(registeredProof, C.int32_t(srcFd), C.uint64_t(srcSize), C.int32_t(dstFd))}
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return 0, nil, err
 	}
 
-	return uint64(resp.value.total_write_unpadded), resp.value.comm_p.copy(), nil
+	commp := ByteArray32{delegate: &resp.delegate.value.comm_p}
+	return uint64(resp.delegate.value.total_write_unpadded), commp.copy(), nil
 }
 
 func SealPreCommitPhase1(registeredProof RegisteredSealProof, cacheDirPath SliceRefUint8, stagedSectorPath SliceRefUint8, sealedSectorPath SliceRefUint8, sectorId uint64, proverId *ByteArray32, ticket *ByteArray32, pieces SliceRefPublicPieceInfo) ([]byte, error) {
-	resp := C.seal_pre_commit_phase1(registeredProof, cacheDirPath, stagedSectorPath, sealedSectorPath, C.uint64_t(sectorId), proverId, ticket, pieces)
+	resp := &resultSliceBoxedUint8{delegate: C.seal_pre_commit_phase1(registeredProof, cacheDirPath, stagedSectorPath, sealedSectorPath, C.uint64_t(sectorId), proverId.delegate, ticket.delegate, pieces)}
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
-	return resp.value.copy(), nil
+	return SliceBoxedUint8{delegate: resp.delegate.value}.copy(), nil
 }
 
 func SealPreCommitPhase2(sealPreCommitPhase1Output SliceRefUint8, cacheDirPath SliceRefUint8, sealedSectorPath SliceRefUint8) ([]byte, []byte, error) {
-	resp := C.seal_pre_commit_phase2(sealPreCommitPhase1Output, cacheDirPath, sealedSectorPath)
+	resp := &resultSealPreCommitPhase2{delegate: C.seal_pre_commit_phase2(sealPreCommitPhase1Output, cacheDirPath, sealedSectorPath)}
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, nil, err
 	}
-	return resp.value.comm_r.copy(), resp.value.comm_d.copy(), nil
+
+	commr := ByteArray32{delegate: &resp.delegate.value.comm_r}
+	commd := ByteArray32{delegate: &resp.delegate.value.comm_d}
+	return commr.copy(), commd.copy(), nil
 }
 
 func SealCommitPhase1(registeredProof RegisteredSealProof, commR *ByteArray32, commD *ByteArray32, cacheDirPath SliceRefUint8, replicaPath SliceRefUint8, sectorId uint64, proverId *ByteArray32, ticket *ByteArray32, seed *ByteArray32, pieces SliceRefPublicPieceInfo) ([]byte, error) {
-	resp := C.seal_commit_phase1(registeredProof, commR, commD, cacheDirPath, replicaPath, C.uint64_t(sectorId), proverId, ticket, seed, pieces)
+	resp := &resultSliceBoxedUint8{delegate: C.seal_commit_phase1(registeredProof, commR.delegate, commD.delegate, cacheDirPath, replicaPath, C.uint64_t(sectorId), proverId.delegate, ticket.delegate, seed.delegate, pieces)}
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
 
-	return resp.value.copy(), nil
+	return SliceBoxedUint8{delegate: resp.delegate.value}.copy(), nil
 }
 
 func SealCommitPhase2(sealCommitPhase1Output SliceRefUint8, sectorId uint64, proverId *ByteArray32) ([]byte, error) {
-	resp := C.seal_commit_phase2(sealCommitPhase1Output, C.uint64_t(sectorId), proverId)
+	resp := &resultSliceBoxedUint8{delegate: C.seal_commit_phase2(sealCommitPhase1Output, C.uint64_t(sectorId), proverId.delegate)}
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
-	return resp.value.copy(), nil
+	return SliceBoxedUint8{delegate: resp.delegate.value}.copy(), nil
 }
 
 func SealCommitPhase2CircuitProofs(sealCommitPhase1Output SliceRefUint8, sectorId uint64) ([]byte, error) {
-	resp := C.seal_commit_phase2_circuit_proofs(sealCommitPhase1Output, C.uint64_t(sectorId))
+	resp := &resultSliceBoxedUint8{delegate: C.seal_commit_phase2_circuit_proofs(sealCommitPhase1Output, C.uint64_t(sectorId))}
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
-	return resp.value.copy(), nil
+	return SliceBoxedUint8{delegate: resp.delegate.value}.copy(), nil
 }
 
 func AggregateSealProofs(registeredProof RegisteredSealProof, registeredAggregation RegisteredAggregationProof, commRs SliceRefByteArray32, seeds SliceRefByteArray32, sealCommitResponses SliceRefSliceBoxedUint8) ([]byte, error) {
-	resp := C.aggregate_seal_proofs(registeredProof, registeredAggregation, commRs, seeds, sealCommitResponses)
+	resp := &resultSliceBoxedUint8{delegate: C.aggregate_seal_proofs(registeredProof, registeredAggregation, commRs, seeds, sealCommitResponses)}
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
-	return resp.value.copy(), nil
+	return SliceBoxedUint8{delegate: resp.delegate.value}.copy(), nil
 }
 
 func UnsealRange(registeredProof RegisteredSealProof, cacheDirPath SliceRefUint8, sealedSectorFdRaw int32, unsealOutputFdRaw int32, sectorId uint64, proverId *ByteArray32, ticket *ByteArray32, commD *ByteArray32, unpaddedByteIndex uint64, unpaddedBytesAmount uint64) error {
-	resp := C.unseal_range(registeredProof, cacheDirPath, C.int32_t(sealedSectorFdRaw), C.int32_t(unsealOutputFdRaw), C.uint64_t(sectorId), proverId, ticket, commD, C.uint64_t(unpaddedByteIndex), C.uint64_t(unpaddedBytesAmount))
+	resp := &resultVoid{delegate: C.unseal_range(registeredProof, cacheDirPath, C.int32_t(sealedSectorFdRaw), C.int32_t(unsealOutputFdRaw), C.uint64_t(sectorId), proverId.delegate, ticket.delegate, commD.delegate, C.uint64_t(unpaddedByteIndex), C.uint64_t(unpaddedBytesAmount))}
 	defer resp.destroy()
-	if err := CheckErr(resp); err != nil {
-		return err
-	}
-	return nil
+	return CheckErr(resp)
 }
 
 func GenerateWinningPoStSectorChallenge(registeredProof RegisteredPoStProof, randomness *ByteArray32, sectorSetLen uint64, proverId *ByteArray32) ([]uint64, error) {
-	resp := C.generate_winning_post_sector_challenge(registeredProof, randomness, C.uint64_t(sectorSetLen), proverId)
+	resp := &resultSliceBoxedUint64{delegate: C.generate_winning_post_sector_challenge(registeredProof, randomness.delegate, C.uint64_t(sectorSetLen), proverId.delegate)}
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
-	return resp.value.copy(), nil
+	return SliceBoxedUint64{delegate: resp.delegate.value}.copy(), nil
 }
 
 func GenerateWinningPoSt(randomness *ByteArray32, replicas SliceRefPrivateReplicaInfo, proverId *ByteArray32) ([]PoStProofGo, error) {
-	resp := C.generate_winning_post(randomness, replicas, proverId)
+	resp := &resultSliceBoxedPoStProof{delegate: C.generate_winning_post(randomness.delegate, replicas, proverId.delegate)}
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
-	return resp.value.copy(), nil
+	return SliceBoxedPoStProof{delegate: resp.delegate.value}.copy(), nil
 }
 
 func GenerateWindowPoSt(randomness *ByteArray32, replicas SliceRefPrivateReplicaInfo, proverId *ByteArray32) ([]PoStProofGo, []uint64, error) {
-	resp := C.generate_window_post(randomness, replicas, proverId)
+	resp := &resultGenerateWindowPoSt{delegate: C.generate_window_post(randomness.delegate, replicas, proverId.delegate)}
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
-		faults := resp.value.faulty_sectors.copy()
+		faults := SliceBoxedUint64{delegate: resp.delegate.value.faulty_sectors}.copy()
 		return nil, faults, err
 	}
 
-	proofs := resp.value.proofs.copy()
+	proofs := SliceBoxedPoStProof{delegate: resp.delegate.value.proofs}.copy()
 	return proofs, []uint64{}, nil
 }
 
 func GetGpuDevices() ([]string, error) {
-	resp := C.get_gpu_devices()
+	resp := &resultSliceBoxedSliceBoxedUint8{delegate: C.get_gpu_devices()}
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
 
-	return resp.value.copyAsStrings(), nil
+	return SliceBoxedSliceBoxedUint8{delegate: resp.delegate.value}.copyAsStrings(), nil
 }
 
 func GetSealVersion(registeredProof RegisteredSealProof) (string, error) {
-	resp := C.get_seal_version(registeredProof)
+	resp := &resultSliceBoxedUint8{delegate: C.get_seal_version(registeredProof)}
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return "", err
 	}
 
-	return string(resp.value.copy()), nil
+	return string(SliceBoxedUint8{delegate: resp.delegate.value}.copy()), nil
 }
 
 func GetPoStVersion(registeredProof RegisteredPoStProof) (string, error) {
-	resp := C.get_post_version(registeredProof)
+	resp := &resultSliceBoxedUint8{delegate: C.get_post_version(registeredProof)}
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return "", err
 	}
 
-	return string(resp.value.copy()), nil
+	return string(SliceBoxedUint8{delegate: resp.delegate.value}.copy()), nil
 }
 
 func GetNumPartitionForFallbackPost(registeredProof RegisteredPoStProof, numSectors uint) (uint, error) {
-	resp := C.get_num_partition_for_fallback_post(registeredProof, C.size_t(numSectors))
+	resp := &resultUint{delegate: C.get_num_partition_for_fallback_post(registeredProof, C.size_t(numSectors))}
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return 0, err
 	}
 
-	return uint(resp.value), nil
+	return uint(resp.delegate.value), nil
 }
 
 func ClearCache(sectorSize uint64, cacheDirPath SliceRefUint8) error {
-	resp := C.clear_cache(C.uint64_t(sectorSize), cacheDirPath)
+	resp := &resultVoid{delegate: C.clear_cache(C.uint64_t(sectorSize), cacheDirPath)}
 	defer resp.destroy()
 	return CheckErr(resp)
 }
 
 func ClearSyntheticProofs(sectorSize uint64, cacheDirPath SliceRefUint8) error {
-	resp := C.clear_synthetic_proofs(C.uint64_t(sectorSize), cacheDirPath)
+	resp := &resultVoid{delegate: C.clear_synthetic_proofs(C.uint64_t(sectorSize), cacheDirPath)}
 	defer resp.destroy()
 	return CheckErr(resp)
 }
@@ -247,210 +251,221 @@ func GenerateSynthProofs(
 	prover_id, ticket ByteArray32,
 	pieces SliceRefPublicPieceInfo,
 ) error {
-	resp := C.generate_synth_proofs(registered_proof,
-		&comm_r,
-		&comm_d,
-		cache_dir_path,
-		replica_path,
-		C.uint64_t(sector_id),
-		&prover_id,
-		&ticket,
-		pieces,
-	)
+	resp := &resultVoid{
+		delegate: C.generate_synth_proofs(registered_proof,
+			comm_r.delegate,
+			comm_d.delegate,
+			cache_dir_path,
+			replica_path,
+			C.uint64_t(sector_id),
+			prover_id.delegate,
+			ticket.delegate,
+			pieces,
+		),
+	}
 	defer resp.destroy()
 	return CheckErr(resp)
 }
 
 func Fauxrep(registeredProf RegisteredSealProof, cacheDirPath SliceRefUint8, sealedSectorPath SliceRefUint8) ([]byte, error) {
-	resp := C.fauxrep(registeredProf, cacheDirPath, sealedSectorPath)
+	resp := &resultByteArray32{delegate: C.fauxrep(registeredProf, cacheDirPath, sealedSectorPath)}
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
-	return resp.value.copy(), nil
+	v := ByteArray32{delegate: &resp.delegate.value}
+	return v.copy(), nil
 }
 
 func Fauxrep2(registeredProf RegisteredSealProof, cacheDirPath SliceRefUint8, existingPAuxPath SliceRefUint8) ([]byte, error) {
-	resp := C.fauxrep2(registeredProf, cacheDirPath, existingPAuxPath)
+	resp := &resultByteArray32{delegate: C.fauxrep2(registeredProf, cacheDirPath, existingPAuxPath)}
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
-	return resp.value.copy(), nil
+	v := ByteArray32{delegate: &resp.delegate.value}
+	return v.copy(), nil
 }
 
 // sector update
 
 func EmptySectorUpdateEncodeInto(registeredProof RegisteredUpdateProof, newReplicaPath SliceRefUint8, newCacheDirPath SliceRefUint8, sectorKeyPath SliceRefUint8, sectorKeyCacheDirPath SliceRefUint8, stagedDataPath SliceRefUint8, pieces SliceRefPublicPieceInfo) ([]byte, []byte, error) {
-	resp := C.empty_sector_update_encode_into(registeredProof, newReplicaPath, newCacheDirPath, sectorKeyPath, sectorKeyCacheDirPath, stagedDataPath, pieces)
+	resp := &resultEmptySectorUpdateEncodeInto{
+		delegate: C.empty_sector_update_encode_into(registeredProof, newReplicaPath, newCacheDirPath, sectorKeyPath, sectorKeyCacheDirPath, stagedDataPath, pieces),
+	}
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, nil, err
 	}
-	return resp.value.comm_r_new.copy(), resp.value.comm_d_new.copy(), nil
+	commrNew := ByteArray32{delegate: &resp.delegate.value.comm_r_new}
+	commdNew := ByteArray32{delegate: &resp.delegate.value.comm_d_new}
+	return commrNew.copy(), commdNew.copy(), nil
 }
 
 func EmptySectorUpdateDecodeFrom(registeredProof RegisteredUpdateProof, outDataPath SliceRefUint8, replicaPath SliceRefUint8, sectorKeyPath SliceRefUint8, sectorKeyCacheDirPath SliceRefUint8, commDNew *ByteArray32) error {
-	resp := C.empty_sector_update_decode_from(registeredProof, outDataPath, replicaPath, sectorKeyPath, sectorKeyCacheDirPath, commDNew)
-	defer resp.destroy()
-	if err := CheckErr(resp); err != nil {
-		return err
+	resp := &resultVoid{
+		delegate: C.empty_sector_update_decode_from(registeredProof, outDataPath, replicaPath, sectorKeyPath, sectorKeyCacheDirPath, commDNew.delegate),
 	}
-	return nil
+	defer resp.destroy()
+	return CheckErr(resp)
 }
 
 func EmptySectorUpdateRemoveEncodedData(registeredProof RegisteredUpdateProof, sectorKeyPath, sectorKeyCacheDirPath, replicaPath, replicaCachePath, dataPath SliceRefUint8, commDNew *ByteArray32) error {
-	resp := C.empty_sector_update_remove_encoded_data(registeredProof, sectorKeyPath, sectorKeyCacheDirPath, replicaPath, replicaCachePath, dataPath, commDNew)
-	defer resp.destroy()
-	if err := CheckErr(resp); err != nil {
-		return err
+	resp := &resultVoid{
+		delegate: C.empty_sector_update_remove_encoded_data(registeredProof, sectorKeyPath, sectorKeyCacheDirPath, replicaPath, replicaCachePath, dataPath, commDNew.delegate),
 	}
-	return nil
+	defer resp.destroy()
+	return CheckErr(resp)
 }
 
 func GenerateEmptySectorUpdatePartitionProofs(registeredProof RegisteredUpdateProof, commROld, commRNew, commDNew *ByteArray32, sectorKeyPath, sectorKeyCacheDirPath, replicaPath, replicaCachePath SliceRefUint8) ([][]byte, error) {
-	resp := C.generate_empty_sector_update_partition_proofs(registeredProof, commROld, commRNew, commDNew, sectorKeyPath, sectorKeyCacheDirPath, replicaPath, replicaCachePath)
+	resp := &resultSliceBoxedSliceBoxedUint8{
+		delegate: C.generate_empty_sector_update_partition_proofs(registeredProof, commROld.delegate, commRNew.delegate, commDNew.delegate, sectorKeyPath, sectorKeyCacheDirPath, replicaPath, replicaCachePath),
+	}
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
-	return resp.value.copyAsBytes(), nil
+	return SliceBoxedSliceBoxedUint8{delegate: resp.delegate.value}.copyAsBytes(), nil
 }
 
 func VerifyEmptySectorUpdatePartitionProofs(registeredProof RegisteredUpdateProof, proofs SliceRefSliceBoxedUint8, commROld, commRNew, commDNew *ByteArray32) (bool, error) {
-	resp := C.verify_empty_sector_update_partition_proofs(registeredProof, proofs, commROld, commRNew, commDNew)
+	resp := &resultBool{delegate: C.verify_empty_sector_update_partition_proofs(registeredProof, proofs, commROld.delegate, commRNew.delegate, commDNew.delegate)}
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return false, err
 	}
 
-	return bool(resp.value), nil
+	return bool(resp.delegate.value), nil
 }
 
 func GenerateEmptySectorUpdateProofWithVanilla(registeredProof RegisteredUpdateProof, vanillaProofs SliceRefSliceBoxedUint8, commROld, commRNew, commDNew *ByteArray32) ([]byte, error) {
-	resp := C.generate_empty_sector_update_proof_with_vanilla(registeredProof, vanillaProofs, commROld, commRNew, commDNew)
+	resp := &resultSliceBoxedUint8{delegate: C.generate_empty_sector_update_proof_with_vanilla(registeredProof, vanillaProofs, commROld.delegate, commRNew.delegate, commDNew.delegate)}
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
 
-	return resp.value.copy(), nil
+	return SliceBoxedUint8{delegate: resp.delegate.value}.copy(), nil
 }
 
 func GenerateEmptySectorUpdateProof(registeredProof RegisteredUpdateProof, commROld, commRNew, commDNew *ByteArray32, sectorKeyPath, sectorKeyCacheDirPath, replicaPath, replicaCachePath SliceRefUint8) ([]byte, error) {
-	resp := C.generate_empty_sector_update_proof(registeredProof, commROld, commRNew, commDNew, sectorKeyPath, sectorKeyCacheDirPath, replicaPath, replicaCachePath)
+	resp := &resultSliceBoxedUint8{delegate: C.generate_empty_sector_update_proof(registeredProof, commROld.delegate, commRNew.delegate, commDNew.delegate, sectorKeyPath, sectorKeyCacheDirPath, replicaPath, replicaCachePath)}
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
 
-	return resp.value.copy(), nil
+	return SliceBoxedUint8{delegate: resp.delegate.value}.copy(), nil
 }
 
 func VerifyEmptySectorUpdateProof(registeredProof RegisteredUpdateProof, proof SliceRefUint8, commROld, commRNew, commDNew *ByteArray32) (bool, error) {
-	resp := C.verify_empty_sector_update_proof(registeredProof, proof, commROld, commRNew, commDNew)
+	resp := &resultBool{delegate: C.verify_empty_sector_update_proof(registeredProof, proof, commROld.delegate, commRNew.delegate, commDNew.delegate)}
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return false, err
 	}
 
-	return bool(resp.value), nil
+	return bool(resp.delegate.value), nil
 }
 
 // -- distributed
 
 func GenerateFallbackSectorChallenges(registeredProof RegisteredPoStProof, randomness *ByteArray32, sectorIds SliceRefUint64, proverId *ByteArray32) ([]uint64, [][]uint64, error) {
-	resp := C.generate_fallback_sector_challenges(registeredProof, randomness, sectorIds, proverId)
+	resp := &resultGenerateFallbackSectorChallenges{delegate: C.generate_fallback_sector_challenges(registeredProof, randomness.delegate, sectorIds, proverId.delegate)}
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, nil, err
 	}
 
-	return resp.value.ids.copy(), resp.value.challenges.copy(), nil
+	return SliceBoxedUint64{delegate: resp.delegate.value.ids}.copy(), SliceBoxedSliceBoxedUint64{delegate: resp.delegate.value.challenges}.copy(), nil
 }
 
 func GenerateSingleVanillaProof(replica PrivateReplicaInfo, challenges SliceRefUint64) ([]byte, error) {
-	resp := C.generate_single_vanilla_proof(replica, challenges)
+	resp := &resultSliceBoxedUint8{delegate: C.generate_single_vanilla_proof(replica.delegate, challenges)}
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
 
-	return resp.value.copy(), nil
+	return SliceBoxedUint8{delegate: resp.delegate.value}.copy(), nil
 }
 
 func GenerateWinningPoStWithVanilla(registeredProof RegisteredPoStProof, randomness, proverId *ByteArray32, vanillaProofs SliceRefSliceBoxedUint8) ([]PoStProofGo, error) {
-	resp := C.generate_winning_post_with_vanilla(registeredProof, randomness, proverId, vanillaProofs)
+	resp := &resultSliceBoxedPoStProof{delegate: C.generate_winning_post_with_vanilla(registeredProof, randomness.delegate, proverId.delegate, vanillaProofs)}
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
 
-	return resp.value.copy(), nil
+	return SliceBoxedPoStProof{delegate: resp.delegate.value}.copy(), nil
 }
 
 func GenerateWindowPoStWithVanilla(registeredProof RegisteredPoStProof, randomness, proverId *ByteArray32, vanillaProofs SliceRefSliceBoxedUint8) ([]PoStProofGo, []uint64, error) {
-	resp := C.generate_window_post_with_vanilla(registeredProof, randomness, proverId, vanillaProofs)
+	resp := &resultGenerateWindowPoSt{delegate: C.generate_window_post_with_vanilla(registeredProof, randomness.delegate, proverId.delegate, vanillaProofs)}
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, nil, err
 	}
 
-	return resp.value.proofs.copy(), resp.value.faulty_sectors.copy(), nil
+	return SliceBoxedPoStProof{delegate: resp.delegate.value.proofs}.copy(), SliceBoxedUint64{delegate: resp.delegate.value.faulty_sectors}.copy(), nil
 }
 
 func GenerateSingleWindowPoStWithVanilla(registeredProof RegisteredPoStProof, randomness, proverId *ByteArray32, vanillaProofs SliceRefSliceBoxedUint8, partitionIndex uint) (PartitionSnarkProofGo, []uint64, error) {
-	resp := C.generate_single_window_post_with_vanilla(registeredProof, randomness, proverId, vanillaProofs, C.size_t(partitionIndex))
+	resp := &resultGenerateSingleWindowPoStWithVanilla{delegate: C.generate_single_window_post_with_vanilla(registeredProof, randomness.delegate, proverId.delegate, vanillaProofs, C.size_t(partitionIndex))}
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return PartitionSnarkProofGo{}, nil, err
 	}
 
-	return resp.value.partition_proof.copy(), resp.value.faulty_sectors.copy(), nil
+	return PartitionSnarkProof{delegate: resp.delegate.value.partition_proof}.copy(), SliceBoxedUint64{delegate: resp.delegate.value.faulty_sectors}.copy(), nil
 }
 
 func MergeWindowPoStPartitionProofs(registeredProof RegisteredPoStProof, partitionProofs SliceRefSliceBoxedUint8) (PoStProofGo, error) {
-	resp := C.merge_window_post_partition_proofs(registeredProof, partitionProofs)
+	resp := &resultPoStProof{delegate: C.merge_window_post_partition_proofs(registeredProof, partitionProofs)}
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return PoStProofGo{}, err
 	}
 
-	return resp.value.copy(), nil
+	return PoStProof{delegate: resp.delegate.value}.copy(), nil
 }
 
 // PoRep primitives
 
 func GenerateSDR(registeredProof RegisteredPoStProof, outDir SliceRefUint8, replicaID *ByteArray32) error {
-	resp := C.generate_sdr(registeredProof, outDir, replicaID)
+	resp := &resultVoid{delegate: C.generate_sdr(registeredProof, outDir, replicaID.delegate)}
 	defer resp.destroy()
 
 	return CheckErr(resp)
 }
 
 func GenerateTreeRLast(registeredProof RegisteredPoStProof, replicaPath, outDir SliceRefUint8) ([]byte, error) {
-	resp := C.generate_tree_r_last(registeredProof, replicaPath, outDir)
+	resp := &resultByteArray32{delegate: C.generate_tree_r_last(registeredProof, replicaPath, outDir)}
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
 
-	return resp.value.copy(), nil
+	v := ByteArray32{delegate: &resp.delegate.value}
+	return v.copy(), nil
 }
 
 func GenerateTreeC(registeredProof RegisteredPoStProof, inputDir, outDir SliceRefUint8) ([]byte, error) {
-	resp := C.generate_tree_c(registeredProof, inputDir, outDir)
+	resp := &resultByteArray32{delegate: C.generate_tree_c(registeredProof, inputDir, outDir)}
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
 
-	return resp.value.copy(), nil
+	v := ByteArray32{delegate: &resp.delegate.value}
+	return v.copy(), nil
 }
 
 func EmptySectorUpdateDecodeFromRange(registeredProof RegisteredUpdateProof, commD, commR *ByteArray32, inputFd, sectorKeyFd, outputFd int32, nodesOffset, numNodes uint64) error {
-	resp := C.empty_sector_update_decode_from_range(registeredProof, commD, commR, C.int(inputFd), C.int(sectorKeyFd), C.int(outputFd), C.uint64_t(nodesOffset), C.uint64_t(numNodes))
+	resp := &resultVoid{
+		delegate: C.empty_sector_update_decode_from_range(registeredProof, commD.delegate, commR.delegate, C.int(inputFd), C.int(sectorKeyFd), C.int(outputFd), C.uint64_t(nodesOffset), C.uint64_t(numNodes)),
+	}
 	defer resp.destroy()
-
 	return CheckErr(resp)
 }

--- a/cgo/types.go
+++ b/cgo/types.go
@@ -23,9 +23,9 @@ type FvmRegisteredVersion = C.FvmRegisteredVersion_t
 type AggregationInputs = C.AggregationInputs_t
 
 type PublicReplicaInfo = C.PublicReplicaInfo_t
-type PrivateReplicaInfo = C.PrivateReplicaInfo_t
-type PartitionSnarkProof = C.PartitionSnarkProof_t
-type PoStProof = C.PoStProof_t
+type PrivateReplicaInfo struct{ delegate C.PrivateReplicaInfo_t }
+type PartitionSnarkProof struct{ delegate C.PartitionSnarkProof_t }
+type PoStProof struct{ delegate C.PoStProof_t }
 type PublicPieceInfo = C.PublicPieceInfo_t
 
 type SliceRefPublicReplicaInfo = C.slice_ref_PublicReplicaInfo_t
@@ -39,39 +39,73 @@ type SliceRefUint8 = C.slice_ref_uint8_t
 type SliceRefUint = C.slice_ref_size_t
 type SliceRefAggregationInputs = C.slice_ref_AggregationInputs_t
 
-type SliceBoxedPoStProof = C.struct_slice_boxed_PoStProof
-type SliceBoxedUint64 = C.struct_slice_boxed_uint64
-type SliceBoxedSliceBoxedUint8 = C.slice_boxed_slice_boxed_uint8_t
-type SliceBoxedSliceBoxedUint64 = C.slice_boxed_slice_boxed_uint64_t
-type SliceBoxedUint8 = C.struct_slice_boxed_uint8
+type SliceBoxedPoStProof struct {
+	delegate C.struct_slice_boxed_PoStProof
+}
+type SliceBoxedUint64 struct{ delegate C.struct_slice_boxed_uint64 }
+type SliceBoxedSliceBoxedUint8 struct {
+	delegate C.slice_boxed_slice_boxed_uint8_t
+}
+type SliceBoxedSliceBoxedUint64 struct {
+	delegate C.slice_boxed_slice_boxed_uint64_t
+}
+type SliceBoxedUint8 struct{ delegate C.struct_slice_boxed_uint8 }
 
-type ByteArray32 = C.uint8_32_array_t
-type ByteArray48 = C.uint8_48_array_t
-type ByteArray96 = C.uint8_96_array_t
+type ByteArray32 struct{ delegate *C.uint8_32_array_t }
+type ByteArray48 struct{ delegate *C.uint8_48_array_t }
+type ByteArray96 struct{ delegate *C.uint8_96_array_t }
 
-type FvmMachine = C.InnerFvmMachine_t
-type FvmMachineExecuteResponse = C.FvmMachineExecuteResponse_t
+type FvmMachine struct{ delegate *C.InnerFvmMachine_t }
+type FvmMachineExecuteResponse struct {
+	delegate *C.FvmMachineExecuteResponse_t
+}
 
-type resultBool = C.Result_bool_t
-type resultGeneratePieceCommitment = C.Result_GeneratePieceCommitment_t
-type resultWriteWithAlignment = C.Result_WriteWithAlignment_t
-type resultWriteWithoutAlignment = C.Result_WriteWithoutAlignment_t
-type resultByteArray32 = C.Result_uint8_32_array_t
-type resultVoid = C.Result_void_t
-type resultSealPreCommitPhase2 = C.Result_SealPreCommitPhase2_t
-type resultSliceBoxedUint8 = C.Result_slice_boxed_uint8_t
-type resultSliceBoxedPoStProof = C.Result_slice_boxed_PoStProof_t
-type resultSliceBoxedUint64 = C.Result_slice_boxed_uint64_t
-type resultUint = C.Result_size_t
-type resultSliceBoxedSliceBoxedUint8 = C.Result_slice_boxed_slice_boxed_uint8_t
-type resultGenerateWindowPoSt = C.Result_GenerateWindowPoSt_t
-type resultEmptySectorUpdateEncodeInto = C.Result_EmptySectorUpdateEncodeInto_t
-type resultGenerateFallbackSectorChallenges = C.Result_GenerateFallbackSectorChallenges_t
-type resultGenerateSingleWindowPoStWithVanilla = C.Result_GenerateSingleWindowPoStWithVanilla_t
-type resultPoStProof = C.Result_PoStProof_t
+type resultBool struct{ delegate *C.Result_bool_t }
+type resultGeneratePieceCommitment struct {
+	delegate *C.Result_GeneratePieceCommitment_t
+}
+type resultWriteWithAlignment struct {
+	delegate *C.Result_WriteWithAlignment_t
+}
+type resultWriteWithoutAlignment struct {
+	delegate *C.Result_WriteWithoutAlignment_t
+}
+type resultByteArray32 struct{ delegate *C.Result_uint8_32_array_t }
+type resultVoid struct{ delegate *C.Result_void_t }
+type resultSealPreCommitPhase2 struct {
+	delegate *C.Result_SealPreCommitPhase2_t
+}
+type resultSliceBoxedUint8 struct{ delegate *C.Result_slice_boxed_uint8_t }
+type resultSliceBoxedPoStProof struct {
+	delegate *C.Result_slice_boxed_PoStProof_t
+}
+type resultSliceBoxedUint64 struct {
+	delegate *C.Result_slice_boxed_uint64_t
+}
+type resultUint struct{ delegate *C.Result_size_t }
+type resultSliceBoxedSliceBoxedUint8 struct {
+	delegate *C.Result_slice_boxed_slice_boxed_uint8_t
+}
+type resultGenerateWindowPoSt struct {
+	delegate *C.Result_GenerateWindowPoSt_t
+}
+type resultEmptySectorUpdateEncodeInto struct {
+	delegate *C.Result_EmptySectorUpdateEncodeInto_t
+}
+type resultGenerateFallbackSectorChallenges struct {
+	delegate *C.Result_GenerateFallbackSectorChallenges_t
+}
+type resultGenerateSingleWindowPoStWithVanilla struct {
+	delegate *C.Result_GenerateSingleWindowPoStWithVanilla_t
+}
+type resultPoStProof struct{ delegate *C.Result_PoStProof_t }
 
-type resultFvmMachine = C.Result_InnerFvmMachine_ptr_t
-type resultFvmMachineExecuteResponse = C.Result_FvmMachineExecuteResponse_t
+type resultFvmMachine struct {
+	delegate *C.Result_InnerFvmMachine_ptr_t
+}
+type resultFvmMachineExecuteResponse struct {
+	delegate *C.Result_FvmMachineExecuteResponse_t
+}
 
 type result interface {
 	statusCode() FCPResponseStatus
@@ -115,64 +149,65 @@ type FvmMachineExecuteResponseGo struct {
 }
 
 func (ptr SliceBoxedUint8) slice() []byte {
-	if ptr.ptr == nil {
+	if ptr.delegate.ptr == nil {
 		return nil
 	}
-	return unsafe.Slice((*byte)(ptr.ptr), int(ptr.len))
+	return unsafe.Slice((*byte)(ptr.delegate.ptr), int(ptr.delegate.len))
 }
 
 func (ptr SliceBoxedUint8) copy() []byte {
-	if ptr.ptr == nil {
+	if ptr.delegate.ptr == nil {
 		return nil
-	} else if ptr.len == 0 {
+	} else if ptr.delegate.len == 0 {
 		return []byte{}
 	}
 
-	res := make([]byte, int(ptr.len))
+	res := make([]byte, int(ptr.delegate.len))
 	copy(res, ptr.slice())
 	return res
 }
 
 func (ptr *resultBool) statusCode() FCPResponseStatus {
-	return FCPResponseStatus(ptr.status_code)
+	return FCPResponseStatus(ptr.delegate.status_code)
 }
 
 func (ptr *resultBool) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return &SliceBoxedUint8{delegate: ptr.delegate.error_msg}
 }
 
 func (ptr *resultBool) destroy() {
-	if ptr != nil {
+	if ptr != nil && ptr.delegate != nil {
 		// TODO: correct naming
-		C.destroy_verify_seal_response(ptr)
-		ptr = nil
+		C.destroy_verify_seal_response(ptr.delegate)
+		ptr.delegate = nil
 	}
 }
 
 func (ptr *PoStProof) registeredProof() RegisteredPoStProof {
-	return ptr.registered_proof
+	return ptr.delegate.registered_proof
 }
 
 func (ptr *PoStProof) destroy() {
 	if ptr != nil {
-		ptr.proof.Destroy()
+		proof := &SliceBoxedUint8{delegate: ptr.delegate.proof}
+		proof.Destroy()
 		ptr = nil
 	}
 }
 
 func (ptr *ByteArray96) destroy() {
-	if ptr != nil {
-		C.destroy_box_bls_digest(ptr)
+	if ptr != nil || ptr.delegate == nil {
+		C.destroy_box_bls_digest(ptr.delegate)
 		ptr = nil
 	}
 }
 
 func (ptr ByteArray96) slice() []byte {
-	return unsafe.Slice((*byte)(unsafe.Pointer(&ptr.idx[0])), 96)
+	return unsafe.Slice((*byte)(unsafe.Pointer(&ptr.delegate.idx[0])), 96)
 }
 
 func (ptr *ByteArray96) copyAsArray() *[96]byte {
-	if ptr == nil {
+	if ptr == nil || ptr.delegate == nil {
 		return nil
 	}
 	var res [96]byte
@@ -181,11 +216,11 @@ func (ptr *ByteArray96) copyAsArray() *[96]byte {
 }
 
 func (ptr ByteArray48) slice() []byte {
-	return unsafe.Slice((*byte)(unsafe.Pointer(&ptr.idx[0])), 48)
+	return unsafe.Slice((*byte)(unsafe.Pointer(&ptr.delegate.idx[0])), 48)
 }
 
 func (ptr *ByteArray48) copyAsArray() *[48]byte {
-	if ptr == nil {
+	if ptr == nil || ptr.delegate == nil {
 		return nil
 	}
 	var res [48]byte
@@ -194,14 +229,15 @@ func (ptr *ByteArray48) copyAsArray() *[48]byte {
 }
 
 func (ptr *ByteArray48) destroy() {
-	if ptr != nil {
-		C.destroy_box_bls_public_key(ptr)
+	if ptr != nil && ptr.delegate != nil {
+		c := &ptr.delegate
+		C.destroy_box_bls_public_key(*c)
 		ptr = nil
 	}
 }
 
 func (ptr ByteArray32) slice() []byte {
-	return unsafe.Slice((*byte)(unsafe.Pointer(&ptr.idx[0])), 32)
+	return unsafe.Slice((*byte)(unsafe.Pointer(&ptr.delegate.idx[0])), 32)
 }
 
 func (ptr *ByteArray32) copy() []byte {
@@ -213,7 +249,7 @@ func (ptr *ByteArray32) copy() []byte {
 }
 
 func (ptr *ByteArray32) copyAsArray() *[32]byte {
-	if ptr == nil {
+	if ptr == nil || ptr.delegate == nil {
 		return nil
 	}
 	var res [32]byte
@@ -222,166 +258,167 @@ func (ptr *ByteArray32) copyAsArray() *[32]byte {
 }
 
 func (ptr *ByteArray32) destroy() {
-	if ptr != nil {
-		C.destroy_box_bls_private_key(ptr)
+	if ptr != nil && ptr.delegate != nil {
+		c := &ptr.delegate
+		C.destroy_box_bls_private_key(*c)
 		ptr = nil
 	}
 }
 
 func (ptr *resultGeneratePieceCommitment) statusCode() FCPResponseStatus {
-	return FCPResponseStatus(ptr.status_code)
+	return FCPResponseStatus(ptr.delegate.status_code)
 }
 
 func (ptr *resultGeneratePieceCommitment) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return &SliceBoxedUint8{delegate: ptr.delegate.error_msg}
 }
 
 func (ptr *resultGeneratePieceCommitment) destroy() {
-	if ptr != nil {
-		C.destroy_generate_piece_commitment_response(ptr)
-		ptr = nil
+	if ptr != nil && ptr.delegate != nil {
+		C.destroy_generate_piece_commitment_response(ptr.delegate)
+		ptr.delegate = nil
 	}
 }
 
 func (ptr *resultByteArray32) statusCode() FCPResponseStatus {
-	return FCPResponseStatus(ptr.status_code)
+	return FCPResponseStatus(ptr.delegate.status_code)
 }
 
 func (ptr *resultByteArray32) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return &SliceBoxedUint8{delegate: ptr.delegate.error_msg}
 }
 
 func (ptr *resultByteArray32) destroy() {
-	if ptr != nil {
+	if ptr != nil && ptr.delegate != nil {
 		// TODO: better naming
-		C.destroy_generate_data_commitment_response(ptr)
-		ptr = nil
+		C.destroy_generate_data_commitment_response(ptr.delegate)
+		ptr.delegate = nil
 	}
 }
 
 func (ptr *resultWriteWithAlignment) statusCode() FCPResponseStatus {
-	return FCPResponseStatus(ptr.status_code)
+	return FCPResponseStatus(ptr.delegate.status_code)
 }
 
 func (ptr *resultWriteWithAlignment) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return &SliceBoxedUint8{delegate: ptr.delegate.error_msg}
 }
 
 func (ptr *resultWriteWithAlignment) destroy() {
-	if ptr != nil {
-		C.destroy_write_with_alignment_response(ptr)
-		ptr = nil
+	if ptr != nil && ptr.delegate != nil {
+		C.destroy_write_with_alignment_response(ptr.delegate)
+		ptr.delegate = nil
 	}
 }
 
 func (ptr *resultWriteWithoutAlignment) statusCode() FCPResponseStatus {
-	return FCPResponseStatus(ptr.status_code)
+	return FCPResponseStatus(ptr.delegate.status_code)
 }
 
 func (ptr *resultWriteWithoutAlignment) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return &SliceBoxedUint8{delegate: ptr.delegate.error_msg}
 }
 
 func (ptr *resultWriteWithoutAlignment) destroy() {
-	if ptr != nil {
-		C.destroy_write_without_alignment_response(ptr)
-		ptr = nil
+	if ptr != nil && ptr.delegate != nil {
+		C.destroy_write_without_alignment_response(ptr.delegate)
+		ptr.delegate = nil
 	}
 }
 
 func (ptr *resultSliceBoxedUint8) statusCode() FCPResponseStatus {
-	return FCPResponseStatus(ptr.status_code)
+	return FCPResponseStatus(ptr.delegate.status_code)
 }
 
 func (ptr *resultSliceBoxedUint8) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return &SliceBoxedUint8{delegate: ptr.delegate.error_msg}
 }
 
 func (ptr *resultSliceBoxedUint8) destroy() {
-	if ptr != nil {
+	if ptr != nil && ptr.delegate != nil {
 		// TODO: naming
-		C.destroy_seal_pre_commit_phase1_response(ptr)
-		ptr = nil
+		C.destroy_seal_pre_commit_phase1_response(ptr.delegate)
+		ptr.delegate = nil
 	}
 }
 
 func (ptr *resultSealPreCommitPhase2) statusCode() FCPResponseStatus {
-	return FCPResponseStatus(ptr.status_code)
+	return FCPResponseStatus(ptr.delegate.status_code)
 }
 
 func (ptr *resultSealPreCommitPhase2) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return &SliceBoxedUint8{delegate: ptr.delegate.error_msg}
 }
 
 func (ptr *resultSealPreCommitPhase2) destroy() {
-	if ptr != nil {
-		C.destroy_seal_pre_commit_phase2_response(ptr)
-		ptr = nil
+	if ptr != nil && ptr.delegate != nil {
+		C.destroy_seal_pre_commit_phase2_response(ptr.delegate)
+		ptr.delegate = nil
 	}
 }
 
 func (ptr *resultVoid) statusCode() FCPResponseStatus {
-	return FCPResponseStatus(ptr.status_code)
+	return FCPResponseStatus(ptr.delegate.status_code)
 }
 
 func (ptr *resultVoid) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return &SliceBoxedUint8{delegate: ptr.delegate.error_msg}
 }
 
 func (ptr *resultVoid) destroy() {
-	if ptr != nil {
+	if ptr != nil && ptr.delegate != nil {
 		// TODO: correct naming
-		C.destroy_unseal_range_response(ptr)
-		ptr = nil
+		C.destroy_unseal_range_response(ptr.delegate)
+		ptr.delegate = nil
 	}
 }
 
 func (ptr SliceBoxedUint64) slice() []uint64 {
-	if ptr.ptr == nil {
+	if ptr.delegate.ptr == nil {
 		return nil
 	}
-	return unsafe.Slice((*uint64)(unsafe.Pointer(ptr.ptr)), int(ptr.len))
+	return unsafe.Slice((*uint64)(unsafe.Pointer(ptr.delegate.ptr)), int(ptr.delegate.len))
 }
 
 func (ptr SliceBoxedUint64) copy() []uint64 {
-	if ptr.ptr == nil {
+	if ptr.delegate.ptr == nil {
 		return nil
-	} else if ptr.len == 0 {
+	} else if ptr.delegate.len == 0 {
 		return []uint64{}
 	}
 
-	res := make([]uint64, int(ptr.len))
+	res := make([]uint64, int(ptr.delegate.len))
 	copy(res, ptr.slice())
 	return res
 }
 
 func (ptr *resultSliceBoxedUint64) statusCode() FCPResponseStatus {
-	return FCPResponseStatus(ptr.status_code)
+	return FCPResponseStatus(ptr.delegate.status_code)
 }
 
 func (ptr *resultSliceBoxedUint64) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return &SliceBoxedUint8{delegate: ptr.delegate.error_msg}
 }
 
 func (ptr *resultSliceBoxedUint64) destroy() {
-	if ptr != nil {
+	if ptr != nil && ptr.delegate != nil {
 		// TODO: correct naming
-		C.destroy_generate_winning_post_sector_challenge(ptr)
-		ptr = nil
+		C.destroy_generate_winning_post_sector_challenge(ptr.delegate)
+		ptr.delegate = nil
 	}
 }
 
 func (ptr SliceBoxedPoStProof) slice() []PoStProof {
-	if ptr.ptr == nil {
+	if ptr.delegate.ptr == nil {
 		return nil
 	}
-	return unsafe.Slice((*PoStProof)(unsafe.Pointer(ptr.ptr)), int(ptr.len))
+	return unsafe.Slice((*PoStProof)(unsafe.Pointer(ptr.delegate.ptr)), int(ptr.delegate.len))
 }
 
 func (ptr SliceBoxedPoStProof) copy() []PoStProofGo {
-	if ptr.ptr == nil {
+	if ptr.delegate.ptr == nil {
 		return nil
-	} else if ptr.len == 0 {
+	} else if ptr.delegate.len == 0 {
 		return []PoStProofGo{}
 	}
 
@@ -396,58 +433,58 @@ func (ptr SliceBoxedPoStProof) copy() []PoStProofGo {
 
 func (proof PoStProof) copy() PoStProofGo {
 	return PoStProofGo{
-		RegisteredProof: proof.registered_proof,
-		Proof:           proof.proof.copy(),
+		RegisteredProof: proof.registeredProof(),
+		Proof:           SliceBoxedUint8{delegate: proof.delegate.proof}.copy(),
 	}
 }
 
 func (ptr *resultSliceBoxedPoStProof) statusCode() FCPResponseStatus {
-	return FCPResponseStatus(ptr.status_code)
+	return FCPResponseStatus(ptr.delegate.status_code)
 }
 
 func (ptr *resultSliceBoxedPoStProof) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return &SliceBoxedUint8{delegate: ptr.delegate.error_msg}
 }
 
 func (ptr *resultSliceBoxedPoStProof) destroy() {
-	if ptr != nil {
+	if ptr != nil && ptr.delegate != nil {
 		// TODO: correct naming
-		C.destroy_generate_winning_post_response(ptr)
-		ptr = nil
+		C.destroy_generate_winning_post_response(ptr.delegate)
+		ptr.delegate = nil
 	}
 }
 
 func (ptr *resultGenerateWindowPoSt) statusCode() FCPResponseStatus {
-	return FCPResponseStatus(ptr.status_code)
+	return FCPResponseStatus(ptr.delegate.status_code)
 }
 
 func (ptr *resultGenerateWindowPoSt) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return &SliceBoxedUint8{delegate: ptr.delegate.error_msg}
 }
 
 func (ptr *resultGenerateWindowPoSt) destroy() {
-	if ptr != nil {
-		C.destroy_generate_window_post_response(ptr)
-		ptr = nil
+	if ptr != nil && ptr.delegate != nil {
+		C.destroy_generate_window_post_response(ptr.delegate)
+		ptr.delegate = nil
 	}
 }
 
 func (ptr SliceBoxedSliceBoxedUint8) slice() []SliceBoxedUint8 {
-	if ptr.ptr == nil {
+	if ptr.delegate.ptr == nil {
 		return nil
 	}
-	return unsafe.Slice((*SliceBoxedUint8)(unsafe.Pointer(ptr.ptr)), int(ptr.len))
+	return unsafe.Slice((*SliceBoxedUint8)(unsafe.Pointer(ptr.delegate.ptr)), int(ptr.delegate.len))
 }
 
 func (ptr SliceBoxedSliceBoxedUint8) copyAsBytes() [][]byte {
-	if ptr.ptr == nil {
+	if ptr.delegate.ptr == nil {
 		return nil
-	} else if ptr.len == 0 {
+	} else if ptr.delegate.len == 0 {
 		return [][]byte{}
 	}
 
 	ref := ptr.slice()
-	res := make([][]byte, int(ptr.len))
+	res := make([][]byte, int(ptr.delegate.len))
 	for i := range ref {
 		res[i] = ref[i].copy()
 	}
@@ -456,13 +493,13 @@ func (ptr SliceBoxedSliceBoxedUint8) copyAsBytes() [][]byte {
 }
 
 func (ptr SliceBoxedSliceBoxedUint8) copyAsStrings() []string {
-	if ptr.ptr == nil {
+	if ptr.delegate.ptr == nil {
 		return nil
-	} else if ptr.len == 0 {
+	} else if ptr.delegate.len == 0 {
 		return []string{}
 	}
 	ref := ptr.slice()
-	res := make([]string, int(ptr.len))
+	res := make([]string, int(ptr.delegate.len))
 	for i := range ref {
 		res[i] = string(ref[i].copy())
 	}
@@ -471,68 +508,68 @@ func (ptr SliceBoxedSliceBoxedUint8) copyAsStrings() []string {
 }
 
 func (ptr *resultSliceBoxedSliceBoxedUint8) statusCode() FCPResponseStatus {
-	return FCPResponseStatus(ptr.status_code)
+	return FCPResponseStatus(ptr.delegate.status_code)
 }
 
 func (ptr *resultSliceBoxedSliceBoxedUint8) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return &SliceBoxedUint8{delegate: ptr.delegate.error_msg}
 }
 
 func (ptr *resultSliceBoxedSliceBoxedUint8) destroy() {
-	if ptr != nil {
+	if ptr != nil && ptr.delegate != nil {
 		// TODO: naming
-		C.destroy_generate_empty_sector_update_partition_proof_response(ptr)
-		ptr = nil
+		C.destroy_generate_empty_sector_update_partition_proof_response(ptr.delegate)
+		ptr.delegate = nil
 	}
 }
 
 func (ptr *resultUint) statusCode() FCPResponseStatus {
-	return FCPResponseStatus(ptr.status_code)
+	return FCPResponseStatus(ptr.delegate.status_code)
 }
 
 func (ptr *resultUint) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return &SliceBoxedUint8{delegate: ptr.delegate.error_msg}
 }
 
 func (ptr *resultUint) destroy() {
-	if ptr != nil {
+	if ptr != nil && ptr.delegate != nil {
 		// TODO: naming
-		C.destroy_get_num_partition_for_fallback_post_response(ptr)
-		ptr = nil
+		C.destroy_get_num_partition_for_fallback_post_response(ptr.delegate)
+		ptr.delegate = nil
 	}
 }
 
 func (ptr *resultEmptySectorUpdateEncodeInto) statusCode() FCPResponseStatus {
-	return FCPResponseStatus(ptr.status_code)
+	return FCPResponseStatus(ptr.delegate.status_code)
 }
 
 func (ptr *resultEmptySectorUpdateEncodeInto) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return &SliceBoxedUint8{delegate: ptr.delegate.error_msg}
 }
 
 func (ptr *resultEmptySectorUpdateEncodeInto) destroy() {
-	if ptr != nil {
-		C.destroy_empty_sector_update_encode_into_response(ptr)
-		ptr = nil
+	if ptr != nil && ptr.delegate != nil {
+		C.destroy_empty_sector_update_encode_into_response(ptr.delegate)
+		ptr.delegate = nil
 	}
 }
 
 func (ptr SliceBoxedSliceBoxedUint64) slice() []SliceBoxedUint64 {
-	if ptr.ptr == nil {
+	if ptr.delegate.ptr == nil {
 		return nil
 	}
-	return unsafe.Slice((*SliceBoxedUint64)(unsafe.Pointer(ptr.ptr)), int(ptr.len))
+	return unsafe.Slice((*SliceBoxedUint64)(unsafe.Pointer(ptr.delegate.ptr)), int(ptr.delegate.len))
 }
 
 func (ptr SliceBoxedSliceBoxedUint64) copy() [][]uint64 {
-	if ptr.ptr == nil {
+	if ptr.delegate.ptr == nil {
 		return nil
-	} else if ptr.len == 0 {
+	} else if ptr.delegate.len == 0 {
 		return [][]uint64{}
 	}
 
 	ref := ptr.slice()
-	res := make([][]uint64, int(ptr.len))
+	res := make([][]uint64, int(ptr.delegate.len))
 	for i := range ref {
 		res[i] = ref[i].copy()
 	}
@@ -541,136 +578,138 @@ func (ptr SliceBoxedSliceBoxedUint64) copy() [][]uint64 {
 }
 
 func (ptr *resultGenerateFallbackSectorChallenges) statusCode() FCPResponseStatus {
-	return FCPResponseStatus(ptr.status_code)
+	return FCPResponseStatus(ptr.delegate.status_code)
 }
 
 func (ptr *resultGenerateFallbackSectorChallenges) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return &SliceBoxedUint8{delegate: ptr.delegate.error_msg}
 }
 
 func (ptr *resultGenerateFallbackSectorChallenges) destroy() {
-	if ptr != nil {
-		C.destroy_generate_fallback_sector_challenges_response(ptr)
-		ptr = nil
+	if ptr != nil && ptr.delegate != nil {
+		C.destroy_generate_fallback_sector_challenges_response(ptr.delegate)
+		ptr.delegate = nil
 	}
 }
 
 func (proof PartitionSnarkProof) copy() PartitionSnarkProofGo {
 	return PartitionSnarkProofGo{
-		RegisteredProof: proof.registered_proof,
-		Proof:           proof.proof.copy(),
+		RegisteredProof: proof.delegate.registered_proof,
+		Proof:           SliceBoxedUint8{delegate: proof.delegate.proof}.copy(),
 	}
 }
 
 func (ptr *resultGenerateSingleWindowPoStWithVanilla) statusCode() FCPResponseStatus {
-	return FCPResponseStatus(ptr.status_code)
+	return FCPResponseStatus(ptr.delegate.status_code)
 }
 
 func (ptr *resultGenerateSingleWindowPoStWithVanilla) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return &SliceBoxedUint8{delegate: ptr.delegate.error_msg}
 }
 
 func (ptr *resultGenerateSingleWindowPoStWithVanilla) destroy() {
-	if ptr != nil {
-		C.destroy_generate_single_window_post_with_vanilla_response(ptr)
-		ptr = nil
+	if ptr != nil && ptr.delegate != nil {
+		C.destroy_generate_single_window_post_with_vanilla_response(ptr.delegate)
+		ptr.delegate = nil
 	}
 }
 
 func (ptr *resultPoStProof) statusCode() FCPResponseStatus {
-	return FCPResponseStatus(ptr.status_code)
+	return FCPResponseStatus(ptr.delegate.status_code)
 }
 
 func (ptr *resultPoStProof) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return &SliceBoxedUint8{delegate: ptr.delegate.error_msg}
 }
 
 func (ptr *resultPoStProof) destroy() {
-	if ptr != nil {
-		C.destroy_merge_window_post_partition_proofs_response(ptr)
-		ptr = nil
+	if ptr != nil && ptr.delegate != nil {
+		C.destroy_merge_window_post_partition_proofs_response(ptr.delegate)
+		ptr.delegate = nil
 	}
 }
 
 func (ptr *SliceBoxedUint8) Destroy() {
-	if ptr.ptr != nil {
-		C.destroy_boxed_slice(*ptr)
-		ptr.ptr = nil
+	if ptr != nil && ptr.delegate.ptr != nil {
+		C.destroy_boxed_slice(ptr.delegate)
+		ptr.delegate.ptr = nil
 	}
 }
 
 func (ptr *PrivateReplicaInfo) Destroy() {
 	if ptr != nil {
-		ptr.cache_dir_path.Destroy()
-		ptr.replica_path.Destroy()
+		cacheDirPath := SliceBoxedUint8{delegate: ptr.delegate.cache_dir_path}
+		cacheDirPath.Destroy()
+		replicaPath := SliceBoxedUint8{delegate: ptr.delegate.replica_path}
+		replicaPath.Destroy()
 		ptr = nil
 	}
 }
 
 func (ptr *PoStProof) Destroy() {
 	if ptr != nil {
-		ptr.proof.Destroy()
+		ptr.destroy()
 		ptr = nil
 	}
 }
 
 func (ptr *resultFvmMachineExecuteResponse) statusCode() FCPResponseStatus {
-	return FCPResponseStatus(ptr.status_code)
+	return FCPResponseStatus(ptr.delegate.status_code)
 }
 
 func (ptr *resultFvmMachineExecuteResponse) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return &SliceBoxedUint8{delegate: ptr.delegate.error_msg}
 }
 
 func (ptr *resultFvmMachineExecuteResponse) destroy() {
-	if ptr != nil {
-		C.destroy_fvm_machine_execute_response(ptr)
-		ptr = nil
+	if ptr != nil && ptr.delegate != nil {
+		C.destroy_fvm_machine_execute_response(ptr.delegate)
+		ptr.delegate = nil
 	}
 }
 
 func (ptr *resultFvmMachine) statusCode() FCPResponseStatus {
-	return FCPResponseStatus(ptr.status_code)
+	return FCPResponseStatus(ptr.delegate.status_code)
 }
 
 func (ptr *resultFvmMachine) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return &SliceBoxedUint8{delegate: ptr.delegate.error_msg}
 }
 
 func (ptr *resultFvmMachine) destroy() {
-	if ptr != nil {
-		C.destroy_create_fvm_machine_response(ptr)
-		ptr = nil
+	if ptr != nil && ptr.delegate != nil {
+		C.destroy_create_fvm_machine_response(ptr.delegate)
+		ptr.delegate = nil
 	}
 }
 
 func (ptr *FvmMachine) Destroy() {
-	if ptr != nil {
-		C.drop_fvm_machine(ptr)
-		ptr = nil
+	if ptr != nil && ptr.delegate != nil {
+		C.drop_fvm_machine(ptr.delegate)
+		ptr.delegate = nil
 	}
 }
 
 func (r FvmMachineExecuteResponse) copy() FvmMachineExecuteResponseGo {
 	return FvmMachineExecuteResponseGo{
-		ExitCode:             uint64(r.exit_code),
-		ReturnVal:            r.return_val.copy(),
-		GasUsed:              uint64(r.gas_used),
-		PenaltyHi:            uint64(r.penalty_hi),
-		PenaltyLo:            uint64(r.penalty_lo),
-		MinerTipHi:           uint64(r.miner_tip_hi),
-		MinerTipLo:           uint64(r.miner_tip_lo),
-		BaseFeeBurnHi:        uint64(r.base_fee_burn_hi),
-		BaseFeeBurnLo:        uint64(r.base_fee_burn_lo),
-		OverEstimationBurnHi: uint64(r.over_estimation_burn_hi),
-		OverEstimationBurnLo: uint64(r.over_estimation_burn_lo),
-		RefundHi:             uint64(r.refund_hi),
-		RefundLo:             uint64(r.refund_lo),
-		GasRefund:            int64(r.gas_refund),
-		GasBurned:            int64(r.gas_burned),
-		ExecTrace:            r.exec_trace.copy(),
-		FailureInfo:          string(r.failure_info.slice()),
-		Events:               r.events.copy(),
-		EventsRoot:           r.events_root.copy(),
+		ExitCode:             uint64(r.delegate.exit_code),
+		ReturnVal:            SliceBoxedUint8{delegate: r.delegate.return_val}.copy(),
+		GasUsed:              uint64(r.delegate.gas_used),
+		PenaltyHi:            uint64(r.delegate.penalty_hi),
+		PenaltyLo:            uint64(r.delegate.penalty_lo),
+		MinerTipHi:           uint64(r.delegate.miner_tip_hi),
+		MinerTipLo:           uint64(r.delegate.miner_tip_lo),
+		BaseFeeBurnHi:        uint64(r.delegate.base_fee_burn_hi),
+		BaseFeeBurnLo:        uint64(r.delegate.base_fee_burn_lo),
+		OverEstimationBurnHi: uint64(r.delegate.over_estimation_burn_hi),
+		OverEstimationBurnLo: uint64(r.delegate.over_estimation_burn_lo),
+		RefundHi:             uint64(r.delegate.refund_hi),
+		RefundLo:             uint64(r.delegate.refund_lo),
+		GasRefund:            int64(r.delegate.gas_refund),
+		GasBurned:            int64(r.delegate.gas_burned),
+		ExecTrace:            SliceBoxedUint8{delegate: r.delegate.exec_trace}.copy(),
+		FailureInfo:          string(SliceBoxedUint8{delegate: r.delegate.failure_info}.slice()),
+		Events:               SliceBoxedUint8{delegate: r.delegate.events}.copy(),
+		EventsRoot:           SliceBoxedUint8{delegate: r.delegate.events_root}.copy(),
 	}
 }

--- a/cgo/util.go
+++ b/cgo/util.go
@@ -9,12 +9,7 @@ package cgo
 import "C"
 
 func InitLogFd(fd int32) error {
-	resp := C.init_log_fd(C.int32_t(fd))
+	resp := &resultVoid{delegate: C.init_log_fd(C.int32_t(fd))}
 	defer resp.destroy()
-
-	if err := CheckErr(resp); err != nil {
-		return err
-	}
-
-	return nil
+	return CheckErr(resp)
 }


### PR DESCRIPTION
As of Go 1.24, the compiler will now always fail if receivers are defined on cgo-generated type aliases. Fix the issue by wrapping the cgo-generated types and access to underlying type via `delegate` field. Note that such types cannot be embedded in go structs. Hence, the explicit field.

See:
 * https://tip.golang.org/doc/go1.24#compiler