### PR TITLE
ci: create release uploader workflow

### DIFF
--- a/.github/actions/upload-release-assets/action.yml
+++ b/.github/actions/upload-release-assets/action.yml
@@ -1,0 +1,73 @@
+name: Configure Environment Variables
+description: Configure environment variables for Filecoin FFI
+
+inputs:
+  id:
+    description: The release ID
+    required: true
+  ref:
+    description: The release ref
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - run: echo "Running on $RUNNER_OS $RUNNER_ARCH"
+      shell: bash
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.ref }}
+        submodules: recursive
+    - uses: ./.github/actions/configure-environment
+    - if: runner.os == 'macOS'
+      run: |
+        rustup target add x86_64-apple-darwin
+        cargo fetch
+      working-directory: rust
+      shell: bash
+    - if: runner.os == 'Linux'
+      name: Build and publish the standard release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+        GITHUB_RELEASE_URL: ${{ github.api_url }}/repos/${{ github.repository }}/releases/${{ inputs.id }}
+      run: |
+        REPOSITORY_NAME=${GITHUB_REPOSITORY##*/}
+
+        TARBALL_PATH="/tmp/${REPOSITORY_NAME}-$(uname)-$(uname -m)-standard.tar.gz"
+        RELEASE_NAME="${REPOSITORY_NAME}-$(uname)-$(uname -m)-standard"
+
+        # Note: the blst dependency uses the portable configuration for maximum compatibility
+        ./scripts/build-release.sh build --verbose --no-default-features --features multicore-sdr,opencl,blst-portable
+        ./scripts/package-release.sh $TARBALL_PATH
+        ./scripts/publish-release.sh $TARBALL_PATH $RELEASE_NAME
+      working-directory: rust
+      shell: bash
+    - if: runner.os == 'Linux'
+      name: Build the optimized release
+      run: |
+        REPOSITORY_NAME=${GITHUB_REPOSITORY##*/}
+
+        TARBALL_PATH="/tmp/${REPOSITORY_NAME}-$(uname)-$(uname -m)-optimized.tar.gz"
+        RUSTFLAGS="-C target-feature=$(cat rustc-target-features-optimized.json | jq -r '.[].rustc_target_feature' | tr '\n' ',')"
+
+        ./scripts/build-release.sh build --verbose --no-default-features --features multicore-sdr,opencl
+        ./scripts/package-release.sh $TARBALL_PATH
+      working-directory: rust
+      shell: bash
+    - if: runner.os == 'macOS'
+      name: Build and publish the universal standard release
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+        GITHUB_RELEASE_URL: ${{ github.api_url }}/repos/${{ github.repository }}/releases/${{ inputs.id }}
+      run: |
+        REPOSITORY_NAME=${GITHUB_REPOSITORY##*/}
+
+        RELEASE_NAME="${REPOSITORY_NAME}-$(uname)-standard"
+        TARBALL_PATH="/tmp/${RELEASE_NAME}.tar.gz"
+
+        # Note: the blst dependency uses the portable configuration for maximum compatibility
+        ./scripts/build-release.sh lipo --verbose --no-default-features --features multicore-sdr,opencl,blst-portable
+        ./scripts/package-release.sh $TARBALL_PATH
+        ./scripts/publish-release.sh $TARBALL_PATH $RELEASE_NAME
+      working-directory: rust
+      shell: bash

--- a/.github/actions/upload-release-assets/action.yml
+++ b/.github/actions/upload-release-assets/action.yml
@@ -1,5 +1,5 @@
-name: Configure Environment Variables
-description: Configure environment variables for Filecoin FFI
+name: Upload Release Assets
+description: Build and upload release assets to an existing GitHub release
 
 inputs:
   id:

--- a/.github/workflows/upload-release-assets.yml
+++ b/.github/workflows/upload-release-assets.yml
@@ -1,10 +1,14 @@
-name: Release Checker
+name: Upload Release Assets
 
 on:
-  pull_request_target:
-    paths: ["version.json"]
-    types: [ opened, synchronize, reopened, labeled, unlabeled ]
   workflow_dispatch:
+    inputs:
+      id:
+        description: The release ID (e.g. 246546694)
+        required: true
+      ref:
+        description: The release ref (e.g. refs/tags/v1.34.0)
+        required: true
 
 permissions:
   contents: write
@@ -15,13 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  release-check:
-    uses: ipdxco/unified-github-workflows/.github/workflows/release-check.yml@v1.0
-    with:
-      sources: '["version.json"]'
   upload-release-assets:
-    needs: [release-check]
-    if: fromJSON(needs.release-check.outputs.json)['version.json']
     name: Publish the static library (${{ matrix.runner }})
     runs-on: ${{ matrix.runner }}
     strategy:
@@ -32,4 +30,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/upload-release-assets
         with:
-          id: ${{ fromJSON(needs.release-check.outputs.json)['version.json'].id }}
+          id: ${{ inputs.id }}
+          ref: ${{ inputs.ref }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,6 +13,7 @@ This document describes the process for releasing a new version of the `filecoin
     4. Comment on the pull request with a link to the draft release.
     5. Build the project for Linux (X64), Linux (ARM64), and MacOS.
     7. Upload the built assets to the draft release (replace any existing assets with the same name).
+       - If for some reason asset uploading fails, the [Upload Release Assets](.github/workflows/upload-release-assets.yml) workflow can be manually run.
 3. On pull request merge, a [Releaser](.github/workflows/release.yml) workflow will run. It will perform the following actions:
     1. Extract the version from the top-level `version.json` file.
     2. Check if a git tag for the version already exists. Continue only if it does not.
@@ -26,3 +27,4 @@ This document describes the process for releasing a new version of the `filecoin
 ## Possible Improvements
 
 1. Add a check to the [Releaser](.github/workflows/release.yml) workflow to ensure that the created/published release contains the expected assets. If it does not, create them and run the [publish-release.sh](rust/scripts/publish-release.sh) script to upload the missing assets.
+   - In the interim, if for some reason asset uploading fails, the [Upload Release Assets](.github/workflows/upload-release-assets.yml) workflow can be manually run.


### PR DESCRIPTION
This will create a new workflow `Upload Release Assets` which can be used to do emergency release assets uploads when something goes wrong.

I tested it by triggering https://github.com/filecoin-project/filecoin-ffi/actions/runs/17773290672 on push. It is failing because the action I'm adding here is not available in the tag of the release that we were uploading assets to. It's just a false negative.