### PR TITLE
fix: bump version to v1.36.1

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v1.36.1-dev"
+  "version": "v1.36.1"
 }


### PR DESCRIPTION
- Updates `version.json` from `v1.36.1-dev` to `v1.36.1` for the upcoming Lotus v1.36.1-aligned release.