### PR TITLE
chore: prep FFI v1.36.0-rc1

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v1.34.6"
+  "version": "v1.36.0-rc1"
 }


### PR DESCRIPTION
chore: prep FFI v1.36.0-rc1 for Butterfly-network testing of the nv28 upgrade