### PR TITLE
fix(deps): pin supraseal-c2/sppark to pre-regression versions

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -886,7 +886,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18e4fdb82bd54a12e42fb58a800dcae6b9e13982238ce2296dc3570b92148e1f"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1307,6 +1307,8 @@ dependencies = [
  "safer-ffi",
  "serde",
  "serde_json",
+ "sppark",
+ "supraseal-c2",
  "tempfile",
  "yastl",
 ]
@@ -3343,9 +3345,9 @@ dependencies = [
 
 [[package]]
 name = "sppark"
-version = "0.1.14"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c900139f3f6fdc8db217881a946adf00e935102fdd82b0e1bc19bacbffa311"
+checksum = "16bf457036c0a778140ce4c3bcf9ff30c5c70a9d9c0bb04fe513af025b647b2c"
 dependencies = [
  "cc",
  "which",
@@ -3534,9 +3536,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "supraseal-c2"
-version = "0.1.2"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea1b727b012f4a4ca34b3a7a90eb5cb8cca9ba614769bc6d6933094fc2be51d2"
+checksum = "fd427b05c226de2e0f99b96600c81dabd2129cb31d6c8feda650c195414beab2"
 dependencies = [
  "blst",
  "cc",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -48,6 +48,12 @@ serde = "1.0.219"
 safer-ffi = { version = "0.1.13", features = ["proc_macros"] }
 filecoin-proofs-api = { version = "19.1", default-features = false }
 yastl = "0.1.2"
+# Pin SupraSeal's GPU stack to pre-regression versions: sppark 0.1.12+ leaks GPU
+# memory under FFI_USE_CUDA_SUPRASEAL=1. Transitive via filecoin-proofs-api ->
+# bellperson; declared here only to hold versions back. Drop once sppark ships a
+# fix. See filecoin-project/lotus#13634 and supranational/sppark#81.
+supraseal-c2 = { version = "=0.1.1", optional = true }
+sppark = { version = "=0.1.11", optional = true }
 
 [dev-dependencies]
 memmap2 = "0.9"


### PR DESCRIPTION
sppark 0.1.12+ leaks GPU memory under FFI_USE_CUDA_SUPRASEAL=1, OOMing long-lived lotus-miner/lotus-worker processes. Hold supraseal-c2 at 0.1.1 and sppark at 0.1.11 until upstream ships a fix.

Ref: filecoin-project/lotus#13634, supranational/sppark#81

---

We don't necessarily have to pull the trigger on this, but we can if we don't get movement upstream and/or this causes problems for SPs and they really need it fixed ASAP.