### PR TITLE
chore: add nv28 skeleton

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1250,12 +1250,12 @@ dependencies = [
  "filepath",
  "fvm 2.11.0",
  "fvm 3.13.0",
- "fvm 4.7.3",
+ "fvm 4.7.4",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_shared 2.11.0",
  "fvm_shared 3.13.0",
- "fvm_shared 4.7.3",
+ "fvm_shared 4.7.4",
  "group",
  "lazy_static",
  "libc",
@@ -1600,9 +1600,9 @@ dependencies = [
 
 [[package]]
 name = "fvm"
-version = "4.7.3"
+version = "4.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "967aa93b65e979405f018b2d34438cc3ce50bd99d46725e5888c9387ee1ccfd3"
+checksum = "ed594b0fb8be1d1dbd566e19707ed5a7f3ef944bd14316562bc5ff581a1e0f1e"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -1614,7 +1614,7 @@ dependencies = [
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding",
  "fvm_ipld_hamt",
- "fvm_shared 4.7.3",
+ "fvm_shared 4.7.4",
  "lazy_static",
  "log",
  "minstant",
@@ -1780,9 +1780,9 @@ dependencies = [
 
 [[package]]
 name = "fvm_shared"
-version = "4.7.3"
+version = "4.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2bef630181cdc25f2522c3fc83a968b42e6b7d3dfa00ed294f6bdb096ad1fa"
+checksum = "96ae4c07a461207b41bd8a79124baaeb191b343b4ea210793069c98a37b179b8"
 dependencies = [
  "anyhow",
  "bitflags 2.9.0",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -33,8 +33,8 @@ rayon = "1.10.0"
 anyhow = "1.0.97"
 serde_json = "1.0.140"
 rust-gpu-tools = { version = "0.7", optional = true, default-features = false }
-fvm4 = { package = "fvm", version = "~4.7.3", default-features = false, features = ["verify-signature"] }
-fvm4_shared = { package = "fvm_shared", version = "~4.7.3" }
+fvm4 = { package = "fvm", version = "~4.7.4", default-features = false, features = ["verify-signature", "nv28-dev"] }
+fvm4_shared = { package = "fvm_shared", version = "~4.7.4" }
 fvm3 = { package = "fvm", version = "~3.13.0", default-features = false }
 fvm3_shared = { package = "fvm_shared", version = "~3.13.0" }
 fvm2 = { package = "fvm", version = "~2.11.0", default-features = false }

--- a/rust/src/fvm/engine.rs
+++ b/rust/src/fvm/engine.rs
@@ -71,7 +71,7 @@ impl TryFrom<u32> for EngineVersion {
         match value {
             16 | 17 => Ok(EngineVersion::V1),
             18..=20 => Ok(EngineVersion::V2),
-            21..=27 => Ok(EngineVersion::V3),
+            21..=28 => Ok(EngineVersion::V3),
             _ => Err(anyhow!("network version not supported")),
         }
     }


### PR DESCRIPTION
Depends on: https://github.com/filecoin-project/ref-fvm/pull/2220 and a new ref-fvm release. Once that is out, will update the lock file.

Closes: #547 