### PR TITLE
chore!: upgrade to Go 1.24

### DIFF
--- a/.github/actions/configure-environment/action.yml
+++ b/.github/actions/configure-environment/action.yml
@@ -63,4 +63,4 @@ runs:
         toolchain: 1.73
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.23'
+        go-version: '1.24'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
           test -z "${output}"
       - name: Run various linters
         run: |
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.1
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
           make go-lint
   cgo-bindings:
     name: Build and test CGO bindings (${{ matrix.runner.name }})

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/filecoin-project/filecoin-ffi
 
-go 1.23.0
+go 1.24.0
 
-toolchain go1.23.7
+toolchain go1.24.7
 
 require (
 	github.com/filecoin-project/go-address v1.2.0


### PR DESCRIPTION
## Proposed Changes
<!-- A clear list of the changes being made -->
This PR updates Go version used in this repo to 1.24.7.

## Additional Info
<!-- Callouts, links to documentation, and etc -->
golangci-lint v1.64 is the last version in the v1 lineage. It has moved on to v2 now. v1.64 does not support Go 1.25 so we'll have to upgrade to v2 before we move on to Go 1.25 ourselves.