### PR TITLE
chore: pass accept header to asset download request

### DIFF
--- a/install-filcrypto
+++ b/install-filcrypto
@@ -131,7 +131,7 @@ download_release_tarball() {
         -w "%{url_effective}" \
         "${__release_url}")
 
-    if ! curl "${auth_header[@]}" --retry 3 --output "${__tar_path}" "${__asset_url}"; then
+    if ! curl "${auth_header[@]}" --header "Accept:application/octet-stream" --retry 3 --output "${__tar_path}" "${__asset_url}"; then
         (>&2 echo "[download_release_tarball] failed to download release asset (tag URL: ${__release_tag_url}, asset URL: ${__asset_url})")
         return 1
     fi

--- a/install-filcrypto
+++ b/install-filcrypto
@@ -131,7 +131,7 @@ download_release_tarball() {
         -w "%{url_effective}" \
         "${__release_url}")
 
-    if ! curl "${auth_header[@]}" --header "Accept:application/octet-stream" --retry 3 --output "${__tar_path}" "${__asset_url}"; then
+    if ! curl "${auth_header[@]}" --header "Accept: application/octet-stream" --retry 3 --output "${__tar_path}" "${__asset_url}"; then
         (>&2 echo "[download_release_tarball] failed to download release asset (tag URL: ${__release_tag_url}, asset URL: ${__asset_url})")
         return 1
     fi


### PR DESCRIPTION
This is a follow-up to https://github.com/filecoin-project/lotus/pull/13223

It passes `Accept:application/octet-stream` header in a request which downloads the release assets. This will ensure we can actually download the assets instead of having to build them from source every time.