### PR TITLE
chore: add nv29 skeleton

### DIFF
--- a/rust/src/fvm/engine.rs
+++ b/rust/src/fvm/engine.rs
@@ -71,7 +71,7 @@ impl TryFrom<u32> for EngineVersion {
         match value {
             16 | 17 => Ok(EngineVersion::V1),
             18..=20 => Ok(EngineVersion::V2),
-            21..=28 => Ok(EngineVersion::V3),
+            21..=29 => Ok(EngineVersion::V3),
             _ => Err(anyhow!("network version not supported")),
         }
     }


### PR DESCRIPTION
## Summary

- Route network version 29 to the existing FVM v4 engine.
- Builds on the already-published ref-fvm 4.8.2 crates, which expose the `nv29-dev` feature.

## Why this is smaller than previous skeleton PRs

The nv28 skeleton PR, filecoin-project/filecoin-ffi#548, changed three things:

- `rust/Cargo.toml`: bump `fvm4` / `fvm4_shared` and enable the new `nvXX-dev` feature.
- `rust/Cargo.lock`: regenerate the lockfile for the new FVM crates.
- `rust/src/fvm/engine.rs`: map the new network version to the FVM v4 engine.

For nv29, the first two pieces already landed in filecoin-project/filecoin-ffi#572:

- `fvm4` / `fvm4_shared` are already on `~4.8.2`.
- `fvm4` already enables `nv29-dev`.
- `rust/Cargo.lock` already resolves `fvm` and `fvm_shared` to `4.8.2`.

That leaves only the missing engine-version mapping in this PR.

Refs #579

## Validation

- `cargo fmt --manifest-path rust/Cargo.toml --check`
- `cargo check --manifest-path rust/Cargo.toml --no-default-features --features fvm`