### PR TITLE
chore: update rust to 1.86.0

### DIFF
--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.78.0"
+channel = "1.86.0"
 components = ["clippy", "rustfmt"]

--- a/rust/src/proofs/api.rs
+++ b/rust/src/proofs/api.rs
@@ -527,7 +527,6 @@ fn generate_winning_post_sector_challenge(
 
         Ok(result
             .into_iter()
-            .map(u64::from)
             .collect::<Vec<_>>()
             .into_boxed_slice()
             .into())


### PR DESCRIPTION
This is the latest upstream rust version. The assumption is that this version of the FFI _won't_ land in the current stable release of Lotus.