### PR TITLE
fix(deps): use curiostorage/sppark fork

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3344,8 +3344,7 @@ dependencies = [
 [[package]]
 name = "sppark"
 version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfae3f3e0559cf04e9d9abce56d1db0dab58e03874cf4db5546540710740cfea"
+source = "git+https://github.com/curiostorage/sppark.git?rev=813d73cfcb3afdc166c00960b37734b23504ac96#813d73cfcb3afdc166c00960b37734b23504ac96"
 dependencies = [
  "cc",
  "which",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -105,3 +105,6 @@ c-headers = ["safer-ffi/headers"]
 # This feature enables a fixed number of discarded rows for TreeR. The `FIL_PROOFS_ROWS_TO_DISCARD`
 # setting is ignored, no `TemporaryAux` file will be written.
 fixed-rows-to-discard = ["filecoin-proofs-api/fixed-rows-to-discard"]
+
+[patch.crates-io]
+sppark = { git = "https://github.com/curiostorage/sppark.git", rev = "813d73cfcb3afdc166c00960b37734b23504ac96" }


### PR DESCRIPTION
The fix for auto-detect breaking on SM80 is not getting picked-up by Supraseal. It appears like a dead repo, so the repo was forked and the change added. 
This enables older hardware to be auto-detected correctly. 