### PR TITLE
fix(deps): bump sppark to 0.1.15

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3343,9 +3343,9 @@ dependencies = [
 
 [[package]]
 name = "sppark"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c900139f3f6fdc8db217881a946adf00e935102fdd82b0e1bc19bacbffa311"
+checksum = "bfae3f3e0559cf04e9d9abce56d1db0dab58e03874cf4db5546540710740cfea"
 dependencies = [
  "cc",
  "which",


### PR DESCRIPTION
## Summary

- Bumps `sppark` from `0.1.14` to `0.1.15` in `rust/Cargo.lock`.
- Picks up the upstream fix released in supranational/sppark `v0.1.15`.
- Provides the forward-fix path for the CUDA SupraSeal GPU OOM issue tracked in filecoin-project/lotus#13634.

## Context

filecoin-project/filecoin-ffi#578 proposed pinning `supraseal-c2`/`sppark` back to pre-regression versions as a temporary mitigation. Upstream has now merged supranational/sppark#81 and released `sppark` `v0.1.15`, so this PR updates the lockfile to consume that fix instead.