### PR TITLE
chore: v1.36.1-dev release

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v1.36.0"
+  "version": "v1.36.1-dev"
 }


### PR DESCRIPTION
Follows #580 and prepares a filecoin-ffi development release for the nv29 skeleton work.

This bumps the release version to `v1.36.1-dev` so the release checker can create the draft GitHub release and build/upload assets. Once merged, the releaser workflow should publish the release/tag for Lotus to consume.

Closes #579.
