### PR TITLE
refactor: support go 1.24 with newtypes

### DIFF
--- a/cgo/bls.go
+++ b/cgo/bls.go
@@ -9,53 +9,59 @@ package cgo
 import "C"
 
 func Hash(message SliceRefUint8) *[96]byte {
-	resp := C.hash(message)
+	resp := (*ByteArray96)(C.hash((C.slice_ref_uint8_t)(message)))
 	defer resp.destroy()
 	return resp.copyAsArray()
 }
 
 func Aggregate(flattenedSignatures SliceRefUint8) *[96]byte {
-	resp := C.aggregate(flattenedSignatures)
+	resp := (*ByteArray96)(C.aggregate((C.slice_ref_uint8_t)(flattenedSignatures)))
 	defer resp.destroy()
 	return resp.copyAsArray()
 }
 
 func Verify(signature SliceRefUint8, flattenedDigests SliceRefUint8, flattenedPublicKeys SliceRefUint8) bool {
-	resp := C.verify(signature, flattenedDigests, flattenedPublicKeys)
+	resp := C.verify((C.slice_ref_uint8_t)(signature),
+		(C.slice_ref_uint8_t)(flattenedDigests),
+		(C.slice_ref_uint8_t)(flattenedPublicKeys))
 	return bool(resp)
 }
 
 func HashVerify(signature SliceRefUint8, flattenedMessages SliceRefUint8, messageSizes SliceRefUint, flattenedPublicKeys SliceRefUint8) bool {
-	resp := C.hash_verify(signature, flattenedMessages, messageSizes, flattenedPublicKeys)
+	resp := C.hash_verify((C.slice_ref_uint8_t)(signature),
+		(C.slice_ref_uint8_t)(flattenedMessages),
+		(C.slice_ref_size_t)(messageSizes),
+		(C.slice_ref_uint8_t)(flattenedPublicKeys))
 	return bool(resp)
 }
 
 func PrivateKeyGenerate() *[32]byte {
-	resp := C.private_key_generate()
+	resp := (*ByteArray32)(C.private_key_generate())
 	defer resp.destroy()
 	return resp.copyAsArray()
 }
 
 func PrivateKeyGenerateWithSeed(rawSeed *ByteArray32) *[32]byte {
-	resp := C.private_key_generate_with_seed(rawSeed)
+	resp := (*ByteArray32)(C.private_key_generate_with_seed((*C.uint8_32_array_t)(rawSeed)))
 	defer resp.destroy()
 	return resp.copyAsArray()
 }
 
 func PrivateKeySign(rawPrivateKey SliceRefUint8, message SliceRefUint8) *[96]byte {
-	resp := C.private_key_sign(rawPrivateKey, message)
+	resp := (*ByteArray96)(C.private_key_sign((C.slice_ref_uint8_t)(rawPrivateKey),
+		(C.slice_ref_uint8_t)(message)))
 	defer resp.destroy()
 	return resp.copyAsArray()
 }
 
 func PrivateKeyPublicKey(rawPrivateKey SliceRefUint8) *[48]byte {
-	resp := C.private_key_public_key(rawPrivateKey)
+	resp := (*ByteArray48)(C.private_key_public_key((C.slice_ref_uint8_t)(rawPrivateKey)))
 	defer resp.destroy()
 	return resp.copyAsArray()
 }
 
 func CreateZeroSignature() *[96]byte {
-	resp := C.create_zero_signature()
+	resp := (*ByteArray96)(C.create_zero_signature())
 	defer resp.destroy()
 	return resp.copyAsArray()
 }

--- a/cgo/fvm.go
+++ b/cgo/fvm.go
@@ -9,8 +9,8 @@ package cgo
 import "C"
 
 func CreateFvmMachine(fvmVersion FvmRegisteredVersion, chainEpoch, chainTimestamp, chainId, baseFeeHi, baseFeeLo, baseCircSupplyHi, baseCircSupplyLo, networkVersion uint64, stateRoot SliceRefUint8, tracing bool, blockstoreId, externsId uint64) (*FvmMachine, error) {
-	resp := C.create_fvm_machine(
-		fvmVersion,
+	resp := (*resultFvmMachine)(C.create_fvm_machine(
+		(C.FvmRegisteredVersion_t)(fvmVersion),
 		C.uint64_t(chainEpoch),
 		C.uint64_t(chainTimestamp),
 		C.uint64_t(chainId),
@@ -19,13 +19,13 @@ func CreateFvmMachine(fvmVersion FvmRegisteredVersion, chainEpoch, chainTimestam
 		C.uint64_t(baseCircSupplyHi),
 		C.uint64_t(baseCircSupplyLo),
 		C.uint32_t(networkVersion),
-		stateRoot,
+		(C.slice_ref_uint8_t)(stateRoot),
 		C.bool(tracing),
 		C.uint64_t(blockstoreId),
 		C.uint64_t(externsId),
-	)
+	))
 	// take out the pointer from the result to ensure it doesn't get freed
-	executor := resp.value
+	executor := (*FvmMachine)(resp.value)
 	resp.value = nil
 	defer resp.destroy()
 
@@ -37,8 +37,8 @@ func CreateFvmMachine(fvmVersion FvmRegisteredVersion, chainEpoch, chainTimestam
 }
 
 func CreateFvmDebugMachine(fvmVersion FvmRegisteredVersion, chainEpoch, chainTimestamp, chainId, baseFeeHi, baseFeeLo, baseCircSupplyHi, baseCircSupplyLo, networkVersion uint64, stateRoot SliceRefUint8, actorRedirect SliceRefUint8, tracing bool, blockstoreId, externsId uint64) (*FvmMachine, error) {
-	resp := C.create_fvm_debug_machine(
-		fvmVersion,
+	resp := (*resultFvmMachine)(C.create_fvm_debug_machine(
+		(C.FvmRegisteredVersion_t)(fvmVersion),
 		C.uint64_t(chainEpoch),
 		C.uint64_t(chainTimestamp),
 		C.uint64_t(chainId),
@@ -47,14 +47,14 @@ func CreateFvmDebugMachine(fvmVersion FvmRegisteredVersion, chainEpoch, chainTim
 		C.uint64_t(baseCircSupplyHi),
 		C.uint64_t(baseCircSupplyLo),
 		C.uint32_t(networkVersion),
-		stateRoot,
-		actorRedirect,
+		(C.slice_ref_uint8_t)(stateRoot),
+		(C.slice_ref_uint8_t)(actorRedirect),
 		C.bool(tracing),
 		C.uint64_t(blockstoreId),
 		C.uint64_t(externsId),
-	)
+	))
 	// take out the pointer from the result to ensure it doesn't get freed
-	executor := resp.value
+	executor := (*FvmMachine)(resp.value)
 	resp.value = nil
 	defer resp.destroy()
 
@@ -66,27 +66,27 @@ func CreateFvmDebugMachine(fvmVersion FvmRegisteredVersion, chainEpoch, chainTim
 }
 
 func FvmMachineExecuteMessage(executor *FvmMachine, message SliceRefUint8, chainLen, applyKind uint64) (FvmMachineExecuteResponseGo, error) {
-	resp := C.fvm_machine_execute_message(
-		executor,
-		message,
+	resp := (*resultFvmMachineExecuteResponse)(C.fvm_machine_execute_message(
+		(*C.InnerFvmMachine_t)(executor),
+		(C.slice_ref_uint8_t)(message),
 		C.uint64_t(chainLen),
 		C.uint64_t(applyKind),
-	)
+	))
 	defer resp.destroy()
 
 	if err := CheckErr(resp); err != nil {
 		return FvmMachineExecuteResponseGo{}, err
 	}
 
-	return resp.value.copy(), nil
+	return (FvmMachineExecuteResponse)(resp.value).copy(), nil
 }
 
 func FvmMachineFlush(executor *FvmMachine) ([]byte, error) {
-	resp := C.fvm_machine_flush(executor)
+	resp := (*resultSliceBoxedUint8)(C.fvm_machine_flush((*C.InnerFvmMachine_t)(executor)))
 	defer resp.destroy()
 
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
-	return resp.value.copy(), nil
+	return (SliceBoxedUint8)(resp.value).copy(), nil
 }

--- a/cgo/helpers.go
+++ b/cgo/helpers.go
@@ -60,7 +60,7 @@ func AsSliceRefUint64(goBytes []uint64) SliceRefUint64 {
 func AllocSliceBoxedUint8(goBytes []byte) SliceBoxedUint8 {
 	len := len(goBytes)
 
-	ptr := C.alloc_boxed_slice(C.size_t(len))
+	ptr := (SliceBoxedUint8)(C.alloc_boxed_slice(C.size_t(len)))
 	copy(ptr.slice(), goBytes)
 
 	return ptr
@@ -227,49 +227,49 @@ func CheckErr(resp result) error {
 
 func NewAggregationInputs(commR ByteArray32, commD ByteArray32, sectorId uint64, ticket ByteArray32, seed ByteArray32) AggregationInputs {
 	return AggregationInputs{
-		comm_r:    commR,
-		comm_d:    commD,
+		comm_r:    (C.uint8_32_array_t)(commR),
+		comm_d:    (C.uint8_32_array_t)(commD),
 		sector_id: C.uint64_t(sectorId),
-		ticket:    ticket,
-		seed:      seed,
+		ticket:    (C.uint8_32_array_t)(ticket),
+		seed:      (C.uint8_32_array_t)(seed),
 	}
 }
 
 func NewPrivateReplicaInfo(pp RegisteredPoStProof, cacheDirPath string, commR ByteArray32, replicaPath string, sectorId uint64) PrivateReplicaInfo {
 	return PrivateReplicaInfo{
-		registered_proof: pp,
-		cache_dir_path:   AllocSliceBoxedUint8([]byte(cacheDirPath)),
-		replica_path:     AllocSliceBoxedUint8([]byte(replicaPath)),
+		registered_proof: (C.RegisteredPoStProof_t)(pp),
+		cache_dir_path:   (C.slice_boxed_uint8_t)(AllocSliceBoxedUint8([]byte(cacheDirPath))),
+		replica_path:     (C.slice_boxed_uint8_t)(AllocSliceBoxedUint8([]byte(replicaPath))),
 		sector_id:        C.uint64_t(sectorId),
-		comm_r:           commR,
+		comm_r:           (C.uint8_32_array_t)(commR),
 	}
 }
 
 func NewPublicReplicaInfo(pp RegisteredPoStProof, commR ByteArray32, sectorId uint64) PublicReplicaInfo {
 	return PublicReplicaInfo{
-		registered_proof: pp,
+		registered_proof: (C.RegisteredPoStProof_t)(pp),
 		sector_id:        C.uint64_t(sectorId),
-		comm_r:           commR,
+		comm_r:           (C.uint8_32_array_t)(commR),
 	}
 }
 
 func NewPoStProof(pp RegisteredPoStProof, proof []byte) PoStProof {
 	return PoStProof{
-		registered_proof: pp,
-		proof:            AllocSliceBoxedUint8(proof),
+		registered_proof: (C.RegisteredPoStProof_t)(pp),
+		proof:            (C.slice_boxed_uint8_t)(AllocSliceBoxedUint8(proof)),
 	}
 }
 
 func NewPublicPieceInfo(numBytes uint64, commP ByteArray32) PublicPieceInfo {
 	return PublicPieceInfo{
 		num_bytes: C.uint64_t(numBytes),
-		comm_p:    commP,
+		comm_p:    (C.uint8_32_array_t)(commP),
 	}
 }
 
 func NewPartitionSnarkProof(pp RegisteredPoStProof, proof []byte) PartitionSnarkProof {
 	return PartitionSnarkProof{
-		registered_proof: pp,
-		proof:            AllocSliceBoxedUint8(proof),
+		registered_proof: (C.RegisteredPoStProof_t)(pp),
+		proof:            (C.slice_boxed_uint8_t)(AllocSliceBoxedUint8(proof)),
 	}
 }

--- a/cgo/proofs.go
+++ b/cgo/proofs.go
@@ -596,7 +596,7 @@ func MergeWindowPoStPartitionProofs(registeredProof RegisteredPoStProof, partiti
 	return (PoStProof)(resp.value).copy(), nil
 }
 
-func GenerateSDR(registeredProof RegisteredPoStProof, outDir SliceRefUint8, replicaID *ByteArray32) error {
+func GenerateSDR(registeredProof RegisteredSealProof, outDir SliceRefUint8, replicaID *ByteArray32) error {
 	resp := (*resultVoid)(C.generate_sdr(
 		(C.RegisteredPoStProof_t)(registeredProof),
 		(C.slice_ref_uint8_t)(outDir),

--- a/cgo/proofs.go
+++ b/cgo/proofs.go
@@ -9,7 +9,15 @@ package cgo
 import "C"
 
 func VerifySeal(registeredProof RegisteredSealProof, commR *ByteArray32, commD *ByteArray32, proverId *ByteArray32, ticket *ByteArray32, seed *ByteArray32, sectorId uint64, proof SliceRefUint8) (bool, error) {
-	resp := C.verify_seal(registeredProof, commR, commD, proverId, ticket, seed, C.uint64_t(sectorId), proof)
+	resp := (*resultBool)(C.verify_seal(
+		(C.RegisteredSealProof_t)(registeredProof),
+		(*C.uint8_32_array_t)(commR),
+		(*C.uint8_32_array_t)(commD),
+		(*C.uint8_32_array_t)(proverId),
+		(*C.uint8_32_array_t)(ticket),
+		(*C.uint8_32_array_t)(seed),
+		C.uint64_t(sectorId),
+		(C.slice_ref_uint8_t)(proof)))
 	defer resp.destroy()
 
 	if err := CheckErr(resp); err != nil {
@@ -20,7 +28,12 @@ func VerifySeal(registeredProof RegisteredSealProof, commR *ByteArray32, commD *
 }
 
 func VerifyAggregateSealProof(registeredProof RegisteredSealProof, registeredAggregation RegisteredAggregationProof, proverId *ByteArray32, proof SliceRefUint8, commitInputs SliceRefAggregationInputs) (bool, error) {
-	resp := C.verify_aggregate_seal_proof(registeredProof, registeredAggregation, proverId, proof, commitInputs)
+	resp := (*resultBool)(C.verify_aggregate_seal_proof(
+		(C.RegisteredSealProof_t)(registeredProof),
+		(C.RegisteredAggregationProof_t)(registeredAggregation),
+		(*C.uint8_32_array_t)(proverId),
+		(C.slice_ref_uint8_t)(proof),
+		(C.slice_ref_AggregationInputs_t)(commitInputs)))
 	defer resp.destroy()
 
 	if err := CheckErr(resp); err != nil {
@@ -30,7 +43,11 @@ func VerifyAggregateSealProof(registeredProof RegisteredSealProof, registeredAgg
 }
 
 func VerifyWinningPoSt(randomness *ByteArray32, replicas SliceRefPublicReplicaInfo, proofs SliceRefPoStProof, proverId *ByteArray32) (bool, error) {
-	resp := C.verify_winning_post(randomness, replicas, proofs, proverId)
+	resp := (*resultBool)(C.verify_winning_post(
+		(*C.uint8_32_array_t)(randomness),
+		(C.slice_ref_PublicReplicaInfo_t)(replicas),
+		(C.slice_ref_PoStProof_t)(proofs),
+		(*C.uint8_32_array_t)(proverId)))
 	defer resp.destroy()
 
 	if err := CheckErr(resp); err != nil {
@@ -41,7 +58,11 @@ func VerifyWinningPoSt(randomness *ByteArray32, replicas SliceRefPublicReplicaIn
 }
 
 func VerifyWindowPoSt(randomness *ByteArray32, replicas SliceRefPublicReplicaInfo, proofs SliceRefPoStProof, proverId *ByteArray32) (bool, error) {
-	resp := C.verify_window_post(randomness, replicas, proofs, proverId)
+	resp := (*resultBool)(C.verify_window_post(
+		(*C.uint8_32_array_t)(randomness),
+		(C.slice_ref_PublicReplicaInfo_t)(replicas),
+		(C.slice_ref_PoStProof_t)(proofs),
+		(*C.uint8_32_array_t)(proverId)))
 	defer resp.destroy()
 
 	if err := CheckErr(resp); err != nil {
@@ -52,104 +73,164 @@ func VerifyWindowPoSt(randomness *ByteArray32, replicas SliceRefPublicReplicaInf
 }
 
 func GeneratePieceCommitment(registeredProof RegisteredSealProof, pieceFdRaw int32, unpaddedPieceSize uint64) ([]byte, error) {
-	resp := C.generate_piece_commitment(registeredProof, C.int32_t(pieceFdRaw), C.uint64_t(unpaddedPieceSize))
+	resp := (*resultGeneratePieceCommitment)(C.generate_piece_commitment(
+		(C.RegisteredSealProof_t)(registeredProof),
+		C.int32_t(pieceFdRaw),
+		C.uint64_t(unpaddedPieceSize)))
 	defer resp.destroy()
 
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
 
-	return resp.value.comm_p.copy(), nil
+	return (*ByteArray32)(&resp.value.comm_p).copy(), nil
 }
 
 func GenerateDataCommitment(registeredProof RegisteredSealProof, pieces SliceRefPublicPieceInfo) ([]byte, error) {
-	resp := C.generate_data_commitment(registeredProof, pieces)
+	resp := (*resultByteArray32)(C.generate_data_commitment(
+		(C.RegisteredSealProof_t)(registeredProof),
+		(C.slice_ref_PublicPieceInfo_t)(pieces)))
 	defer resp.destroy()
 
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
 
-	return resp.value.copy(), nil
+	return (*ByteArray32)(&resp.value).copy(), nil
 }
 
 func WriteWithAlignment(registeredProof RegisteredSealProof, srcFd int32, srcSize uint64, dstFd int32, existingPieceSizes SliceRefUint64) (uint64, uint64, []byte, error) {
-	resp := C.write_with_alignment(registeredProof, C.int32_t(srcFd), C.uint64_t(srcSize), C.int32_t(dstFd), existingPieceSizes)
+	resp := (*resultWriteWithAlignment)(C.write_with_alignment(
+		(C.RegisteredSealProof_t)(registeredProof),
+		C.int32_t(srcFd),
+		C.uint64_t(srcSize),
+		C.int32_t(dstFd),
+		(C.slice_ref_uint64_t)(existingPieceSizes)))
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return 0, 0, nil, err
 	}
 
-	return uint64(resp.value.left_alignment_unpadded), uint64(resp.value.total_write_unpadded), resp.value.comm_p.copy(), nil
+	return uint64(resp.value.left_alignment_unpadded),
+		uint64(resp.value.total_write_unpadded),
+		(*ByteArray32)(&resp.value.comm_p).copy(),
+		nil
 }
 
 func WriteWithoutAlignment(registeredProof RegisteredSealProof, srcFd int32, srcSize uint64, dstFd int32) (uint64, []byte, error) {
-	resp := C.write_without_alignment(registeredProof, C.int32_t(srcFd), C.uint64_t(srcSize), C.int32_t(dstFd))
+	resp := (*resultWriteWithoutAlignment)(C.write_without_alignment(
+		(C.RegisteredSealProof_t)(registeredProof),
+		C.int32_t(srcFd),
+		C.uint64_t(srcSize),
+		C.int32_t(dstFd)))
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return 0, nil, err
 	}
 
-	return uint64(resp.value.total_write_unpadded), resp.value.comm_p.copy(), nil
+	return uint64(resp.value.total_write_unpadded),
+		(*ByteArray32)(&resp.value.comm_p).copy(),
+		nil
 }
 
 func SealPreCommitPhase1(registeredProof RegisteredSealProof, cacheDirPath SliceRefUint8, stagedSectorPath SliceRefUint8, sealedSectorPath SliceRefUint8, sectorId uint64, proverId *ByteArray32, ticket *ByteArray32, pieces SliceRefPublicPieceInfo) ([]byte, error) {
-	resp := C.seal_pre_commit_phase1(registeredProof, cacheDirPath, stagedSectorPath, sealedSectorPath, C.uint64_t(sectorId), proverId, ticket, pieces)
+	resp := (*resultSliceBoxedUint8)(C.seal_pre_commit_phase1(
+		(C.RegisteredSealProof_t)(registeredProof),
+		(C.slice_ref_uint8_t)(cacheDirPath),
+		(C.slice_ref_uint8_t)(stagedSectorPath),
+		(C.slice_ref_uint8_t)(sealedSectorPath),
+		C.uint64_t(sectorId),
+		(*C.uint8_32_array_t)(proverId),
+		(*C.uint8_32_array_t)(ticket),
+		(C.slice_ref_PublicPieceInfo_t)(pieces)))
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
-	return resp.value.copy(), nil
+	return (SliceBoxedUint8)(resp.value).copy(), nil
 }
 
 func SealPreCommitPhase2(sealPreCommitPhase1Output SliceRefUint8, cacheDirPath SliceRefUint8, sealedSectorPath SliceRefUint8) ([]byte, []byte, error) {
-	resp := C.seal_pre_commit_phase2(sealPreCommitPhase1Output, cacheDirPath, sealedSectorPath)
+	resp := (*resultSealPreCommitPhase2)(C.seal_pre_commit_phase2(
+		(C.slice_ref_uint8_t)(sealPreCommitPhase1Output),
+		(C.slice_ref_uint8_t)(cacheDirPath),
+		(C.slice_ref_uint8_t)(sealedSectorPath)))
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, nil, err
 	}
-	return resp.value.comm_r.copy(), resp.value.comm_d.copy(), nil
+	return (*ByteArray32)(&resp.value.comm_r).copy(), (*ByteArray32)(&resp.value.comm_d).copy(), nil
 }
 
 func SealCommitPhase1(registeredProof RegisteredSealProof, commR *ByteArray32, commD *ByteArray32, cacheDirPath SliceRefUint8, replicaPath SliceRefUint8, sectorId uint64, proverId *ByteArray32, ticket *ByteArray32, seed *ByteArray32, pieces SliceRefPublicPieceInfo) ([]byte, error) {
-	resp := C.seal_commit_phase1(registeredProof, commR, commD, cacheDirPath, replicaPath, C.uint64_t(sectorId), proverId, ticket, seed, pieces)
+	resp := (*resultSliceBoxedUint8)(C.seal_commit_phase1(
+		(C.RegisteredSealProof_t)(registeredProof),
+		(*C.uint8_32_array_t)(commR),
+		(*C.uint8_32_array_t)(commD),
+		(C.slice_ref_uint8_t)(cacheDirPath),
+		(C.slice_ref_uint8_t)(replicaPath),
+		C.uint64_t(sectorId),
+		(*C.uint8_32_array_t)(proverId),
+		(*C.uint8_32_array_t)(ticket),
+		(*C.uint8_32_array_t)(seed),
+		(C.slice_ref_PublicPieceInfo_t)(pieces)))
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
 
-	return resp.value.copy(), nil
+	return (SliceBoxedUint8)(resp.value).copy(), nil
 }
 
 func SealCommitPhase2(sealCommitPhase1Output SliceRefUint8, sectorId uint64, proverId *ByteArray32) ([]byte, error) {
-	resp := C.seal_commit_phase2(sealCommitPhase1Output, C.uint64_t(sectorId), proverId)
+	resp := (*resultSliceBoxedUint8)(C.seal_commit_phase2(
+		(C.slice_ref_uint8_t)(sealCommitPhase1Output),
+		C.uint64_t(sectorId),
+		(*C.uint8_32_array_t)(proverId)))
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
-	return resp.value.copy(), nil
+	return (SliceBoxedUint8)(resp.value).copy(), nil
 }
 
 func SealCommitPhase2CircuitProofs(sealCommitPhase1Output SliceRefUint8, sectorId uint64) ([]byte, error) {
-	resp := C.seal_commit_phase2_circuit_proofs(sealCommitPhase1Output, C.uint64_t(sectorId))
+	resp := (*resultSliceBoxedUint8)(C.seal_commit_phase2_circuit_proofs(
+		(C.slice_ref_uint8_t)(sealCommitPhase1Output),
+		C.uint64_t(sectorId)))
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
-	return resp.value.copy(), nil
+	return (SliceBoxedUint8)(resp.value).copy(), nil
 }
 
 func AggregateSealProofs(registeredProof RegisteredSealProof, registeredAggregation RegisteredAggregationProof, commRs SliceRefByteArray32, seeds SliceRefByteArray32, sealCommitResponses SliceRefSliceBoxedUint8) ([]byte, error) {
-	resp := C.aggregate_seal_proofs(registeredProof, registeredAggregation, commRs, seeds, sealCommitResponses)
+	resp := (*resultSliceBoxedUint8)(C.aggregate_seal_proofs(
+		(C.RegisteredSealProof_t)(registeredProof),
+		(C.RegisteredAggregationProof_t)(registeredAggregation),
+		(C.slice_ref_uint8_32_array_t)(commRs),
+		(C.slice_ref_uint8_32_array_t)(seeds),
+		(C.slice_ref_slice_boxed_uint8_t)(sealCommitResponses)))
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
-	return resp.value.copy(), nil
+	return (SliceBoxedUint8)(resp.value).copy(), nil
 }
 
 func UnsealRange(registeredProof RegisteredSealProof, cacheDirPath SliceRefUint8, sealedSectorFdRaw int32, unsealOutputFdRaw int32, sectorId uint64, proverId *ByteArray32, ticket *ByteArray32, commD *ByteArray32, unpaddedByteIndex uint64, unpaddedBytesAmount uint64) error {
-	resp := C.unseal_range(registeredProof, cacheDirPath, C.int32_t(sealedSectorFdRaw), C.int32_t(unsealOutputFdRaw), C.uint64_t(sectorId), proverId, ticket, commD, C.uint64_t(unpaddedByteIndex), C.uint64_t(unpaddedBytesAmount))
+	resp := (*resultVoid)(C.unseal_range(
+		(C.RegisteredSealProof_t)(registeredProof),
+		(C.slice_ref_uint8_t)(cacheDirPath),
+		C.int32_t(sealedSectorFdRaw),
+		C.int32_t(unsealOutputFdRaw),
+		C.uint64_t(sectorId),
+		(*C.uint8_32_array_t)(proverId),
+		(*C.uint8_32_array_t)(ticket),
+		(*C.uint8_32_array_t)(commD),
+		C.uint64_t(unpaddedByteIndex),
+		C.uint64_t(unpaddedBytesAmount)))
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return err
@@ -158,67 +239,81 @@ func UnsealRange(registeredProof RegisteredSealProof, cacheDirPath SliceRefUint8
 }
 
 func GenerateWinningPoStSectorChallenge(registeredProof RegisteredPoStProof, randomness *ByteArray32, sectorSetLen uint64, proverId *ByteArray32) ([]uint64, error) {
-	resp := C.generate_winning_post_sector_challenge(registeredProof, randomness, C.uint64_t(sectorSetLen), proverId)
+	resp := (*resultSliceBoxedUint64)(C.generate_winning_post_sector_challenge(
+		(C.RegisteredPoStProof_t)(registeredProof),
+		(*C.uint8_32_array_t)(randomness),
+		C.uint64_t(sectorSetLen),
+		(*C.uint8_32_array_t)(proverId)))
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
-	return resp.value.copy(), nil
+	return (SliceBoxedUint64)(resp.value).copy(), nil
 }
 
 func GenerateWinningPoSt(randomness *ByteArray32, replicas SliceRefPrivateReplicaInfo, proverId *ByteArray32) ([]PoStProofGo, error) {
-	resp := C.generate_winning_post(randomness, replicas, proverId)
+	resp := (*resultSliceBoxedPoStProof)(C.generate_winning_post(
+		(*C.uint8_32_array_t)(randomness),
+		(C.slice_ref_PrivateReplicaInfo_t)(replicas),
+		(*C.uint8_32_array_t)(proverId)))
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
-	return resp.value.copy(), nil
+	return (SliceBoxedPoStProof)(resp.value).copy(), nil
 }
 
 func GenerateWindowPoSt(randomness *ByteArray32, replicas SliceRefPrivateReplicaInfo, proverId *ByteArray32) ([]PoStProofGo, []uint64, error) {
-	resp := C.generate_window_post(randomness, replicas, proverId)
+	resp := (*resultGenerateWindowPoSt)(C.generate_window_post(
+		(*C.uint8_32_array_t)(randomness),
+		(C.slice_ref_PrivateReplicaInfo_t)(replicas),
+		(*C.uint8_32_array_t)(proverId)))
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
-		faults := resp.value.faulty_sectors.copy()
+		faults := (SliceBoxedUint64)(resp.value.faulty_sectors).copy()
 		return nil, faults, err
 	}
 
-	proofs := resp.value.proofs.copy()
+	proofs := (SliceBoxedPoStProof)(resp.value.proofs).copy()
 	return proofs, []uint64{}, nil
 }
 
 func GetGpuDevices() ([]string, error) {
-	resp := C.get_gpu_devices()
+	resp := (*resultSliceBoxedSliceBoxedUint8)(C.get_gpu_devices())
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
 
-	return resp.value.copyAsStrings(), nil
+	return (SliceBoxedSliceBoxedUint8)(resp.value).copyAsStrings(), nil
 }
 
 func GetSealVersion(registeredProof RegisteredSealProof) (string, error) {
-	resp := C.get_seal_version(registeredProof)
+	resp := (*resultSliceBoxedUint8)(C.get_seal_version(
+		(C.RegisteredSealProof_t)(registeredProof)))
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return "", err
 	}
 
-	return string(resp.value.copy()), nil
+	return string((SliceBoxedUint8)(resp.value).copy()), nil
 }
 
 func GetPoStVersion(registeredProof RegisteredPoStProof) (string, error) {
-	resp := C.get_post_version(registeredProof)
+	resp := (*resultSliceBoxedUint8)(C.get_post_version(
+		(C.RegisteredPoStProof_t)(registeredProof)))
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return "", err
 	}
 
-	return string(resp.value.copy()), nil
+	return string((SliceBoxedUint8)(resp.value).copy()), nil
 }
 
 func GetNumPartitionForFallbackPost(registeredProof RegisteredPoStProof, numSectors uint) (uint, error) {
-	resp := C.get_num_partition_for_fallback_post(registeredProof, C.size_t(numSectors))
+	resp := (*resultUint)(C.get_num_partition_for_fallback_post(
+		(C.RegisteredPoStProof_t)(registeredProof),
+		C.size_t(numSectors)))
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return 0, err
@@ -228,13 +323,17 @@ func GetNumPartitionForFallbackPost(registeredProof RegisteredPoStProof, numSect
 }
 
 func ClearCache(sectorSize uint64, cacheDirPath SliceRefUint8) error {
-	resp := C.clear_cache(C.uint64_t(sectorSize), cacheDirPath)
+	resp := (*resultVoid)(C.clear_cache(
+		C.uint64_t(sectorSize),
+		(C.slice_ref_uint8_t)(cacheDirPath)))
 	defer resp.destroy()
 	return CheckErr(resp)
 }
 
 func ClearSyntheticProofs(sectorSize uint64, cacheDirPath SliceRefUint8) error {
-	resp := C.clear_synthetic_proofs(C.uint64_t(sectorSize), cacheDirPath)
+	resp := (*resultVoid)(C.clear_synthetic_proofs(
+		C.uint64_t(sectorSize),
+		(C.slice_ref_uint8_t)(cacheDirPath)))
 	defer resp.destroy()
 	return CheckErr(resp)
 }
@@ -247,51 +346,70 @@ func GenerateSynthProofs(
 	prover_id, ticket ByteArray32,
 	pieces SliceRefPublicPieceInfo,
 ) error {
-	resp := C.generate_synth_proofs(registered_proof,
-		&comm_r,
-		&comm_d,
-		cache_dir_path,
-		replica_path,
+	resp := (*resultVoid)(C.generate_synth_proofs(
+		(C.RegisteredSealProof_t)(registered_proof),
+		(*C.uint8_32_array_t)(&comm_r),
+		(*C.uint8_32_array_t)(&comm_d),
+		(C.slice_ref_uint8_t)(cache_dir_path),
+		(C.slice_ref_uint8_t)(replica_path),
 		C.uint64_t(sector_id),
-		&prover_id,
-		&ticket,
-		pieces,
-	)
+		(*C.uint8_32_array_t)(&prover_id),
+		(*C.uint8_32_array_t)(&ticket),
+		(C.slice_ref_PublicPieceInfo_t)(pieces)))
 	defer resp.destroy()
 	return CheckErr(resp)
 }
 
 func Fauxrep(registeredProf RegisteredSealProof, cacheDirPath SliceRefUint8, sealedSectorPath SliceRefUint8) ([]byte, error) {
-	resp := C.fauxrep(registeredProf, cacheDirPath, sealedSectorPath)
+	resp := (*resultByteArray32)(C.fauxrep(
+		(C.RegisteredSealProof_t)(registeredProf),
+		(C.slice_ref_uint8_t)(cacheDirPath),
+		(C.slice_ref_uint8_t)(sealedSectorPath)))
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
-	return resp.value.copy(), nil
+	return (*ByteArray32)(&resp.value).copy(), nil
 }
 
 func Fauxrep2(registeredProf RegisteredSealProof, cacheDirPath SliceRefUint8, existingPAuxPath SliceRefUint8) ([]byte, error) {
-	resp := C.fauxrep2(registeredProf, cacheDirPath, existingPAuxPath)
+	resp := (*resultByteArray32)(C.fauxrep2(
+		(C.RegisteredSealProof_t)(registeredProf),
+		(C.slice_ref_uint8_t)(cacheDirPath),
+		(C.slice_ref_uint8_t)(existingPAuxPath)))
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
-	return resp.value.copy(), nil
+	return (*ByteArray32)(&resp.value).copy(), nil
 }
 
 // sector update
 
 func EmptySectorUpdateEncodeInto(registeredProof RegisteredUpdateProof, newReplicaPath SliceRefUint8, newCacheDirPath SliceRefUint8, sectorKeyPath SliceRefUint8, sectorKeyCacheDirPath SliceRefUint8, stagedDataPath SliceRefUint8, pieces SliceRefPublicPieceInfo) ([]byte, []byte, error) {
-	resp := C.empty_sector_update_encode_into(registeredProof, newReplicaPath, newCacheDirPath, sectorKeyPath, sectorKeyCacheDirPath, stagedDataPath, pieces)
+	resp := (*resultEmptySectorUpdateEncodeInto)(C.empty_sector_update_encode_into(
+		(C.RegisteredUpdateProof_t)(registeredProof),
+		(C.slice_ref_uint8_t)(newReplicaPath),
+		(C.slice_ref_uint8_t)(newCacheDirPath),
+		(C.slice_ref_uint8_t)(sectorKeyPath),
+		(C.slice_ref_uint8_t)(sectorKeyCacheDirPath),
+		(C.slice_ref_uint8_t)(stagedDataPath),
+		(C.slice_ref_PublicPieceInfo_t)(pieces)))
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, nil, err
 	}
-	return resp.value.comm_r_new.copy(), resp.value.comm_d_new.copy(), nil
+	return (*ByteArray32)(&resp.value.comm_r_new).copy(), (*ByteArray32)(&resp.value.comm_d_new).copy(), nil
 }
 
 func EmptySectorUpdateDecodeFrom(registeredProof RegisteredUpdateProof, outDataPath SliceRefUint8, replicaPath SliceRefUint8, sectorKeyPath SliceRefUint8, sectorKeyCacheDirPath SliceRefUint8, commDNew *ByteArray32) error {
-	resp := C.empty_sector_update_decode_from(registeredProof, outDataPath, replicaPath, sectorKeyPath, sectorKeyCacheDirPath, commDNew)
+	resp := (*resultVoid)(C.empty_sector_update_decode_from(
+		(C.RegisteredUpdateProof_t)(registeredProof),
+		(C.slice_ref_uint8_t)(outDataPath),
+		(C.slice_ref_uint8_t)(replicaPath),
+		(C.slice_ref_uint8_t)(sectorKeyPath),
+		(C.slice_ref_uint8_t)(sectorKeyCacheDirPath),
+		(*C.uint8_32_array_t)(commDNew)))
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return err
@@ -300,7 +418,14 @@ func EmptySectorUpdateDecodeFrom(registeredProof RegisteredUpdateProof, outDataP
 }
 
 func EmptySectorUpdateRemoveEncodedData(registeredProof RegisteredUpdateProof, sectorKeyPath, sectorKeyCacheDirPath, replicaPath, replicaCachePath, dataPath SliceRefUint8, commDNew *ByteArray32) error {
-	resp := C.empty_sector_update_remove_encoded_data(registeredProof, sectorKeyPath, sectorKeyCacheDirPath, replicaPath, replicaCachePath, dataPath, commDNew)
+	resp := (*resultVoid)(C.empty_sector_update_remove_encoded_data(
+		(C.RegisteredUpdateProof_t)(registeredProof),
+		(C.slice_ref_uint8_t)(sectorKeyPath),
+		(C.slice_ref_uint8_t)(sectorKeyCacheDirPath),
+		(C.slice_ref_uint8_t)(replicaPath),
+		(C.slice_ref_uint8_t)(replicaCachePath),
+		(C.slice_ref_uint8_t)(dataPath),
+		(*C.uint8_32_array_t)(commDNew)))
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return err
@@ -309,16 +434,29 @@ func EmptySectorUpdateRemoveEncodedData(registeredProof RegisteredUpdateProof, s
 }
 
 func GenerateEmptySectorUpdatePartitionProofs(registeredProof RegisteredUpdateProof, commROld, commRNew, commDNew *ByteArray32, sectorKeyPath, sectorKeyCacheDirPath, replicaPath, replicaCachePath SliceRefUint8) ([][]byte, error) {
-	resp := C.generate_empty_sector_update_partition_proofs(registeredProof, commROld, commRNew, commDNew, sectorKeyPath, sectorKeyCacheDirPath, replicaPath, replicaCachePath)
+	resp := (*resultSliceBoxedSliceBoxedUint8)(C.generate_empty_sector_update_partition_proofs(
+		(C.RegisteredUpdateProof_t)(registeredProof),
+		(*C.uint8_32_array_t)(commROld),
+		(*C.uint8_32_array_t)(commRNew),
+		(*C.uint8_32_array_t)(commDNew),
+		(C.slice_ref_uint8_t)(sectorKeyPath),
+		(C.slice_ref_uint8_t)(sectorKeyCacheDirPath),
+		(C.slice_ref_uint8_t)(replicaPath),
+		(C.slice_ref_uint8_t)(replicaCachePath)))
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
-	return resp.value.copyAsBytes(), nil
+	return (SliceBoxedSliceBoxedUint8)(resp.value).copyAsBytes(), nil
 }
 
 func VerifyEmptySectorUpdatePartitionProofs(registeredProof RegisteredUpdateProof, proofs SliceRefSliceBoxedUint8, commROld, commRNew, commDNew *ByteArray32) (bool, error) {
-	resp := C.verify_empty_sector_update_partition_proofs(registeredProof, proofs, commROld, commRNew, commDNew)
+	resp := (*resultBool)(C.verify_empty_sector_update_partition_proofs(
+		(C.RegisteredUpdateProof_t)(registeredProof),
+		(C.slice_ref_slice_boxed_uint8_t)(proofs),
+		(*C.uint8_32_array_t)(commROld),
+		(*C.uint8_32_array_t)(commRNew),
+		(*C.uint8_32_array_t)(commDNew)))
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return false, err
@@ -328,27 +466,45 @@ func VerifyEmptySectorUpdatePartitionProofs(registeredProof RegisteredUpdateProo
 }
 
 func GenerateEmptySectorUpdateProofWithVanilla(registeredProof RegisteredUpdateProof, vanillaProofs SliceRefSliceBoxedUint8, commROld, commRNew, commDNew *ByteArray32) ([]byte, error) {
-	resp := C.generate_empty_sector_update_proof_with_vanilla(registeredProof, vanillaProofs, commROld, commRNew, commDNew)
+	resp := (*resultSliceBoxedUint8)(C.generate_empty_sector_update_proof_with_vanilla(
+		(C.RegisteredUpdateProof_t)(registeredProof),
+		(C.slice_ref_slice_boxed_uint8_t)(vanillaProofs),
+		(*C.uint8_32_array_t)(commROld),
+		(*C.uint8_32_array_t)(commRNew),
+		(*C.uint8_32_array_t)(commDNew)))
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
 
-	return resp.value.copy(), nil
+	return (SliceBoxedUint8)(resp.value).copy(), nil
 }
 
 func GenerateEmptySectorUpdateProof(registeredProof RegisteredUpdateProof, commROld, commRNew, commDNew *ByteArray32, sectorKeyPath, sectorKeyCacheDirPath, replicaPath, replicaCachePath SliceRefUint8) ([]byte, error) {
-	resp := C.generate_empty_sector_update_proof(registeredProof, commROld, commRNew, commDNew, sectorKeyPath, sectorKeyCacheDirPath, replicaPath, replicaCachePath)
+	resp := (*resultSliceBoxedUint8)(C.generate_empty_sector_update_proof(
+		(C.RegisteredUpdateProof_t)(registeredProof),
+		(*C.uint8_32_array_t)(commROld),
+		(*C.uint8_32_array_t)(commRNew),
+		(*C.uint8_32_array_t)(commDNew),
+		(C.slice_ref_uint8_t)(sectorKeyPath),
+		(C.slice_ref_uint8_t)(sectorKeyCacheDirPath),
+		(C.slice_ref_uint8_t)(replicaPath),
+		(C.slice_ref_uint8_t)(replicaCachePath)))
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
 
-	return resp.value.copy(), nil
+	return (SliceBoxedUint8)(resp.value).copy(), nil
 }
 
 func VerifyEmptySectorUpdateProof(registeredProof RegisteredUpdateProof, proof SliceRefUint8, commROld, commRNew, commDNew *ByteArray32) (bool, error) {
-	resp := C.verify_empty_sector_update_proof(registeredProof, proof, commROld, commRNew, commDNew)
+	resp := (*resultBool)(C.verify_empty_sector_update_proof(
+		(C.RegisteredUpdateProof_t)(registeredProof),
+		(C.slice_ref_uint8_t)(proof),
+		(*C.uint8_32_array_t)(commROld),
+		(*C.uint8_32_array_t)(commRNew),
+		(*C.uint8_32_array_t)(commDNew)))
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return false, err
@@ -360,96 +516,132 @@ func VerifyEmptySectorUpdateProof(registeredProof RegisteredUpdateProof, proof S
 // -- distributed
 
 func GenerateFallbackSectorChallenges(registeredProof RegisteredPoStProof, randomness *ByteArray32, sectorIds SliceRefUint64, proverId *ByteArray32) ([]uint64, [][]uint64, error) {
-	resp := C.generate_fallback_sector_challenges(registeredProof, randomness, sectorIds, proverId)
+	resp := (*resultGenerateFallbackSectorChallenges)(C.generate_fallback_sector_challenges(
+		(C.RegisteredPoStProof_t)(registeredProof),
+		(*C.uint8_32_array_t)(randomness),
+		(C.slice_ref_uint64_t)(sectorIds),
+		(*C.uint8_32_array_t)(proverId)))
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, nil, err
 	}
 
-	return resp.value.ids.copy(), resp.value.challenges.copy(), nil
+	return (SliceBoxedUint64)(resp.value.ids).copy(), (SliceBoxedSliceBoxedUint64)(resp.value.challenges).copy(), nil
 }
 
 func GenerateSingleVanillaProof(replica PrivateReplicaInfo, challenges SliceRefUint64) ([]byte, error) {
-	resp := C.generate_single_vanilla_proof(replica, challenges)
+	resp := (*resultSliceBoxedUint8)(C.generate_single_vanilla_proof(
+		(C.PrivateReplicaInfo_t)(replica),
+		(C.slice_ref_uint64_t)(challenges)))
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
 
-	return resp.value.copy(), nil
+	return (SliceBoxedUint8)(resp.value).copy(), nil
 }
 
 func GenerateWinningPoStWithVanilla(registeredProof RegisteredPoStProof, randomness, proverId *ByteArray32, vanillaProofs SliceRefSliceBoxedUint8) ([]PoStProofGo, error) {
-	resp := C.generate_winning_post_with_vanilla(registeredProof, randomness, proverId, vanillaProofs)
+	resp := (*resultSliceBoxedPoStProof)(C.generate_winning_post_with_vanilla(
+		(C.RegisteredPoStProof_t)(registeredProof),
+		(*C.uint8_32_array_t)(randomness),
+		(*C.uint8_32_array_t)(proverId),
+		(C.slice_ref_slice_boxed_uint8_t)(vanillaProofs)))
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
 
-	return resp.value.copy(), nil
+	return (SliceBoxedPoStProof)(resp.value).copy(), nil
 }
 
 func GenerateWindowPoStWithVanilla(registeredProof RegisteredPoStProof, randomness, proverId *ByteArray32, vanillaProofs SliceRefSliceBoxedUint8) ([]PoStProofGo, []uint64, error) {
-	resp := C.generate_window_post_with_vanilla(registeredProof, randomness, proverId, vanillaProofs)
+	resp := (*resultGenerateWindowPoSt)(C.generate_window_post_with_vanilla(
+		(C.RegisteredPoStProof_t)(registeredProof),
+		(*C.uint8_32_array_t)(randomness),
+		(*C.uint8_32_array_t)(proverId),
+		(C.slice_ref_slice_boxed_uint8_t)(vanillaProofs)))
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, nil, err
 	}
 
-	return resp.value.proofs.copy(), resp.value.faulty_sectors.copy(), nil
+	return (SliceBoxedPoStProof)(resp.value.proofs).copy(), (SliceBoxedUint64)(resp.value.faulty_sectors).copy(), nil
 }
 
 func GenerateSingleWindowPoStWithVanilla(registeredProof RegisteredPoStProof, randomness, proverId *ByteArray32, vanillaProofs SliceRefSliceBoxedUint8, partitionIndex uint) (PartitionSnarkProofGo, []uint64, error) {
-	resp := C.generate_single_window_post_with_vanilla(registeredProof, randomness, proverId, vanillaProofs, C.size_t(partitionIndex))
+	resp := (*resultGenerateSingleWindowPoStWithVanilla)(C.generate_single_window_post_with_vanilla(
+		(C.RegisteredPoStProof_t)(registeredProof),
+		(*C.uint8_32_array_t)(randomness),
+		(*C.uint8_32_array_t)(proverId),
+		(C.slice_ref_slice_boxed_uint8_t)(vanillaProofs),
+		C.size_t(partitionIndex)))
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return PartitionSnarkProofGo{}, nil, err
 	}
 
-	return resp.value.partition_proof.copy(), resp.value.faulty_sectors.copy(), nil
+	return (PartitionSnarkProof)(resp.value.partition_proof).copy(), (SliceBoxedUint64)(resp.value.faulty_sectors).copy(), nil
 }
 
 func MergeWindowPoStPartitionProofs(registeredProof RegisteredPoStProof, partitionProofs SliceRefSliceBoxedUint8) (PoStProofGo, error) {
-	resp := C.merge_window_post_partition_proofs(registeredProof, partitionProofs)
+	resp := (*resultPoStProof)(C.merge_window_post_partition_proofs(
+		(C.RegisteredPoStProof_t)(registeredProof),
+		(C.slice_ref_slice_boxed_uint8_t)(partitionProofs)))
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return PoStProofGo{}, err
 	}
 
-	return resp.value.copy(), nil
+	return (PoStProof)(resp.value).copy(), nil
 }
 
-// PoRep primitives
-
 func GenerateSDR(registeredProof RegisteredPoStProof, outDir SliceRefUint8, replicaID *ByteArray32) error {
-	resp := C.generate_sdr(registeredProof, outDir, replicaID)
+	resp := (*resultVoid)(C.generate_sdr(
+		(C.RegisteredPoStProof_t)(registeredProof),
+		(C.slice_ref_uint8_t)(outDir),
+		(*C.uint8_32_array_t)(replicaID)))
 	defer resp.destroy()
 
 	return CheckErr(resp)
 }
 
 func GenerateTreeRLast(registeredProof RegisteredPoStProof, replicaPath, outDir SliceRefUint8) ([]byte, error) {
-	resp := C.generate_tree_r_last(registeredProof, replicaPath, outDir)
+	resp := (*resultByteArray32)(C.generate_tree_r_last(
+		(C.RegisteredPoStProof_t)(registeredProof),
+		(C.slice_ref_uint8_t)(replicaPath),
+		(C.slice_ref_uint8_t)(outDir)))
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
 
-	return resp.value.copy(), nil
+	return (*ByteArray32)(&resp.value).copy(), nil
 }
 
 func GenerateTreeC(registeredProof RegisteredPoStProof, inputDir, outDir SliceRefUint8) ([]byte, error) {
-	resp := C.generate_tree_c(registeredProof, inputDir, outDir)
+	resp := (*resultByteArray32)(C.generate_tree_c(
+		(C.RegisteredPoStProof_t)(registeredProof),
+		(C.slice_ref_uint8_t)(inputDir),
+		(C.slice_ref_uint8_t)(outDir)))
 	defer resp.destroy()
 	if err := CheckErr(resp); err != nil {
 		return nil, err
 	}
 
-	return resp.value.copy(), nil
+	return (*ByteArray32)(&resp.value).copy(), nil
 }
 
 func EmptySectorUpdateDecodeFromRange(registeredProof RegisteredUpdateProof, commD, commR *ByteArray32, inputFd, sectorKeyFd, outputFd int32, nodesOffset, numNodes uint64) error {
-	resp := C.empty_sector_update_decode_from_range(registeredProof, commD, commR, C.int(inputFd), C.int(sectorKeyFd), C.int(outputFd), C.uint64_t(nodesOffset), C.uint64_t(numNodes))
+	resp := (*resultVoid)(C.empty_sector_update_decode_from_range(
+		(C.RegisteredUpdateProof_t)(registeredProof),
+		(*C.uint8_32_array_t)(commD),
+		(*C.uint8_32_array_t)(commR),
+		C.int(inputFd),
+		C.int(sectorKeyFd),
+		C.int(outputFd),
+		C.uint64_t(nodesOffset),
+		C.uint64_t(numNodes)))
 	defer resp.destroy()
 
 	return CheckErr(resp)

--- a/cgo/types.go
+++ b/cgo/types.go
@@ -11,67 +11,67 @@ import (
 	"unsafe"
 )
 
-type FCPResponseStatus = int64
+type FCPResponseStatus int64
 
-type RegisteredSealProof = C.RegisteredSealProof_t
-type RegisteredAggregationProof = C.RegisteredAggregationProof_t
-type RegisteredPoStProof = C.RegisteredPoStProof_t
-type RegisteredUpdateProof = C.RegisteredUpdateProof_t
+type RegisteredSealProof C.RegisteredSealProof_t
+type RegisteredAggregationProof C.RegisteredAggregationProof_t
+type RegisteredPoStProof C.RegisteredPoStProof_t
+type RegisteredUpdateProof C.RegisteredUpdateProof_t
 
-type FvmRegisteredVersion = C.FvmRegisteredVersion_t
+type FvmRegisteredVersion C.FvmRegisteredVersion_t
 
-type AggregationInputs = C.AggregationInputs_t
+type AggregationInputs C.AggregationInputs_t
 
-type PublicReplicaInfo = C.PublicReplicaInfo_t
-type PrivateReplicaInfo = C.PrivateReplicaInfo_t
-type PartitionSnarkProof = C.PartitionSnarkProof_t
-type PoStProof = C.PoStProof_t
-type PublicPieceInfo = C.PublicPieceInfo_t
+type PublicReplicaInfo C.PublicReplicaInfo_t
+type PrivateReplicaInfo C.PrivateReplicaInfo_t
+type PartitionSnarkProof C.PartitionSnarkProof_t
+type PoStProof C.PoStProof_t
+type PublicPieceInfo C.PublicPieceInfo_t
 
-type SliceRefPublicReplicaInfo = C.slice_ref_PublicReplicaInfo_t
-type SliceRefPrivateReplicaInfo = C.slice_ref_PrivateReplicaInfo_t
-type SliceRefByteArray32 = C.slice_ref_uint8_32_array_t
-type SliceRefSliceBoxedUint8 = C.slice_ref_slice_boxed_uint8_t
-type SliceRefUint64 = C.slice_ref_uint64_t
-type SliceRefPoStProof = C.slice_ref_PoStProof_t
-type SliceRefPublicPieceInfo = C.slice_ref_PublicPieceInfo_t
-type SliceRefUint8 = C.slice_ref_uint8_t
-type SliceRefUint = C.slice_ref_size_t
-type SliceRefAggregationInputs = C.slice_ref_AggregationInputs_t
+type SliceRefPublicReplicaInfo C.slice_ref_PublicReplicaInfo_t
+type SliceRefPrivateReplicaInfo C.slice_ref_PrivateReplicaInfo_t
+type SliceRefByteArray32 C.slice_ref_uint8_32_array_t
+type SliceRefSliceBoxedUint8 C.slice_ref_slice_boxed_uint8_t
+type SliceRefUint64 C.slice_ref_uint64_t
+type SliceRefPoStProof C.slice_ref_PoStProof_t
+type SliceRefPublicPieceInfo C.slice_ref_PublicPieceInfo_t
+type SliceRefUint8 C.slice_ref_uint8_t
+type SliceRefUint C.slice_ref_size_t
+type SliceRefAggregationInputs C.slice_ref_AggregationInputs_t
 
-type SliceBoxedPoStProof = C.struct_slice_boxed_PoStProof
-type SliceBoxedUint64 = C.struct_slice_boxed_uint64
-type SliceBoxedSliceBoxedUint8 = C.slice_boxed_slice_boxed_uint8_t
-type SliceBoxedSliceBoxedUint64 = C.slice_boxed_slice_boxed_uint64_t
-type SliceBoxedUint8 = C.struct_slice_boxed_uint8
+type SliceBoxedPoStProof C.struct_slice_boxed_PoStProof
+type SliceBoxedUint64 C.struct_slice_boxed_uint64
+type SliceBoxedSliceBoxedUint8 C.slice_boxed_slice_boxed_uint8_t
+type SliceBoxedSliceBoxedUint64 C.slice_boxed_slice_boxed_uint64_t
+type SliceBoxedUint8 C.struct_slice_boxed_uint8
 
-type ByteArray32 = C.uint8_32_array_t
-type ByteArray48 = C.uint8_48_array_t
-type ByteArray96 = C.uint8_96_array_t
+type ByteArray32 C.uint8_32_array_t
+type ByteArray48 C.uint8_48_array_t
+type ByteArray96 C.uint8_96_array_t
 
-type FvmMachine = C.InnerFvmMachine_t
-type FvmMachineExecuteResponse = C.FvmMachineExecuteResponse_t
+type FvmMachine C.InnerFvmMachine_t
+type FvmMachineExecuteResponse C.FvmMachineExecuteResponse_t
 
-type resultBool = C.Result_bool_t
-type resultGeneratePieceCommitment = C.Result_GeneratePieceCommitment_t
-type resultWriteWithAlignment = C.Result_WriteWithAlignment_t
-type resultWriteWithoutAlignment = C.Result_WriteWithoutAlignment_t
-type resultByteArray32 = C.Result_uint8_32_array_t
-type resultVoid = C.Result_void_t
-type resultSealPreCommitPhase2 = C.Result_SealPreCommitPhase2_t
-type resultSliceBoxedUint8 = C.Result_slice_boxed_uint8_t
-type resultSliceBoxedPoStProof = C.Result_slice_boxed_PoStProof_t
-type resultSliceBoxedUint64 = C.Result_slice_boxed_uint64_t
-type resultUint = C.Result_size_t
-type resultSliceBoxedSliceBoxedUint8 = C.Result_slice_boxed_slice_boxed_uint8_t
-type resultGenerateWindowPoSt = C.Result_GenerateWindowPoSt_t
-type resultEmptySectorUpdateEncodeInto = C.Result_EmptySectorUpdateEncodeInto_t
-type resultGenerateFallbackSectorChallenges = C.Result_GenerateFallbackSectorChallenges_t
-type resultGenerateSingleWindowPoStWithVanilla = C.Result_GenerateSingleWindowPoStWithVanilla_t
-type resultPoStProof = C.Result_PoStProof_t
+type resultBool C.Result_bool_t
+type resultGeneratePieceCommitment C.Result_GeneratePieceCommitment_t
+type resultWriteWithAlignment C.Result_WriteWithAlignment_t
+type resultWriteWithoutAlignment C.Result_WriteWithoutAlignment_t
+type resultByteArray32 C.Result_uint8_32_array_t
+type resultVoid C.Result_void_t
+type resultSealPreCommitPhase2 C.Result_SealPreCommitPhase2_t
+type resultSliceBoxedUint8 C.Result_slice_boxed_uint8_t
+type resultSliceBoxedPoStProof C.Result_slice_boxed_PoStProof_t
+type resultSliceBoxedUint64 C.Result_slice_boxed_uint64_t
+type resultUint C.Result_size_t
+type resultSliceBoxedSliceBoxedUint8 C.Result_slice_boxed_slice_boxed_uint8_t
+type resultGenerateWindowPoSt C.Result_GenerateWindowPoSt_t
+type resultEmptySectorUpdateEncodeInto C.Result_EmptySectorUpdateEncodeInto_t
+type resultGenerateFallbackSectorChallenges C.Result_GenerateFallbackSectorChallenges_t
+type resultGenerateSingleWindowPoStWithVanilla C.Result_GenerateSingleWindowPoStWithVanilla_t
+type resultPoStProof C.Result_PoStProof_t
 
-type resultFvmMachine = C.Result_InnerFvmMachine_ptr_t
-type resultFvmMachineExecuteResponse = C.Result_FvmMachineExecuteResponse_t
+type resultFvmMachine C.Result_InnerFvmMachine_ptr_t
+type resultFvmMachineExecuteResponse C.Result_FvmMachineExecuteResponse_t
 
 type result interface {
 	statusCode() FCPResponseStatus
@@ -138,31 +138,30 @@ func (ptr *resultBool) statusCode() FCPResponseStatus {
 }
 
 func (ptr *resultBool) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return (*SliceBoxedUint8)(&ptr.error_msg)
 }
 
 func (ptr *resultBool) destroy() {
 	if ptr != nil {
-		// TODO: correct naming
-		C.destroy_verify_seal_response(ptr)
+		C.destroy_verify_seal_response((*C.Result_bool_t)(ptr))
 		ptr = nil
 	}
 }
 
 func (ptr *PoStProof) registeredProof() RegisteredPoStProof {
-	return ptr.registered_proof
+	return RegisteredPoStProof(ptr.registered_proof)
 }
 
 func (ptr *PoStProof) destroy() {
 	if ptr != nil {
-		ptr.proof.Destroy()
+		(*SliceBoxedUint8)(&ptr.proof).Destroy()
 		ptr = nil
 	}
 }
 
 func (ptr *ByteArray96) destroy() {
 	if ptr != nil {
-		C.destroy_box_bls_digest(ptr)
+		C.destroy_box_bls_digest((*C.uint8_96_array_t)(ptr))
 		ptr = nil
 	}
 }
@@ -195,7 +194,7 @@ func (ptr *ByteArray48) copyAsArray() *[48]byte {
 
 func (ptr *ByteArray48) destroy() {
 	if ptr != nil {
-		C.destroy_box_bls_public_key(ptr)
+		C.destroy_box_bls_public_key((*C.uint8_48_array_t)(ptr))
 		ptr = nil
 	}
 }
@@ -223,7 +222,7 @@ func (ptr *ByteArray32) copyAsArray() *[32]byte {
 
 func (ptr *ByteArray32) destroy() {
 	if ptr != nil {
-		C.destroy_box_bls_private_key(ptr)
+		C.destroy_box_bls_private_key((*C.uint8_32_array_t)(ptr))
 		ptr = nil
 	}
 }
@@ -233,12 +232,12 @@ func (ptr *resultGeneratePieceCommitment) statusCode() FCPResponseStatus {
 }
 
 func (ptr *resultGeneratePieceCommitment) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return (*SliceBoxedUint8)(&ptr.error_msg)
 }
 
 func (ptr *resultGeneratePieceCommitment) destroy() {
 	if ptr != nil {
-		C.destroy_generate_piece_commitment_response(ptr)
+		C.destroy_generate_piece_commitment_response((*C.Result_GeneratePieceCommitment_t)(ptr))
 		ptr = nil
 	}
 }
@@ -248,13 +247,12 @@ func (ptr *resultByteArray32) statusCode() FCPResponseStatus {
 }
 
 func (ptr *resultByteArray32) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return (*SliceBoxedUint8)(&ptr.error_msg)
 }
 
 func (ptr *resultByteArray32) destroy() {
 	if ptr != nil {
-		// TODO: better naming
-		C.destroy_generate_data_commitment_response(ptr)
+		C.destroy_generate_data_commitment_response((*C.Result_uint8_32_array_t)(ptr))
 		ptr = nil
 	}
 }
@@ -264,12 +262,12 @@ func (ptr *resultWriteWithAlignment) statusCode() FCPResponseStatus {
 }
 
 func (ptr *resultWriteWithAlignment) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return (*SliceBoxedUint8)(&ptr.error_msg)
 }
 
 func (ptr *resultWriteWithAlignment) destroy() {
 	if ptr != nil {
-		C.destroy_write_with_alignment_response(ptr)
+		C.destroy_write_with_alignment_response((*C.Result_WriteWithAlignment_t)(ptr))
 		ptr = nil
 	}
 }
@@ -279,12 +277,12 @@ func (ptr *resultWriteWithoutAlignment) statusCode() FCPResponseStatus {
 }
 
 func (ptr *resultWriteWithoutAlignment) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return (*SliceBoxedUint8)(&ptr.error_msg)
 }
 
 func (ptr *resultWriteWithoutAlignment) destroy() {
 	if ptr != nil {
-		C.destroy_write_without_alignment_response(ptr)
+		C.destroy_write_without_alignment_response((*C.Result_WriteWithoutAlignment_t)(ptr))
 		ptr = nil
 	}
 }
@@ -294,13 +292,12 @@ func (ptr *resultSliceBoxedUint8) statusCode() FCPResponseStatus {
 }
 
 func (ptr *resultSliceBoxedUint8) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return (*SliceBoxedUint8)(&ptr.error_msg)
 }
 
 func (ptr *resultSliceBoxedUint8) destroy() {
 	if ptr != nil {
-		// TODO: naming
-		C.destroy_seal_pre_commit_phase1_response(ptr)
+		C.destroy_seal_pre_commit_phase1_response((*C.Result_slice_boxed_uint8_t)(ptr))
 		ptr = nil
 	}
 }
@@ -310,12 +307,12 @@ func (ptr *resultSealPreCommitPhase2) statusCode() FCPResponseStatus {
 }
 
 func (ptr *resultSealPreCommitPhase2) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return (*SliceBoxedUint8)(&ptr.error_msg)
 }
 
 func (ptr *resultSealPreCommitPhase2) destroy() {
 	if ptr != nil {
-		C.destroy_seal_pre_commit_phase2_response(ptr)
+		C.destroy_seal_pre_commit_phase2_response((*C.Result_SealPreCommitPhase2_t)(ptr))
 		ptr = nil
 	}
 }
@@ -325,13 +322,12 @@ func (ptr *resultVoid) statusCode() FCPResponseStatus {
 }
 
 func (ptr *resultVoid) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return (*SliceBoxedUint8)(&ptr.error_msg)
 }
 
 func (ptr *resultVoid) destroy() {
 	if ptr != nil {
-		// TODO: correct naming
-		C.destroy_unseal_range_response(ptr)
+		C.destroy_unseal_range_response((*C.Result_void_t)(ptr))
 		ptr = nil
 	}
 }
@@ -360,13 +356,12 @@ func (ptr *resultSliceBoxedUint64) statusCode() FCPResponseStatus {
 }
 
 func (ptr *resultSliceBoxedUint64) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return (*SliceBoxedUint8)(&ptr.error_msg)
 }
 
 func (ptr *resultSliceBoxedUint64) destroy() {
 	if ptr != nil {
-		// TODO: correct naming
-		C.destroy_generate_winning_post_sector_challenge(ptr)
+		C.destroy_generate_winning_post_sector_challenge((*C.Result_slice_boxed_uint64_t)(ptr))
 		ptr = nil
 	}
 }
@@ -396,8 +391,8 @@ func (ptr SliceBoxedPoStProof) copy() []PoStProofGo {
 
 func (proof PoStProof) copy() PoStProofGo {
 	return PoStProofGo{
-		RegisteredProof: proof.registered_proof,
-		Proof:           proof.proof.copy(),
+		RegisteredProof: RegisteredPoStProof(proof.registered_proof),
+		Proof:           (*SliceBoxedUint8)(&proof.proof).copy(),
 	}
 }
 
@@ -406,13 +401,12 @@ func (ptr *resultSliceBoxedPoStProof) statusCode() FCPResponseStatus {
 }
 
 func (ptr *resultSliceBoxedPoStProof) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return (*SliceBoxedUint8)(&ptr.error_msg)
 }
 
 func (ptr *resultSliceBoxedPoStProof) destroy() {
 	if ptr != nil {
-		// TODO: correct naming
-		C.destroy_generate_winning_post_response(ptr)
+		C.destroy_generate_winning_post_response((*C.Result_slice_boxed_PoStProof_t)(ptr))
 		ptr = nil
 	}
 }
@@ -422,12 +416,12 @@ func (ptr *resultGenerateWindowPoSt) statusCode() FCPResponseStatus {
 }
 
 func (ptr *resultGenerateWindowPoSt) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return (*SliceBoxedUint8)(&ptr.error_msg)
 }
 
 func (ptr *resultGenerateWindowPoSt) destroy() {
 	if ptr != nil {
-		C.destroy_generate_window_post_response(ptr)
+		C.destroy_generate_window_post_response((*C.Result_GenerateWindowPoSt_t)(ptr))
 		ptr = nil
 	}
 }
@@ -475,13 +469,12 @@ func (ptr *resultSliceBoxedSliceBoxedUint8) statusCode() FCPResponseStatus {
 }
 
 func (ptr *resultSliceBoxedSliceBoxedUint8) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return (*SliceBoxedUint8)(&ptr.error_msg)
 }
 
 func (ptr *resultSliceBoxedSliceBoxedUint8) destroy() {
 	if ptr != nil {
-		// TODO: naming
-		C.destroy_generate_empty_sector_update_partition_proof_response(ptr)
+		C.destroy_generate_empty_sector_update_partition_proof_response((*C.Result_slice_boxed_slice_boxed_uint8_t)(ptr))
 		ptr = nil
 	}
 }
@@ -491,13 +484,12 @@ func (ptr *resultUint) statusCode() FCPResponseStatus {
 }
 
 func (ptr *resultUint) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return (*SliceBoxedUint8)(&ptr.error_msg)
 }
 
 func (ptr *resultUint) destroy() {
 	if ptr != nil {
-		// TODO: naming
-		C.destroy_get_num_partition_for_fallback_post_response(ptr)
+		C.destroy_get_num_partition_for_fallback_post_response((*C.Result_size_t)(ptr))
 		ptr = nil
 	}
 }
@@ -507,12 +499,12 @@ func (ptr *resultEmptySectorUpdateEncodeInto) statusCode() FCPResponseStatus {
 }
 
 func (ptr *resultEmptySectorUpdateEncodeInto) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return (*SliceBoxedUint8)(&ptr.error_msg)
 }
 
 func (ptr *resultEmptySectorUpdateEncodeInto) destroy() {
 	if ptr != nil {
-		C.destroy_empty_sector_update_encode_into_response(ptr)
+		C.destroy_empty_sector_update_encode_into_response((*C.Result_EmptySectorUpdateEncodeInto_t)(ptr))
 		ptr = nil
 	}
 }
@@ -545,20 +537,20 @@ func (ptr *resultGenerateFallbackSectorChallenges) statusCode() FCPResponseStatu
 }
 
 func (ptr *resultGenerateFallbackSectorChallenges) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return (*SliceBoxedUint8)(&ptr.error_msg)
 }
 
 func (ptr *resultGenerateFallbackSectorChallenges) destroy() {
 	if ptr != nil {
-		C.destroy_generate_fallback_sector_challenges_response(ptr)
+		C.destroy_generate_fallback_sector_challenges_response((*C.Result_GenerateFallbackSectorChallenges_t)(ptr))
 		ptr = nil
 	}
 }
 
 func (proof PartitionSnarkProof) copy() PartitionSnarkProofGo {
 	return PartitionSnarkProofGo{
-		RegisteredProof: proof.registered_proof,
-		Proof:           proof.proof.copy(),
+		RegisteredProof: RegisteredPoStProof(proof.registered_proof),
+		Proof:           (*SliceBoxedUint8)(&proof.proof).copy(),
 	}
 }
 
@@ -567,12 +559,12 @@ func (ptr *resultGenerateSingleWindowPoStWithVanilla) statusCode() FCPResponseSt
 }
 
 func (ptr *resultGenerateSingleWindowPoStWithVanilla) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return (*SliceBoxedUint8)(&ptr.error_msg)
 }
 
 func (ptr *resultGenerateSingleWindowPoStWithVanilla) destroy() {
 	if ptr != nil {
-		C.destroy_generate_single_window_post_with_vanilla_response(ptr)
+		C.destroy_generate_single_window_post_with_vanilla_response((*C.Result_GenerateSingleWindowPoStWithVanilla_t)(ptr))
 		ptr = nil
 	}
 }
@@ -582,34 +574,34 @@ func (ptr *resultPoStProof) statusCode() FCPResponseStatus {
 }
 
 func (ptr *resultPoStProof) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return (*SliceBoxedUint8)(&ptr.error_msg)
 }
 
 func (ptr *resultPoStProof) destroy() {
 	if ptr != nil {
-		C.destroy_merge_window_post_partition_proofs_response(ptr)
+		C.destroy_merge_window_post_partition_proofs_response((*C.Result_PoStProof_t)(ptr))
 		ptr = nil
 	}
 }
 
 func (ptr *SliceBoxedUint8) Destroy() {
 	if ptr.ptr != nil {
-		C.destroy_boxed_slice(*ptr)
+		C.destroy_boxed_slice(*(*C.struct_slice_boxed_uint8)(ptr))
 		ptr.ptr = nil
 	}
 }
 
 func (ptr *PrivateReplicaInfo) Destroy() {
 	if ptr != nil {
-		ptr.cache_dir_path.Destroy()
-		ptr.replica_path.Destroy()
+		(*SliceBoxedUint8)(&ptr.cache_dir_path).Destroy()
+		(*SliceBoxedUint8)(&ptr.replica_path).Destroy()
 		ptr = nil
 	}
 }
 
 func (ptr *PoStProof) Destroy() {
 	if ptr != nil {
-		ptr.proof.Destroy()
+		(*SliceBoxedUint8)(&ptr.proof).Destroy()
 		ptr = nil
 	}
 }
@@ -619,12 +611,12 @@ func (ptr *resultFvmMachineExecuteResponse) statusCode() FCPResponseStatus {
 }
 
 func (ptr *resultFvmMachineExecuteResponse) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return (*SliceBoxedUint8)(&ptr.error_msg)
 }
 
 func (ptr *resultFvmMachineExecuteResponse) destroy() {
 	if ptr != nil {
-		C.destroy_fvm_machine_execute_response(ptr)
+		C.destroy_fvm_machine_execute_response((*C.Result_FvmMachineExecuteResponse_t)(ptr))
 		ptr = nil
 	}
 }
@@ -634,19 +626,19 @@ func (ptr *resultFvmMachine) statusCode() FCPResponseStatus {
 }
 
 func (ptr *resultFvmMachine) errorMsg() *SliceBoxedUint8 {
-	return &ptr.error_msg
+	return (*SliceBoxedUint8)(&ptr.error_msg)
 }
 
 func (ptr *resultFvmMachine) destroy() {
 	if ptr != nil {
-		C.destroy_create_fvm_machine_response(ptr)
+		C.destroy_create_fvm_machine_response((*C.Result_InnerFvmMachine_ptr_t)(ptr))
 		ptr = nil
 	}
 }
 
 func (ptr *FvmMachine) Destroy() {
 	if ptr != nil {
-		C.drop_fvm_machine(ptr)
+		C.drop_fvm_machine((*C.InnerFvmMachine_t)(ptr))
 		ptr = nil
 	}
 }
@@ -654,7 +646,7 @@ func (ptr *FvmMachine) Destroy() {
 func (r FvmMachineExecuteResponse) copy() FvmMachineExecuteResponseGo {
 	return FvmMachineExecuteResponseGo{
 		ExitCode:             uint64(r.exit_code),
-		ReturnVal:            r.return_val.copy(),
+		ReturnVal:            (*SliceBoxedUint8)(&r.return_val).copy(),
 		GasUsed:              uint64(r.gas_used),
 		PenaltyHi:            uint64(r.penalty_hi),
 		PenaltyLo:            uint64(r.penalty_lo),
@@ -668,9 +660,9 @@ func (r FvmMachineExecuteResponse) copy() FvmMachineExecuteResponseGo {
 		RefundLo:             uint64(r.refund_lo),
 		GasRefund:            int64(r.gas_refund),
 		GasBurned:            int64(r.gas_burned),
-		ExecTrace:            r.exec_trace.copy(),
-		FailureInfo:          string(r.failure_info.slice()),
-		Events:               r.events.copy(),
-		EventsRoot:           r.events_root.copy(),
+		ExecTrace:            (*SliceBoxedUint8)(&r.exec_trace).copy(),
+		FailureInfo:          string((*SliceBoxedUint8)(&r.failure_info).slice()),
+		Events:               (*SliceBoxedUint8)(&r.events).copy(),
+		EventsRoot:           (*SliceBoxedUint8)(&r.events_root).copy(),
 	}
 }

--- a/cgo/util.go
+++ b/cgo/util.go
@@ -9,7 +9,7 @@ package cgo
 import "C"
 
 func InitLogFd(fd int32) error {
-	resp := C.init_log_fd(C.int32_t(fd))
+	resp := (*resultVoid)(C.init_log_fd(C.int32_t(fd)))
 	defer resp.destroy()
 
 	if err := CheckErr(resp); err != nil {


### PR DESCRIPTION
Alternative to #517 that uses newtypes. IMO, this is a bit less risky as we're not introducing any new pointers, wrappers, etc.