### PR TITLE
chore: reduce install script output noise

### DIFF
--- a/install-filcrypto
+++ b/install-filcrypto
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2155 enable=require-variable-braces
 
-set -Exeo pipefail
+set -Eeo pipefail
 auth_header=()
 if [ -n "${GITHUB_TOKEN}" ]; then
 	auth_header=("-H" "Authorization: token ${GITHUB_TOKEN}")


### PR DESCRIPTION
Remove xtrace flag (x) from set options to suppress command echoing
during install, which produces excessive noise without aiding debugging.