### PR TITLE
chore!: upgrade to Go 1.24

### DIFF
--- a/.github/actions/configure-environment/action.yml
+++ b/.github/actions/configure-environment/action.yml
@@ -63,4 +63,4 @@ runs:
         toolchain: 1.73
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.23'
+        go-version: '1.24'

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/filecoin-project/filecoin-ffi
 
-go 1.23.0
-
-toolchain go1.23.7
+go 1.24
 
 require (
 	github.com/filecoin-project/go-address v1.2.0


### PR DESCRIPTION
This PR upgrades Go to version 1.24.